### PR TITLE
S,M,L connected to SpinButton

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -348,7 +348,7 @@ impl Default for Configuration {
             corner_roundness: 12.0,
             initial_tool: Tools::Pointer,
             copy_command: None,
-            annotation_size_factor: 1.0,
+            annotation_size_factor: 100.0, /* 100% ~ medium | 33% ~ small | 300% ~ large */
             action_on_enter: Action::SaveToClipboard,
             action_on_escape: Action::Exit,
             save_after_copy: false,

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -430,12 +430,6 @@ impl SketchBoard {
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))
             }
-            ToolbarEvent::AnnotationSizeChanged(value) => {
-                self.style.annotation_size_factor = value;
-                self.active_tool
-                    .borrow_mut()
-                    .handle_event(ToolEvent::StyleChanged(self.style))
-            }
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -16,7 +16,6 @@ pub struct Style {
     pub color: Color,
     pub size: Size,
     pub fill: bool,
-    pub annotation_size_factor: f32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -27,21 +26,19 @@ pub struct Color {
     pub a: u8,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
-pub enum Size {
-    Small = 0,
-    #[default]
-    Medium = 1,
-    Large = 2,
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
+pub struct Size {
+    pub value: f32,
 }
 
 impl Default for Style {
     fn default() -> Self {
         Self {
             color: Color::default(),
-            size: Size::default(),
             fill: bool::default(),
-            annotation_size_factor: APP_CONFIG.read().annotation_size_factor(),
+            size: Size {
+                value: APP_CONFIG.read().annotation_size_factor(),
+            },
         }
     }
 }
@@ -165,81 +162,34 @@ impl From<Style> for Paint {
     fn from(value: Style) -> Self {
         Paint::default()
             .with_anti_alias(true)
-            .with_font_size(value.size.to_text_size(value.annotation_size_factor) as f32)
+            .with_font_size(value.size.to_text_size())
             .with_color(value.color.into())
-            .with_line_width(value.size.to_line_width(value.annotation_size_factor))
-    }
-}
-
-impl StaticVariantType for Size {
-    fn static_variant_type() -> Cow<'static, VariantTy> {
-        Cow::Borrowed(VariantTy::UINT32)
-    }
-}
-
-impl ToVariant for Size {
-    fn to_variant(&self) -> Variant {
-        Variant::from(*self as u32)
-    }
-}
-
-impl FromVariant for Size {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.get::<u32>().and_then(|v| match v {
-            0 => Some(Size::Small),
-            1 => Some(Size::Medium),
-            2 => Some(Size::Large),
-            _ => None,
-        })
+            .with_line_width(value.size.to_line_width())
     }
 }
 
 impl Size {
-    pub fn to_text_size(self, size_factor: f32) -> i32 {
-        match self {
-            Size::Small => (36.0 * size_factor) as i32,
-            Size::Medium => (54.0 * size_factor) as i32,
-            Size::Large => (96.0 * size_factor) as i32,
-        }
+    pub fn to_text_size(self) -> f32 {
+        self.value
     }
 
-    pub fn to_line_width(self, size_factor: f32) -> f32 {
-        match self {
-            Size::Small => 3.0 * size_factor,
-            Size::Medium => 5.0 * size_factor,
-            Size::Large => 7.0 * size_factor,
-        }
+    pub fn to_line_width(self) -> f32 {
+        0.1 * self.value
     }
 
-    pub fn to_arrow_tail_width(self, size_factor: f32) -> f32 {
-        match self {
-            Size::Small => 3.0 * size_factor,
-            Size::Medium => 10.0 * size_factor,
-            Size::Large => 25.0 * size_factor,
-        }
+    pub fn to_arrow_tail_width(self) -> f32 {
+        0.2 * self.value
     }
 
-    pub fn to_arrow_head_length(self, size_factor: f32) -> f32 {
-        match self {
-            Size::Small => 15.0 * size_factor,
-            Size::Medium => 30.0 * size_factor,
-            Size::Large => 60.0 * size_factor,
-        }
+    pub fn to_arrow_head_length(self) -> f32 {
+        0.6 * self.value
     }
 
-    pub fn to_blur_factor(self, size_factor: f32) -> f32 {
-        match self {
-            Size::Small => 10.0 * size_factor,
-            Size::Medium => 20.0 * size_factor,
-            Size::Large => 30.0 * size_factor,
-        }
+    pub fn to_blur_factor(self) -> f32 {
+        0.4 * self.value
     }
 
-    pub fn to_highlight_width(self, size_factor: f32) -> f32 {
-        match self {
-            Size::Small => 15.0 * size_factor,
-            Size::Medium => 30.0 * size_factor,
-            Size::Large => 45.0 * size_factor,
-        }
+    pub fn to_highlight_width(self) -> f32 {
+        0.6 * self.value
     }
 }

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -153,15 +153,9 @@ impl Drawable for Arrow {
         canvas.rotate(arrow_direction.angle().radians);
 
         // The width of the tail (double distance from start to head side)
-        let tail_width = self
-            .style
-            .size
-            .to_arrow_tail_width(self.style.annotation_size_factor);
+        let tail_width = self.style.size.to_arrow_tail_width();
         // The length of the (sloped) side of the arrow head (distance from end to head side).
-        let head_side_length = self
-            .style
-            .size
-            .to_arrow_head_length(self.style.annotation_size_factor);
+        let head_side_length = self.style.size.to_arrow_head_length();
         // The offset of the midpoint is the distance the midpoint moves toward the end of the arrow.
         // A offset of 0 will place the midpoint right below the head side.
         // A negative value will result in a diamond head.

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -111,9 +111,7 @@ impl Drawable for Blur {
                     canvas,
                     pos,
                     size,
-                    self.style
-                        .size
-                        .to_blur_factor(self.style.annotation_size_factor),
+                    self.style.size.to_blur_factor(),
                 )?);
             }
 

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -79,11 +79,7 @@ impl Highlight for Highlighter<FreehandHighlight> {
             self.style.color.b,
             (255.0 * HIGHLIGHT_OPACITY) as u8,
         ));
-        paint.set_line_width(
-            self.style
-                .size
-                .to_highlight_width(self.style.annotation_size_factor),
-        );
+        paint.set_line_width(self.style.size.to_highlight_width());
         paint.set_line_join(femtovg::LineJoin::Round);
         paint.set_line_cap(femtovg::LineCap::Square);
 

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -34,12 +34,7 @@ impl Drawable for Marker {
 
         let mut paint = Paint::color(Color::white());
         paint.set_font(&[font]);
-        paint.set_font_size(
-            (self
-                .style
-                .size
-                .to_text_size(self.style.annotation_size_factor)) as f32,
-        );
+        paint.set_font_size(self.style.size.to_text_size());
         paint.set_text_align(femtovg::Align::Center);
         paint.set_text_baseline(femtovg::Baseline::Middle);
 
@@ -69,12 +64,8 @@ impl Drawable for Marker {
             femtovg::Solidity::Solid,
         );
 
-        let circle_paint = Paint::color(self.style.color.into()).with_line_width(
-            self.style
-                .size
-                .to_line_width(self.style.annotation_size_factor)
-                * 2.0,
-        );
+        let circle_paint = Paint::color(self.style.color.into())
+            .with_line_width(self.style.size.to_line_width() * 2.0);
 
         canvas.save();
         canvas.fill_path(&inner_circle_path, &circle_paint);


### PR DESCRIPTION
related to #171

![image](https://github.com/user-attachments/assets/ff726648-21ce-41ad-b4ba-530281908399)

Idea is to simplify the UX a bit.
- The sizes are percentages
- We could add back button with a "size" that translate this way (this is what's exposed in the screenshot)
  - S(mall) => 33%
  - M(edium) => 100%
  - L(arge) => 300%

For now the PR breaks things, like
- Text inputs
  - Because the focus in always in the SpinButton atm

I find it more intuitive like this but this is maybe me?
WDYT?