### PR TITLE
fix: change Pan shortcut to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 - `Ctrl+T`: Toggle toolbars
 - `Ctrl+Y`: Redo
 - `Ctrl+Z`: Undo
-- `Left`/`Right`/`Up`/`Down`: Pan, also available with middle mouse button drag <sup>NEXTRELEASE</sup>
+- `Ctrl`+(`Left`/`Right`/`Up`/`Down`): Pan, also available with middle mouse button drag <sup>NEXTRELEASE</sup>
 
 #### Tool Selection Shortcuts (configurable) <sup>0.20.0</sup>
 Default single-key shortcuts:

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -813,10 +813,11 @@ impl Component for SketchBoard {
                     {
                         self.renderer.request_render(&[Action::SaveToClipboard]);
                         ToolUpdateResult::Unmodified
-                    } else if ke.is_one_of(Key::leftarrow, KeyMappingId::ArrowLeft)
+                    } else if (ke.is_one_of(Key::leftarrow, KeyMappingId::ArrowLeft)
                         || ke.is_one_of(Key::rightarrow, KeyMappingId::ArrowRight)
                         || ke.is_one_of(Key::uparrow, KeyMappingId::ArrowUp)
-                        || ke.is_one_of(Key::downarrow, KeyMappingId::ArrowDown)
+                        || ke.is_one_of(Key::downarrow, KeyMappingId::ArrowDown))
+                        && ke.modifier == ModifierType::CONTROL_MASK
                     {
                         let pan_step_size = APP_CONFIG.read().pan_step_size();
                         match ke.key {


### PR DESCRIPTION
As mentioned in the title, the default Pan shortcut conflicted with text cursor movement, so it now requires `Ctrl` as a modifier.