### PR TITLE
feat: flatpak build script and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,33 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: satty-${{ matrix.target }}.${{ matrix.archive }}
+
+  flatpak:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
+      options: --privileged
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git safe directory
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Build Flatpak
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          manifest-path: org.satty.Satty.yml
+          bundle: satty-${{ github.ref_name }}.flatpak
+          cache-key: flatpak-builder-${{ github.sha }}
+
+      - name: Release Flatpak
+        uses: softprops/action-gh-release@v1
+        with:
+          files: satty-${{ github.ref_name }}.flatpak

--- a/README.md
+++ b/README.md
@@ -319,6 +319,18 @@ PREFIX=/usr/local make install
 PREFIX=/usr/local make uninstall
 ```
 
+### Flatpak
+
+Satty is available as a Flatpak bundle. Pre-built bundles are automatically created for each release and can be downloaded from the [GitHub Releases](https://github.com/Satty-org/Satty/releases) page.
+
+#### Installing from Flatpak bundle
+
+```sh
+# Download the .flatpak file from the latest release
+# Then install it:
+flatpak install satty-<version>.flatpak
+```
+
 ## Dependencies
 
 Satty is based on GTK-4 and Adwaita.

--- a/org.satty.Satty.yml
+++ b/org.satty.Satty.yml
@@ -1,0 +1,56 @@
+app-id: org.satty.Satty
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+command: satty
+build-options:
+  append-path: /usr/lib/sdk/rust-stable/bin
+  build-args:
+    - --share=network
+  env:
+    CARGO_HOME: /run/build/satty/cargo
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+    RUSTFLAGS: -C link-arg=-Wl,-z,now
+finish-args:
+  # Wayland support
+  - --socket=wayland
+  - --socket=x11
+  - --device=dri
+  # File access
+  - --filesystem=home
+  - --filesystem=xdg-config/satty:ro
+  - --filesystem=xdg-data/satty:rw
+  # Clipboard access
+  - --talk-name=org.freedesktop.portal.Clipboard
+  - --talk-name=org.freedesktop.portal.Secret
+  # Screenshot/desktop integration
+  - --talk-name=org.freedesktop.portal.Screenshot
+  - --talk-name=org.freedesktop.portal.Desktop
+  # Notifications
+  - --talk-name=org.freedesktop.Notifications
+  # Share MIME types
+  - --share=ipc
+  # Allow reading from stdin
+  - --share=network
+
+modules:
+  - name: satty
+    buildsystem: simple
+    build-commands:
+      - cargo build --release --locked
+      - install -Dm755 target/release/satty /app/bin/satty
+      - install -Dm644 satty.desktop /app/share/applications/org.satty.Satty.desktop
+      - install -Dm644 assets/satty.svg /app/share/icons/hicolor/scalable/apps/org.satty.Satty.svg
+      - install -Dm644 LICENSE /app/share/licenses/org.satty.Satty/LICENSE
+      - install -Dm644 completions/satty.bash /app/share/bash-completion/completions/satty
+      - install -Dm644 completions/satty.fish /app/share/fish/vendor_completions.d/satty.fish
+      - install -Dm644 completions/satty.elv /app/share/elvish/lib/satty.elv
+      - install -Dm644 completions/satty.nu /app/share/nushell/completions/satty.nu
+      - sed -i 's|^Exec=satty|Exec=/app/bin/satty|' /app/share/applications/org.satty.Satty.desktop
+      - sed -i 's|^TryExec=satty|TryExec=/app/bin/satty|' /app/share/applications/org.satty.Satty.desktop
+      - sed -i 's|^Icon=satty|Icon=org.satty.Satty|' /app/share/applications/org.satty.Satty.desktop
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
Automate building and publishing of flatpak for each Satty release.

This does not publish the release to flathub, just creates a downloadable artifact in for the Github release.

Discussed in #237 

Tested on my fork, here is a test-release https://github.com/martintrojer/Satty/releases/tag/v0.20.1