### PR TITLE
fix: text: use font metrics instead of text metrics

### DIFF
--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -65,13 +65,13 @@ impl Drawable for Text {
 
         let lines = canvas.break_text_vec(width, text, &paint)?;
 
+        let font_metrics = canvas.measure_font(&paint)?;
         for line_range in lines {
             if let Ok(text_metrics) = canvas.fill_text(self.pos.x, y, &text[line_range], &paint) {
-                y += text_metrics.height() * 1.2;
+                y += font_metrics.height() / canva_scale;
                 metrics.push(text_metrics);
             }
         }
-        let font_metrics = canvas.measure_font(&paint)?;
         if self.editing {
             // GTK is working with UTF-8 and character positions, pango is working with UTF-8 but byte positions.
             // here we transform one into the other!


### PR DESCRIPTION
Closes #222
Closes #225

Text metrics does not respect stand alone newlines (values close to 0), might get rounded down (speculation).

Also, editing text (e.g. adding j or g on first line) move consecutive lines, gaps between lines can differ based on chars entered.

`font_metrics.height()` is identical with ascender - descender. This respects manual multiple newlines as well as offer consistent results for different glyphs -- unless glyphs are entered that use a fallback font. The latter is tricky to cover, GTK has the same challenge (see
https://gitlab.gnome.org/GNOME/gtk/-/issues/7555#note_2445986).