### PR TITLE
fix(crop): return Unmodified on Escape when crop is inactive

### DIFF
--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -376,11 +376,16 @@ impl Tool for CropTool {
     }
 
     fn handle_key_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.crop.is_some() {
-            self.handle_deactivated()
-        } else {
-            ToolUpdateResult::Unmodified
+        if event.key == Key::Escape {
+            if let Some(crop) = &self.crop {
+                if crop.active {
+                    // Crop is active, deactivate it
+                    return self.handle_deactivated();
+                }
+            }
         }
+        // No crop exists or crop is inactive - let event bubble to global handler
+        ToolUpdateResult::Unmodified
     }
 
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {


### PR DESCRIPTION
Fixes #329

## Problem
Previously, the crop tool consumed all Escape keypresses even after being deactivated, preventing the global escape
handler from executing configured actions-on-escape (e.g., exit application).

## Solution
The tool now only handles Escape when the crop is active, returning `Unmodified` when inactive to allow the event to
bubble up to the global handler.

## Testing
1. Launch Satty with crop tool:  
`grim -t ppm - | ./target/release/satty --filename - --fullscreen --initial-tool=crop --actions-on-escape=exit`
3. Press Escape once → crop deactivates (handles disappear)
4. Press Escape again → application exits

## Changes
- Modified `handle_key_event()` in `src/tools/crop.rs` to check `crop.active` state before consuming Escape events
