### PR TITLE
fix: stale scale factor

### DIFF
--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -165,4 +165,8 @@ impl FemtoVGArea {
         //trigger resize to reset
         self.imp().resize(0, 0);
     }
+
+    pub fn resize(&self, width: i32, height: i32) {
+        self.imp().resize(width, height);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,7 @@ enum AppInput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    ScaleFactorChanged,
 }
 
 #[derive(Debug)]
@@ -231,6 +232,11 @@ impl Component for App {
                         ui::toolbars::ColorButtons::Palette(index),
                     ));
             }
+            AppInput::ScaleFactorChanged => {
+                self.sketch_board
+                    .sender()
+                    .emit(SketchBoardInput::ScaleFactorChanged);
+            }
         }
     }
 
@@ -290,16 +296,26 @@ impl Component for App {
         if APP_CONFIG.read().focus_toggles_toolbars() {
             let motion_controller = gtk::EventControllerMotion::builder().build();
             let sender_clone = sender.clone();
+            let sender_clone2 = sender.clone();
 
             motion_controller.connect_enter(move |_, _, _| {
-                sender.input(AppInput::SetToolbarsDisplay(true));
+                sender_clone.input(AppInput::SetToolbarsDisplay(true));
             });
             motion_controller.connect_leave(move |_| {
-                sender_clone.input(AppInput::SetToolbarsDisplay(false));
+                sender_clone2.input(AppInput::SetToolbarsDisplay(false));
             });
 
             root.add_controller(motion_controller);
         }
+
+        root.connect_map(move |r| {
+            let sender_clone3 = sender.clone();
+            if let Some(surface) = r.surface() {
+                surface.connect_notify_local(Some("scale-factor"), move |_, _| {
+                    sender_clone3.input(AppInput::ScaleFactorChanged);
+                });
+            }
+        });
 
         generate_profile_output!("app init end");
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -37,6 +37,7 @@ pub enum SketchBoardInput {
     CommitEvent(TextEventMsg),
     Refresh,
     Exit,
+    ScaleFactorChanged,
 }
 
 #[derive(Debug, Clone)]
@@ -1115,6 +1116,10 @@ impl Component for SketchBoard {
             SketchBoardInput::Exit => {
                 self.handle_exit();
                 ToolUpdateResult::Unmodified
+            }
+            SketchBoardInput::ScaleFactorChanged => {
+                self.renderer.resize(0, 0);
+                ToolUpdateResult::Redraw
             }
         };
 


### PR DESCRIPTION
Closes: #293

When starting satty e.g. on a DPI scale factor = 1.6 screen and moving the window to a scale factor = 1.0 screen, the scale factor of femtovg area is stale for the first tool used.

This causes the first tool after window move to appear in a wrong position.

Fix this by adding an event handler for changed scale-factor.