### PR TITLE
fix!: use OUT_DIR only for cargo publish compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release --locked --target ${{ matrix.target }}
+        run: cargo build --release --locked --target ${{ matrix.target }} --features ci-release
 
       - name: Pack Artifacts
         if: matrix.os == 'ubuntu-latest'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ include = [
   "LICENSE*",
   "README.md",
   "assets/",
+  "build.rs"
 ]
+
+[features]
+ci-release = []
 
 [dependencies]
 satty_cli.workspace = true
@@ -76,5 +80,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
-satty_cli = { path = "cli" }
+satty_cli = { path = "cli", version = "0.20.1" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -5,34 +5,49 @@ endif
 SOURCEDIRS:=src $(wildcard src/*)
 SOURCEFILES:=$(foreach d,$(SOURCEDIRS),$(wildcard $(d)/*.rs))
 
+BINDIR:=$(PREFIX)/bin
+
+BASHDIR:=$(PREFIX)/share/bash-completion/completions
+ZSHDIR:=$(PREFIX)/share/zsh/site-functions
+FISHDIR:=$(PREFIX)/share/fish/vendor_completions.d
+ELVDIR:=$(PREFIX)/share/elvish/lib
+NUDIR:=$(PREFIX)/share/nushell/completions
+FIGDIR:=$(PREFIX)/share/fig/autocomplete
+
 build: target/debug/satty
 
 build-release: target/release/satty
 
 force-build:
-	cargo build
+	cargo build --features ci-release
 
 force-build-release:
-	cargo build --release
+	cargo build --release --features ci-release
 
 target/debug/satty: $(SOURCEFILES) Cargo.lock Cargo.toml
-	cargo build
+	cargo build --features ci-release
 
 target/release/satty: $(SOURCEFILES) Cargo.lock Cargo.toml
-	cargo build --release
+	cargo build --release --features ci-release
 
 clean:
 	cargo clean
 
 install: target/release/satty
-	install -s -Dm755 target/release/satty -t ${PREFIX}/bin/
-	install -Dm644 satty.desktop ${PREFIX}/share/applications/satty.desktop
-	install -Dm644 assets/satty.svg ${PREFIX}/share/icons/hicolor/scalable/apps/satty.svg
+	install -s -Dm755 target/release/satty -t $(BINDIR)
+	install -Dm644 satty.desktop $(PREFIX)/share/applications/satty.desktop
+	install -Dm644 assets/satty.svg $(PREFIX)/share/icons/hicolor/scalable/apps/satty.svg
 	install -Dm644 satty.1 ${PREFIX}/share/man/man1
-	install -Dm644 LICENSE ${PREFIX}/share/licenses/satty/LICENSE
+	install -Dm644 LICENSE $(PREFIX)/share/licenses/satty/LICENSE
+	install -Dm644 completions/_satty $(ZSHDIR)/_satty
+	install -Dm644 completions/satty.bash $(BASHDIR)/satty
+	install -Dm644 completions/satty.fish $(FISHDIR)/satty.fish
+	install -Dm644 completions/satty.elv $(ELVDIR)/satty.elv
+	install -Dm644 completions/satty.nu $(NUDIR)/satty.nu
+	install -Dm644 completions/satty.ts $(FIGDIR)/satty.ts
 
 uninstall:
-	rm ${PREFIX}/bin/satty
+	rm ${BINDIR}/satty
 	rmdir -p ${PREFIX}/bin || true
 
 	rm ${PREFIX}/share/applications/satty.desktop
@@ -45,7 +60,25 @@ uninstall:
 	rmdir -p ${PREFIX}/share/licenses/satty || true
 
 	rm ${PREFIX}/share/man/man1/satty.1
-	
+
+	rm $(ZSHDIR)/_satty
+	rmdir -p $(ZSHDIR) || true
+
+	rm $(BASHDIR)/satty
+	rmdir -p $(BASHDIR) || true
+
+	rm $(FISHDIR)/satty.fish
+	rmdir -p $(FISHDIR) || true
+
+	rm $(ELVDIR)/satty.elv
+	rmdir -p $(ELVDIR) || true
+
+	rm $(NUDIR)/satty.nu
+	rmdir -p $(NUDIR) || true
+
+	rm $(FIGDIR)/satty.ts
+	rmdir -p $(FIGDIR) || true
+
 package: clean build-release
 	$(eval TMP := $(shell mktemp -d))
 	echo "Temporary folder ${TMP}"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@
 use std::borrow::BorrowMut;
 use std::fs;
 use std::io;
+use std::path::PathBuf;
 
 use clap::CommandFactory;
 use clap_complete::{generate_to, Shell};
@@ -17,15 +18,20 @@ fn main() -> Result<(), io::Error> {
     let mut cmd = command_line::CommandLine::command();
     let cmd2 = cmd.borrow_mut();
     let bin = "satty";
-    let out = "completions";
+    let completions = if cfg!(feature = "ci-release") {
+        PathBuf::from("completions")
+    } else {
+        // make cargo publish happy about OUT_DIR ;)
+        out_dir.join(PathBuf::from("completions"))
+    };
 
-    fs::create_dir_all(out)?;
-    generate_to(Shell::Bash, cmd2, bin, out)?;
-    generate_to(Shell::Fish, cmd2, bin, out)?;
-    generate_to(Shell::Zsh, cmd2, bin, out)?;
-    generate_to(Shell::Elvish, cmd2, bin, out)?;
-    generate_to(Nushell, cmd2, bin, out)?;
-    generate_to(Fig, cmd2, bin, out)?;
+    fs::create_dir_all(completions.as_path())?;
+    generate_to(Shell::Bash, cmd2, bin, &completions)?;
+    generate_to(Shell::Fish, cmd2, bin, &completions)?;
+    generate_to(Shell::Zsh, cmd2, bin, &completions)?;
+    generate_to(Shell::Elvish, cmd2, bin, &completions)?;
+    generate_to(Nushell, cmd2, bin, &completions)?;
+    generate_to(Fig, cmd2, bin, &completions)?;
 
     let man = Man::new(cmd);
     let mut buffer: Vec<u8> = Default::default();

--- a/org.satty.Satty.yml
+++ b/org.satty.Satty.yml
@@ -39,7 +39,7 @@ modules:
   - name: satty
     buildsystem: simple
     build-commands:
-      - cargo build --release --locked
+      - cargo build --release --locked --features ci-release
       - install -Dm755 target/release/satty /app/bin/satty
       - install -Dm644 satty.desktop /app/share/applications/org.satty.Satty.desktop
       - install -Dm644 org.satty.Satty.metainfo.xml /app/share/metainfo/org.satty.Satty.metainfo.xml


### PR DESCRIPTION
Related to #395

Introduces a feature ci-release which can be used to generate completions to "completions" dir.

Otherwise, in cargo publish scenario, have clap_complete generate these to OUT_DIR. Otherwise cargo publish complains about stuff generated to outside of OUT_DIR.

This needs a modification of the release/flatpak workflows to use this new feature, otherwise packing the completions from the OUT_DIR would become considerably more difficult.

While we're at it, install completions via `make install` as well. This works well if /usr/local is used as a prefix but is not perfect yet for user home installations.

EDIT: For the release notes: This may need a note for package maintainers, if they're not using the ci-release feature, they may have trouble finding the completions in the artifact directory.