### PR TITLE
release: replace NEXTRELEASE with release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If a PR changes Satty's behaviour and where appropriate, please adjust `README.m
 Command line parameters changes
 --
 
-Please include anticipated next version in the comment for command line arguments, especially when adding arguments or options.
+Please include anticipated next version in the comment for command line arguments, especially when adding arguments or options. You can use the placeholder `NEXTRELEASE` in `command_line.rs`, `configuration.rs` and `README.md`.
 
 GenAI usage
 --


### PR DESCRIPTION
Affects README.md, command_line.rs and configuration.rs.

With this, the literal placeholder NEXTRELEASE can be used in the above files to indicate from when a parameter, config etc is supposed to work, without actually knowing the next release version at the time of writing.