### PR TITLE
feat: Display image and crop dimensions in toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Default single-key shortcuts:
   - <kbd>Ctrl+X</kbd> to cut selected text to clipboard. <sup>0.20.1</sup>
   - <kbd>Ctrl+V</kbd> to paste text from clipboard. <sup>0.20.1</sup>
   - <kbd>Alt+Ctrl</kbd> with <kbd>Left</kbd> or <kbd>Right</kbd> or <kbd>Up</kbd> or <kbd>Down</kbd> to move the text. Use <kbd>Alt+Ctrl+Shift</kbd> with arrow keys to nudge the text. <sup>0.20.1</sup>
+- Crop:
+   - Press <kbd>Esc</kbd> or right mouse button while editing to reset crop altogether <sup>NEXTRELEASE</sup>
+   - Press <kbd>Enter</kbd> while editing to finish editing crop and keep the crop area active <sup>NEXTRELEASE</sup>
+   - Left click crop area when tool is active but not editing to resume editing<sup>NEXTRELEASE</sup>
 
 ### Configuration File
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,8 @@ enum AppInput {
     ColorSwitchShortcut(u64),
     ScaleFactorChanged,
     FullscreenChanged(bool),
+    CropDimensionsUpdate((i32, i32)),
+    CropToolActivated(bool),
 }
 
 #[derive(Debug)]
@@ -282,6 +284,21 @@ impl Component for App {
                     self.outer_box.append(style);
                 }
             }
+            AppInput::CropDimensionsUpdate((width, height)) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::CropDimensionsChanged((width, height)));
+            }
+            AppInput::CropToolActivated(active) => {
+                if !active {
+                    // Show full image dimensions when crop tool is deactivated
+                    self.style_toolbar
+                        .sender()
+                        .emit(StyleToolbarInput::CropDimensionsChanged(
+                            self.image_dimensions,
+                        ));
+                }
+            }
         }
     }
 
@@ -316,6 +333,12 @@ impl Component for App {
                     SketchBoardOutput::ColorSwitchShortcut(index) => {
                         AppInput::ColorSwitchShortcut(index)
                     }
+                    SketchBoardOutput::CropDimensionsUpdate(dimensions) => {
+                        AppInput::CropDimensionsUpdate(dimensions)
+                    }
+                    SketchBoardOutput::CropToolActivated(active) => {
+                        AppInput::CropToolActivated(active)
+                    }
                 });
 
         // Toolbars
@@ -341,6 +364,12 @@ impl Component for App {
             outer_box,
             overlay,
         };
+
+        // Initialize style toolbar with full image dimensions
+        model
+            .style_toolbar
+            .sender()
+            .emit(StyleToolbarInput::CropDimensionsChanged(image_dimensions));
 
         let widgets = view_output!();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,9 +285,14 @@ impl Component for App {
                 }
             }
             AppInput::CropDimensionsUpdate((width, height)) => {
+                let dimensions = if (width, height) == (0, 0) {
+                    self.image_dimensions
+                } else {
+                    (width, height)
+                };
                 self.style_toolbar
                     .sender()
-                    .emit(StyleToolbarInput::CropDimensionsChanged((width, height)));
+                    .emit(StyleToolbarInput::CropDimensionsChanged(dimensions));
             }
             AppInput::CropToolActivated(active) => {
                 if !active {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,8 +71,7 @@ enum AppInput {
     ColorSwitchShortcut(u64),
     ScaleFactorChanged,
     FullscreenChanged(bool),
-    CropDimensionsUpdate((i32, i32)),
-    CropToolActivated(bool),
+    DimensionsUpdate(Option<(i32, i32)>),
 }
 
 #[derive(Debug)]
@@ -284,25 +283,11 @@ impl Component for App {
                     self.outer_box.append(style);
                 }
             }
-            AppInput::CropDimensionsUpdate((width, height)) => {
-                let dimensions = if (width, height) == (0, 0) {
-                    self.image_dimensions
-                } else {
-                    (width, height)
-                };
+            AppInput::DimensionsUpdate(dimensions) => {
+                let d = dimensions.unwrap_or(self.image_dimensions);
                 self.style_toolbar
                     .sender()
-                    .emit(StyleToolbarInput::CropDimensionsChanged(dimensions));
-            }
-            AppInput::CropToolActivated(active) => {
-                if !active {
-                    // Show full image dimensions when crop tool is deactivated
-                    self.style_toolbar
-                        .sender()
-                        .emit(StyleToolbarInput::CropDimensionsChanged(
-                            self.image_dimensions,
-                        ));
-                }
+                    .emit(StyleToolbarInput::DimensionsChanged(d));
             }
         }
     }
@@ -338,11 +323,8 @@ impl Component for App {
                     SketchBoardOutput::ColorSwitchShortcut(index) => {
                         AppInput::ColorSwitchShortcut(index)
                     }
-                    SketchBoardOutput::CropDimensionsUpdate(dimensions) => {
-                        AppInput::CropDimensionsUpdate(dimensions)
-                    }
-                    SketchBoardOutput::CropToolActivated(active) => {
-                        AppInput::CropToolActivated(active)
+                    SketchBoardOutput::DimensionsUpdate(dimensions) => {
+                        AppInput::DimensionsUpdate(dimensions)
                     }
                 });
 
@@ -374,7 +356,7 @@ impl Component for App {
         model
             .style_toolbar
             .sender()
-            .emit(StyleToolbarInput::CropDimensionsChanged(image_dimensions));
+            .emit(StyleToolbarInput::DimensionsChanged(image_dimensions));
 
         let widgets = view_output!();
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -38,6 +38,7 @@ pub enum SketchBoardInput {
     Refresh,
     Exit,
     ScaleFactorChanged,
+    Output(SketchBoardOutput),
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +46,8 @@ pub enum SketchBoardOutput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    CropDimensionsUpdate((i32, i32)),
+    CropToolActivated(bool),
 }
 
 #[derive(Debug, Clone)]
@@ -675,6 +678,15 @@ impl SketchBoard {
     ) -> ToolUpdateResult {
         match toolbar_event {
             ToolbarEvent::ToolSelected(tool) => {
+                let crop_was_active = self.active_tool.borrow().get_tool_type() == Tools::Crop;
+                let crop_is_active = tool == Tools::Crop;
+
+                if crop_was_active != crop_is_active {
+                    sender
+                        .output_sender()
+                        .emit(SketchBoardOutput::CropToolActivated(crop_is_active));
+                }
+
                 // deactivate old tool and save drawable, if any
                 let old_tool = self.active_tool.clone();
                 let mut deactivate_result =
@@ -755,6 +767,12 @@ impl SketchBoard {
             ToolbarEvent::SaveFileAs => self.handle_action(&[Action::SaveToFileAs]),
             ToolbarEvent::Resize => self.handle_resize(),
             ToolbarEvent::OriginalScale => self.handle_original_scale(),
+            ToolbarEvent::CropDimensionsUpdated((w, h)) => {
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::CropDimensionsUpdate((w, h)));
+                ToolUpdateResult::Unmodified
+            }
         }
     }
 
@@ -1127,6 +1145,10 @@ impl Component for SketchBoard {
             SketchBoardInput::ScaleFactorChanged => {
                 self.renderer.resize(0, 0);
                 ToolUpdateResult::Redraw
+            }
+            SketchBoardInput::Output(output) => {
+                sender.output_sender().emit(output);
+                ToolUpdateResult::Unmodified
             }
         };
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -46,8 +46,7 @@ pub enum SketchBoardOutput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
-    CropDimensionsUpdate((i32, i32)),
-    CropToolActivated(bool),
+    DimensionsUpdate(Option<(i32, i32)>),
 }
 
 #[derive(Debug, Clone)]
@@ -678,15 +677,6 @@ impl SketchBoard {
     ) -> ToolUpdateResult {
         match toolbar_event {
             ToolbarEvent::ToolSelected(tool) => {
-                let crop_was_active = self.active_tool.borrow().get_tool_type() == Tools::Crop;
-                let crop_is_active = tool == Tools::Crop;
-
-                if crop_was_active != crop_is_active {
-                    sender
-                        .output_sender()
-                        .emit(SketchBoardOutput::CropToolActivated(crop_is_active));
-                }
-
                 // deactivate old tool and save drawable, if any
                 let old_tool = self.active_tool.clone();
                 let mut deactivate_result =
@@ -767,12 +757,12 @@ impl SketchBoard {
             ToolbarEvent::SaveFileAs => self.handle_action(&[Action::SaveToFileAs]),
             ToolbarEvent::Resize => self.handle_resize(),
             ToolbarEvent::OriginalScale => self.handle_original_scale(),
-            ToolbarEvent::CropDimensionsUpdated((width, height)) => {
+            /*            ToolbarEvent::CropDimensionsUpdated(dimensions) => {
                 sender
                     .output_sender()
-                    .emit(SketchBoardOutput::CropDimensionsUpdate((width, height)));
+                    .emit(SketchBoardOutput::DimensionsUpdate(Some(dimensions)));
                 ToolUpdateResult::Unmodified
-            }
+            }*/
         }
     }
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -767,10 +767,10 @@ impl SketchBoard {
             ToolbarEvent::SaveFileAs => self.handle_action(&[Action::SaveToFileAs]),
             ToolbarEvent::Resize => self.handle_resize(),
             ToolbarEvent::OriginalScale => self.handle_original_scale(),
-            ToolbarEvent::CropDimensionsUpdated((w, h)) => {
+            ToolbarEvent::CropDimensionsUpdated((width, height)) => {
                 sender
                     .output_sender()
-                    .emit(SketchBoardOutput::CropDimensionsUpdate((w, h)));
+                    .emit(SketchBoardOutput::CropDimensionsUpdate((width, height)));
                 ToolUpdateResult::Unmodified
             }
         }

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -398,14 +398,20 @@ impl Tool for CropTool {
     }
 
     fn handle_key_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape
-            && let Some(crop) = &self.crop
-            && crop.active
-        {
-            // Crop is active, deactivate it
-            return self.handle_deactivated();
+        if event.key == Key::Escape && self.crop.is_some() {
+            self.crop = None;
+            self.action = None;
+
+            if let Some(sender) = &self.sender {
+                sender
+                    .send(SketchBoardInput::Output(
+                        SketchBoardOutput::CropDimensionsUpdate((0, 0)),
+                    ))
+                    .ok();
+            }
+
+            return ToolUpdateResult::Redraw;
         }
-        // No crop exists or crop is inactive - let event bubble to global handler
         ToolUpdateResult::Unmodified
     }
 

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -286,6 +286,7 @@ impl CropTool {
     }
 
     fn begin_drag(&mut self, pos: Vec2D) -> ToolUpdateResult {
+        let mut activate = false;
         match &self.crop {
             None => {
                 // No crop exists, create a new one
@@ -293,6 +294,9 @@ impl CropTool {
                 self.action = Some(CropToolAction::NewCrop);
             }
             Some(c) => {
+                if !c.active {
+                    activate = true;
+                }
                 if let Some(handle) = c.test_handle_hit(pos, CropTool::HANDLE_MARGIN_IN_2) {
                     // Crop exists and we are near a handle, drag it
                     self.action = Some(CropToolAction::DragHandle(DragHandleState {
@@ -317,6 +321,9 @@ impl CropTool {
                     self.action = Some(CropToolAction::NewCrop);
                 }
             }
+        }
+        if activate && let Some(c) = &mut self.crop {
+            c.active = true;
         }
         ToolUpdateResult::Redraw
     }
@@ -382,6 +389,20 @@ impl CropTool {
             }
         }
     }
+
+    fn handle_deactivate_and_reset(&mut self) -> ToolUpdateResult {
+        self.crop = None;
+        self.action = None;
+
+        if let Some(sender) = &self.sender {
+            sender
+                .send(SketchBoardInput::Output(
+                    SketchBoardOutput::DimensionsUpdate(None),
+                ))
+                .ok();
+        }
+        ToolUpdateResult::Redraw
+    }
 }
 
 impl Tool for CropTool {
@@ -398,41 +419,45 @@ impl Tool for CropTool {
     }
 
     fn handle_key_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.crop.is_some() {
-            self.crop = None;
-            self.action = None;
-
-            if let Some(sender) = &self.sender {
-                sender
-                    .send(SketchBoardInput::Output(
-                        SketchBoardOutput::DimensionsUpdate(None),
-                    ))
-                    .ok();
+        match event.key {
+            //FIXME: use if let guards as soon as they're stabilized (1.95)
+            Key::Escape if self.crop.is_some() => {
+                if self.crop.as_mut().unwrap().active {
+                    self.handle_deactivate_and_reset()
+                } else {
+                    ToolUpdateResult::Unmodified
+                }
             }
-
-            return ToolUpdateResult::Redraw;
+            //FIXME: use if let guards as soon as they're stabilized (1.95)
+            Key::Return if self.crop.is_some() => {
+                if self.crop.as_mut().unwrap().active {
+                    self.handle_deactivated()
+                } else {
+                    ToolUpdateResult::Unmodified
+                }
+            }
+            _ => ToolUpdateResult::Unmodified,
         }
-        ToolUpdateResult::Unmodified
     }
 
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
-            MouseEventType::BeginDrag => {
-                if event.button == MouseButton::Middle {
-                    return ToolUpdateResult::Unmodified;
+            MouseEventType::Click if event.button == MouseButton::Secondary => {
+                if let Some(crop) = &self.crop
+                    && crop.active
+                {
+                    self.handle_deactivate_and_reset()
+                } else {
+                    ToolUpdateResult::Unmodified
                 }
+            }
+            MouseEventType::BeginDrag if event.button == MouseButton::Primary => {
                 self.begin_drag(event.pos)
             }
-            MouseEventType::EndDrag => {
-                if event.button == MouseButton::Middle {
-                    return ToolUpdateResult::Unmodified;
-                }
+            MouseEventType::EndDrag if event.button == MouseButton::Primary => {
                 self.end_drag(event.pos)
             }
-            MouseEventType::UpdateDrag => {
-                if event.button == MouseButton::Middle {
-                    return ToolUpdateResult::Unmodified;
-                }
+            MouseEventType::UpdateDrag if event.button == MouseButton::Primary => {
                 self.update_drag(event.pos)
             }
             _ => ToolUpdateResult::Unmodified,

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -279,7 +279,7 @@ impl CropTool {
             let height = size.y.round() as i32;
             sender
                 .send(SketchBoardInput::Output(
-                    SketchBoardOutput::CropDimensionsUpdate((width, height)),
+                    SketchBoardOutput::DimensionsUpdate(Some((width, height))),
                 ))
                 .ok();
         }
@@ -405,7 +405,7 @@ impl Tool for CropTool {
             if let Some(sender) = &self.sender {
                 sender
                     .send(SketchBoardInput::Output(
-                        SketchBoardOutput::CropDimensionsUpdate((0, 0)),
+                        SketchBoardOutput::DimensionsUpdate(None),
                     ))
                     .ok();
             }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -33,6 +33,7 @@ pub struct StyleToolbar {
     annotation_size: f32,
     annotation_size_formatted: String,
     annotation_dialog_controller: Option<Controller<AnnotationSizeDialog>>,
+    crop_dimensions: String,
 }
 
 pub struct AnnotationSizeDialog {
@@ -54,6 +55,7 @@ pub enum ToolbarEvent {
     SaveFileAs,
     Resize,
     OriginalScale,
+    CropDimensionsUpdated((i32, i32)),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -72,6 +74,7 @@ pub enum StyleToolbarInput {
     ToggleVisibility,
     ShowAnnotationDialog,
     AnnotationDialogFinished(Option<f32>),
+    CropDimensionsChanged((i32, i32)),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -555,6 +558,16 @@ impl Component for StyleToolbar {
                 connect_clicked => StyleToolbarInput::ShowAnnotationDialog
             },
             gtk::Separator {},
+            gtk::Label {
+                set_focusable: false,
+                set_hexpand: false,
+                set_margin_start: 10,
+
+                #[watch]
+                set_text: &model.crop_dimensions,
+                set_tooltip: "Crop dimensions (width x height)",
+            },
+            gtk::Separator {},
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
@@ -625,6 +638,9 @@ impl Component for StyleToolbar {
             StyleToolbarInput::ToggleVisibility => {
                 self.visible = !self.visible;
             }
+            StyleToolbarInput::CropDimensionsChanged((width, height)) => {
+                self.crop_dimensions = format!("{}x{}", width, height);
+            }
         }
     }
 
@@ -692,6 +708,7 @@ impl Component for StyleToolbar {
                 APP_CONFIG.read().annotation_size_factor()
             ),
             annotation_dialog_controller: None,
+            crop_dimensions: String::new(),
         };
 
         // create widgets

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -33,7 +33,7 @@ pub struct StyleToolbar {
     annotation_size: f32,
     annotation_size_formatted: String,
     annotation_dialog_controller: Option<Controller<AnnotationSizeDialog>>,
-    crop_dimensions: String,
+    output_dimensions: String,
 }
 
 pub struct AnnotationSizeDialog {
@@ -55,7 +55,6 @@ pub enum ToolbarEvent {
     SaveFileAs,
     Resize,
     OriginalScale,
-    CropDimensionsUpdated((i32, i32)),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -74,7 +73,7 @@ pub enum StyleToolbarInput {
     ToggleVisibility,
     ShowAnnotationDialog,
     AnnotationDialogFinished(Option<f32>),
-    CropDimensionsChanged((i32, i32)),
+    DimensionsChanged((i32, i32)),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -562,10 +561,11 @@ impl Component for StyleToolbar {
                 set_focusable: false,
                 set_hexpand: false,
                 set_margin_start: 10,
+                set_width_chars: 11,
 
                 #[watch]
-                set_text: &model.crop_dimensions,
-                set_tooltip: "Crop dimensions (width x height)",
+                set_text: &model.output_dimensions,
+                set_tooltip: "Output dimensions (width x height)",
             },
             gtk::Separator {},
             gtk::Button {
@@ -638,8 +638,8 @@ impl Component for StyleToolbar {
             StyleToolbarInput::ToggleVisibility => {
                 self.visible = !self.visible;
             }
-            StyleToolbarInput::CropDimensionsChanged((width, height)) => {
-                self.crop_dimensions = format!("{}x{}", width, height);
+            StyleToolbarInput::DimensionsChanged((width, height)) => {
+                self.output_dimensions = format!("{}x{}", width, height);
             }
         }
     }
@@ -708,7 +708,7 @@ impl Component for StyleToolbar {
                 APP_CONFIG.read().annotation_size_factor()
             ),
             annotation_dialog_controller: None,
-            crop_dimensions: String::new(),
+            output_dimensions: String::new(),
         };
 
         // create widgets


### PR DESCRIPTION
This PR adds image and crop dimensions display to the toolbar for better visibility and fixed-size rendering.

- Show full image dimensions in toolbar (bottom right) when crop tool is inactive
- Display crop selection dimensions when crop tool is active  


NOTE: event flow from `CropTool → SketchBoard → App → StyleToolbar`




<img width="700" height="69" alt="251216_11h22m24s_screenshot" src="https://github.com/user-attachments/assets/dc90acc7-4afc-4f9d-9ee3-cc31740fe338" />


-------


Update: [eab8720](https://github.com/Satty-org/Satty/pull/357/commits/eab87205bfbded43d6f82437c23f4368160b2a9e) Adds:
- Esc key cancels crop selection instead of killing process when crop tool is active.
