### PR TITLE
fix: set the correct version in the released flatpak

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           manifest-path: org.satty.Satty.yml
           bundle: satty-${{ github.ref_name }}.flatpak
+          branch: ${{ github.ref_name }}
           cache-key: flatpak-builder-${{ github.sha }}
 
       - name: Release Flatpak

--- a/org.satty.Satty.metainfo.xml
+++ b/org.satty.Satty.metainfo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.satty.Satty</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MPL-2.0</project_license>
+  <name>Satty</name>
+  <summary>Modern Screenshot Annotation</summary>
+  <icon type="stock">org.satty.Satty</icon>
+  <description>
+    <p>
+      Satty is a modern screenshot annotation tool for Linux, designed for wlroots-based compositors.
+      It provides a simple, intuitive toolset for annotating screenshots with smooth hardware-accelerated rendering.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/Satty-org/Satty</url>
+  <url type="bugtracker">https://github.com/Satty-org/Satty/issues</url>
+  <developer_name>Matthias Gabriel</developer_name>
+</component>

--- a/org.satty.Satty.yml
+++ b/org.satty.Satty.yml
@@ -42,6 +42,7 @@ modules:
       - cargo build --release --locked
       - install -Dm755 target/release/satty /app/bin/satty
       - install -Dm644 satty.desktop /app/share/applications/org.satty.Satty.desktop
+      - install -Dm644 org.satty.Satty.metainfo.xml /app/share/metainfo/org.satty.Satty.metainfo.xml
       - install -Dm644 assets/satty.svg /app/share/icons/hicolor/scalable/apps/org.satty.Satty.svg
       - install -Dm644 LICENSE /app/share/licenses/org.satty.Satty/LICENSE
       - install -Dm644 completions/satty.bash /app/share/bash-completion/completions/satty


### PR DESCRIPTION
fba1855ec6b286ba5c8db78178283dc37093b9f0 lacked the metainfo.xml file to properly populate the branch/version of the flatpak and making sure it shows 'installed apps' in UIs used for managing flatpaks (such as Gnome Software).

This diff adds:

- `org.satty.Satty.metainfo.xml`: AppData/MetaInfo file following the AppStream specification with application metadata including name, description, icon, URLs, and release version information
- Metainfo installation: Updated `org.satty.Satty.yml` to install the metainfo file to `/app/share/metainfo/org.satty.Satty.metainfo.xml` during the Flatpak build
- Branch configuration: Set the `branch` parameter in the Flatpak build action to use the tag name, ensuring proper versioning in the Branch column of `flatpak list`

- The version is automatically synchronized with git tags during release builds


Tests (after local install of a test release):

```
Satty ❯ flatpak list                                            
Name                      Application ID                 Version                  Branch      Origin       Installation
GNOME Application Platfo… org.gnome.Platform                                      49          flathub      system
Satty                     org.satty.Satty                                         v0.20.1     satty-origin system
```

Screenshot from 'Gnome Software'

<img width="1231" height="738" alt="Screenshot from 2026-01-02 11-49-38" src="https://github.com/user-attachments/assets/e131686c-cf13-48df-9404-0b194aae1f6f" />
