### PR TITLE
feat!: change early-exit to allow individual triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ resize = { mode = "size", width=2000, height=800 }
 floating-hack = true
 # Change to true to automatically copy to clipboard after every annotation change
 auto-copy = false
-# Exit directly after copy/save action. 0.20.1: Does not apply to save as
-early-exit = true
-# Exit directly after save as (0.20.1)
-early-exit-save-as = true
+# Exit directly after copy/save action. NEXTRELEASE: change to list of triggers
+# Note that exit-early-save-as was removed with NEXTRELEASE.
+early-exit = ["all"]
+# is equivalent to both
+# early-exit = ["copy", "save", "save-as"]
+# early-exit = true
 # Draw corners of rectangles round if the value is greater than 0 (0 disables rounded corners)
 corner-roundness = 12
 # Select the tool on startup [possible values: pointer, crop, line, arrow, rectangle, text, marker, blur, brush]
@@ -255,10 +257,8 @@ Options:
           Try to enforce floating (0.20.1). Mileage may vary depending on compositor
   -o, --output-filename <OUTPUT_FILENAME>
           Filename to use for saving action or '-' to print to stdout. Omit to disable saving to file. Might contain format specifiers: <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>. Since 0.20.0, can contain tilde (~) for home dir
-      --early-exit
-          Exit directly after copy/save action. 0.20.1: This does not apply to "save as"
-      --early-exit-save-as
-          Experimental (0.20.1): Exit directly after save as
+      --early-exit [<EARLY_EXIT>...]
+          Exit directly after save action. NEXTRELEASE: changed to accommodate different triggers [possible values: all, copy, save, save-as]
       --corner-roundness <CORNER_ROUNDNESS>
           Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
@@ -308,7 +308,7 @@ Options:
       --title <TITLE>
           Experimental feature (NEXTRELEASE): Set window title
       --app-id <APP_ID>
-          Experimental feature (NEXTRELEASE): Set toplevel app_id. Note that this applies gtk format expectations
+          Experimental feature (NEXTRELEASE): Set toplevel app_id. Note that this has to match D-Bus well known name format, otherwise GTK does not accept it
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -44,13 +44,9 @@ pub struct CommandLine {
     #[arg(short, long)]
     pub output_filename: Option<String>,
 
-    /// Exit directly after copy/save action. 0.20.1: This does not apply to "save as".
-    #[arg(long)]
-    pub early_exit: bool,
-
-    /// Experimental (0.20.1): Exit directly after save as
-    #[arg(long)]
-    pub early_exit_save_as: bool,
+    /// Exit directly after save action. NEXTRELEASE: changed to accommodate different triggers
+    #[arg(long, value_delimiter = ',', num_args=0.., default_missing_value = "all")]
+    pub early_exit: Option<Vec<EarlyExitTriggers>>,
 
     /// Draw corners of rectangles round if the value is greater than 0
     /// (Defaults to 12) (0 disables rounded corners)
@@ -207,6 +203,16 @@ impl FromStr for Resize {
             }
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, ValueEnum, PartialEq)]
+#[value(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
+pub enum EarlyExitTriggers {
+    All,
+    Copy,
+    Save,
+    SaveAs,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -19,7 +19,9 @@ use crate::{
     tools::{Highlighters, Tools},
 };
 
-use satty_cli::command_line::{Action as CommandLineAction, CommandLine, Fullscreen, Resize};
+use satty_cli::command_line::{
+    Action as CommandLineAction, CommandLine, EarlyExitTriggers, Fullscreen, Resize,
+};
 
 pub static APP_CONFIG: SharedState<Configuration> = SharedState::new();
 
@@ -43,8 +45,7 @@ pub struct Configuration {
     fullscreen: Option<Fullscreen>,
     resize: Option<Resize>,
     floating_hack: bool,
-    early_exit: bool,
-    early_exit_save_as: bool,
+    early_exit: EarlyExit,
     corner_roundness: f32,
     initial_tool: Tools,
     copy_command: Option<String>,
@@ -224,6 +225,71 @@ where
     }
 }
 
+// backwards compatibility, allow early-exit = true in config
+#[derive(Deserialize)]
+#[serde(untagged)]
+#[serde(rename_all = "kebab-case")]
+enum EarlyExitCompat {
+    Bool(bool),
+    Triggers(Vec<EarlyExitTriggers>),
+}
+
+fn de_early_exit<'de, D>(d: D) -> Result<Option<Vec<EarlyExitTriggers>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match EarlyExitCompat::deserialize(d)? {
+        EarlyExitCompat::Bool(true) => Ok(Some(vec![EarlyExitTriggers::All])),
+        EarlyExitCompat::Bool(false) => Ok(None),
+        EarlyExitCompat::Triggers(m) => Ok(Some(m)),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct EarlyExit {
+    copy: bool,
+    save: bool,
+    save_as: bool,
+}
+
+impl EarlyExit {
+    pub fn copy(&self) -> bool {
+        self.copy
+    }
+    pub fn save(&self) -> bool {
+        self.save
+    }
+    pub fn save_as(&self) -> bool {
+        self.save_as
+    }
+}
+
+impl From<Vec<EarlyExitTriggers>> for EarlyExit {
+    fn from(val: Vec<EarlyExitTriggers>) -> Self {
+        let mut ee = EarlyExit::default();
+        for e in val {
+            match e {
+                EarlyExitTriggers::All => {
+                    ee.copy = true;
+                    ee.save = true;
+                    ee.save_as = true;
+                }
+                EarlyExitTriggers::Copy => {
+                    ee.copy = true;
+                }
+                EarlyExitTriggers::Save => {
+                    ee.save = true;
+                }
+                EarlyExitTriggers::SaveAs => {
+                    ee.save_as = true;
+                }
+            }
+        }
+        ee
+    }
+}
+
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Action {
@@ -286,10 +352,7 @@ impl Configuration {
             self.floating_hack = v;
         }
         if let Some(v) = general.early_exit {
-            self.early_exit = v;
-        }
-        if let Some(v) = general.early_exit_save_as {
-            self.early_exit_save_as = v;
+            self.early_exit = v.into();
         }
         if let Some(v) = general.corner_roundness {
             self.corner_roundness = v;
@@ -412,11 +475,8 @@ impl Configuration {
         if command_line.license {
             self.license = command_line.license;
         }
-        if command_line.early_exit {
-            self.early_exit = command_line.early_exit;
-        }
-        if command_line.early_exit_save_as {
-            self.early_exit_save_as = command_line.early_exit_save_as;
+        if let Some(v) = command_line.early_exit {
+            self.early_exit = v.into();
         }
         if let Some(v) = command_line.corner_roundness {
             self.corner_roundness = v;
@@ -520,12 +580,16 @@ impl Configuration {
         self.license
     }
 
-    pub fn early_exit(&self) -> bool {
-        self.early_exit
+    pub fn early_exit_copy(&self) -> bool {
+        self.early_exit.copy()
+    }
+
+    pub fn early_exit_save(&self) -> bool {
+        self.early_exit.save()
     }
 
     pub fn early_exit_save_as(&self) -> bool {
-        self.early_exit_save_as
+        self.early_exit.save_as()
     }
 
     pub fn corner_roundness(&self) -> f32 {
@@ -666,8 +730,7 @@ impl Default for Configuration {
             fullscreen: None,
             resize: None,
             floating_hack: false,
-            early_exit: false,
-            early_exit_save_as: false,
+            early_exit: EarlyExit::default(),
             corner_roundness: 12.0,
             initial_tool: Tools::Pointer,
             copy_command: None,
@@ -753,8 +816,8 @@ struct ConfigurationFileGeneral {
     fullscreen: Option<Fullscreen>,
     resize: Option<Resize>,
     floating_hack: Option<bool>,
-    early_exit: Option<bool>,
-    early_exit_save_as: Option<bool>,
+    #[serde(deserialize_with = "de_early_exit", default)]
+    early_exit: Option<Vec<EarlyExitTriggers>>,
     corner_roundness: Option<f32>,
     initial_tool: Option<Tools>,
     copy_command: Option<String>,

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -300,14 +300,14 @@ impl SketchBoard {
                     if let Some(ref pix_buf) = pix_buf {
                         self.handle_copy_clipboard(pix_buf);
                         if !APP_CONFIG.read().auto_copy() {
-                            early_exit = APP_CONFIG.read().early_exit();
+                            early_exit = APP_CONFIG.read().early_exit_copy();
                         }
                     }
                 }
                 Action::SaveToFile => {
                     if let Some(ref pix_buf) = pix_buf {
                         self.handle_save(pix_buf);
-                        early_exit = APP_CONFIG.read().early_exit();
+                        early_exit = APP_CONFIG.read().early_exit_save();
                     }
                 }
                 /* SaveToFileAs runs through a callback, so any further actions need to be triggered


### PR DESCRIPTION
Closes: #152

This allows the following configs

```
early-exit = true
early-exit = [ "all" ]
early-exit = [ "copy", "save", "save-as" ]
```
as well as command line
```
--early-exit
--early-exit=all
--early-exit=copy,save,save-as
```
