### PR TITLE
fix: adjust minimum width to accommodate additional buttons

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ impl App {
         css_provider.load_from_data(
             "
             .root {
-                min-width: 50rem;
+                min-width: 65rem;
                 min-height: 10rem;
             }
             .toolbar {color: #f9f9f9 ; background: #00000099;}


### PR DESCRIPTION
Closes: #365

Buttons have been added to toolbars, the old minimum width doesn't show all of them anymore.

This is a quick fix, better ways to deal with this may be in #49 in the long run.