### PR TITLE
Update Annotation Size Spinner Step

### DIFF
--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -746,8 +746,8 @@ impl Component for AnnotationSizeDialog {
 
                     set_tooltip: "Annotation Size Factor",
                     set_numeric: true,
-                    set_adjustment: &gtk::Adjustment::new(0.0, 0.0, 100.0, 0.01, 0.1, 0.0),
-                    set_climb_rate: 0.1,
+                    set_adjustment: &gtk::Adjustment::new(0.0, 0.0, 100.0, 1.0, 5.0, 0.0),
+                    set_climb_rate: 1.0,
                     set_digits: 2,
                     #[watch]
                     #[block_signal(value_changed)]


### PR DESCRIPTION
## Summary

Adjusted the annotation size dialog so the spinner buttons jump in whole-number increments instead of 0.01 steps. 

Most people tweaking annotation sizes are looking for a visibly larger or smaller mark, not a fractional change they can’t perceive. Switching the spinner to whole-number steps matches that expectation, gets them to the desired size faster, and keeps the dialog from feeling unnecessarily fussy.

## Testing Notes
* Manual: Opened the annotation size dialog and confirmed that the up/down arrows now change the value by ±1.
