### PR TITLE
Remove broken `--help` highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ custom = [
 
 ### Command Line
 
-```sh
+```
 » satty --help
 Modern Screenshot Annotation.
 


### PR DESCRIPTION
# What?

Removed the `shell` syntax highlighting for the `satty --help` codeblock.

# Why?

The `--help` is mostly text, leading to an apostrophe rendering the second half to be highlighted as a string. There are also some undesired syntax highlighting like red keywords `if` and `for`.

<img width="825" height="733" alt="2025-10-30T13:34:31+01:00" src="https://github.com/user-attachments/assets/cb99549c-42a4-4507-bcc2-aba5cb8d9ac0" />