### PR TITLE
feat: monitor_scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ pan-step-size = 50.0
 zoom-factor = 1.1
 # experimental feature (NEXTRELEASE): The length to move the text when using arrow keys. defaults to 50.0
 text-move-length = 50.0 
+# experimental feature (NEXTRELEASE): Scale factor on the input image when it was taken (e.g. DPI scale on the monitor it was recorded from).
+# This may be more useful to set via the command line.
+input-scale = 2.0
 
 # Tool selection keyboard shortcuts (since 0.20.0)
 [keybinds]
@@ -262,16 +265,18 @@ Options:
           Disable the window decoration (title bar, borders, etc.) Please note that the compositor has the final say in this. Requires xdg-decoration-unstable-v1
       --brush-smooth-history-size <BRUSH_SMOOTH_HISTORY_SIZE>
           Experimental feature: How many points to use for the brush smoothing algorithm. 0 disables smoothing. The default value is 0 (disabled)
-      --right-click-copy
-          Right click to copy. Preferably use the `action_on_right_click` option instead
-      --action-on-enter <ACTION_ON_ENTER>
-          Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
       --zoom-factor <ZOOM_FACTOR>
           Experimental feature (NEXTRELEASE): The zoom factor to use for the image. 1.0 means no zoom. defaults to 1.1
       --pan-step-size <PAN_STEP_SIZE>
           Experimental feature (NEXTRELEASE): The pan step size to use when panning with arrow keys. defaults to 50.0
       --text-move-length <TEXT_MOVE_LENGTH>
           Experimental feature (NEXTRELEASE): The length to move the text when using the arrow keys. defaults to 50.0
+      --input-scale <INPUT_SCALE>
+          Experimental feature (NEXTRELEASE): Scale the default window size to fit different displays
+      --right-click-copy
+          Right click to copy. Preferably use the `action_on_right_click` option instead
+      --action-on-enter <ACTION_ON_ENTER>
+          Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
   -h, --help
           Print help
   -V, --version

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -108,16 +108,6 @@ pub struct CommandLine {
     #[arg(long)]
     pub brush_smooth_history_size: Option<usize>,
 
-    // --- deprecated options ---
-    /// Right click to copy.
-    /// Preferably use the `action_on_right_click` option instead.
-    #[arg(long)]
-    pub right_click_copy: bool,
-    /// Action to perform when pressing Enter.
-    /// Preferably use the `actions_on_enter` option instead.
-    #[arg(long, value_delimiter = ',')]
-    pub action_on_enter: Option<Action>,
-
     /// Experimental feature (NEXTRELEASE): The zoom factor to use for the image.
     /// 1.0 means no zoom.
     /// defaults to 1.1
@@ -134,9 +124,19 @@ pub struct CommandLine {
     #[arg(long)]
     pub text_move_length: Option<f32>,
 
-    /// Scale the default window size to fit different displays.
+    /// Experimental feature (NEXTRELEASE): Scale the default window size to fit different displays.
     #[arg(long)]
-    pub monitor_scale: Option<f32>,
+    pub input_scale: Option<f32>,
+
+    // --- deprecated options ---
+    /// Right click to copy.
+    /// Preferably use the `action_on_right_click` option instead.
+    #[arg(long)]
+    pub right_click_copy: bool,
+    /// Action to perform when pressing Enter.
+    /// Preferably use the `actions_on_enter` option instead.
+    #[arg(long, value_delimiter = ',')]
+    pub action_on_enter: Option<Action>,
     // ---
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -61,7 +61,7 @@ pub struct Configuration {
     zoom_factor: f32,
     pan_step_size: f32,
     text_move_length: f32,
-    monitor_scale: f32,
+    input_scale: f32,
 }
 
 pub struct Keybinds {
@@ -310,8 +310,8 @@ impl Configuration {
         if let Some(v) = general.text_move_length {
             self.text_move_length = v;
         }
-        if let Some(v) = general.monitor_scale {
-            self.monitor_scale = v;
+        if let Some(v) = general.input_scale {
+            self.input_scale = v;
         }
 
         // --- deprecated options ---
@@ -425,8 +425,8 @@ impl Configuration {
         if let Some(v) = command_line.text_move_length {
             self.text_move_length = v;
         }
-        if let Some(v) = command_line.monitor_scale {
-            self.monitor_scale = v;
+        if let Some(v) = command_line.input_scale {
+            self.input_scale = v;
         }
 
         // --- deprecated options ---
@@ -551,8 +551,8 @@ impl Configuration {
     pub fn text_move_length(&self) -> f32 {
         self.text_move_length
     }
-    pub fn monitor_scale(&self) -> f32 {
-        self.monitor_scale
+    pub fn input_scale(&self) -> f32 {
+        self.input_scale
     }
 }
 
@@ -586,7 +586,7 @@ impl Default for Configuration {
             zoom_factor: 1.1,
             pan_step_size: 50.,
             text_move_length: 50.0,
-            monitor_scale: 1.0,
+            input_scale: 1.0,
         }
     }
 }
@@ -664,7 +664,7 @@ struct ConfigurationFileGeneral {
     zoom_factor: Option<f32>,
     pan_step_size: Option<f32>,
     text_move_length: Option<f32>,
-    monitor_scale: Option<f32>,
+    input_scale: Option<f32>,
 
     // --- deprecated options ---
     right_click_copy: Option<bool>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,12 +82,15 @@ impl App {
     }
 
     fn resize_window_initial(&self, root: &Window, sender: ComponentSender<Self>) {
-        let scale = APP_CONFIG.read().monitor_scale();
+        let scale = APP_CONFIG.read().input_scale();
 
         let monitor_size = match Self::get_monitor_size(root) {
             Some(s) => s,
             None => {
-                root.set_default_size((self.image_dimensions.0 as f32 / scale) as i32, (self.image_dimensions.1 as f32 / scale) as i32);
+                root.set_default_size(
+                    (self.image_dimensions.0 as f32 / scale) as i32,
+                    (self.image_dimensions.1 as f32 / scale) as i32,
+                );
                 return;
             }
         };


### PR DESCRIPTION
After taking a screenshot on a HiDPI display, satty by default opens with a window size matching the image’s pixel resolution.
This PR adds a `--monitor-scale` option so that the window can open at the expected physical size — i.e., the size it appeared to the eye when the screenshot was taken.

For example:
On a `3840×2160` display with `SCALE=2`, satty’s window normally appears twice as large as expected.
If you launch it with `--monitor-scale 2.0`, the window will match the size you saw when taking the screenshot.

The reason for explicitly specifying the scale instead of using the monitor’s scale factor is that, when multiple displays are connected, a screenshot taken on a `SCALE=2` display should still be opened with `--monitor-scale 2.0`, even if viewed on a `SCALE=1` monitor.

And this also makes it more controllable.

> Since in my case the code has never executed any path other than 
`None => { root.set_default_size((self.image_dimensions.0 as f32 / scale) as i32, (self.image_dimensions.1 as f32 / scale) as i32); return;}`
, I'm not sure whether the other changes behave as expected.

https://github.com/user-attachments/assets/a12947fc-7d5a-457c-8cf0-aa62a44d84c5


