### PR TITLE
fix: read_css_overrides: improve error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,12 +327,26 @@ impl Component for App {
 fn read_css_overrides() -> Option<String> {
     let dirs = BaseDirectories::with_prefix(env!("CARGO_PKG_NAME"));
     let path = dirs.get_config_file("overrides.css")?;
-    let Ok(content) = fs::read_to_string(&path) else {
-        eprintln!("failed to read CSS overrides from {}", &path.display());
-        return None;
-    };
 
-    Some(content)
+    if !path.exists() {
+        eprintln!(
+            "CSS overrides file {} does not exist, using builtin CSS only.",
+            &path.display()
+        );
+        return None;
+    }
+
+    match fs::read_to_string(&path) {
+        Ok(content) => Some(content),
+        Err(e) => {
+            eprintln!(
+                "failed to read CSS overrides from {} with error: {}",
+                &path.display(),
+                e
+            );
+            None
+        }
+    }
 }
 
 fn load_gl() -> Result<()> {


### PR DESCRIPTION
from #241

Handle file not found separately. This is not really an error situation, the user just didn't provide any override file. I know I said "remove it" as well earlier, but now I think if the message is just a bit clearer it may still help users to become aware about the override file, so I'd actually rather keep it. I think it's clearer now. In the future, if we ever have log levels, this could be a level with less priority (info or even lower).

Also include actual error with `read_to_string` failures further down.