### PR TITLE
fix: duplicate eventcontroller for vertical scrolling

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -922,14 +922,6 @@ impl Component for SketchBoard {
                     },
                 },
 
-                add_controller = gtk::EventControllerScroll{
-                    set_flags: gtk::EventControllerScrollFlags::VERTICAL,
-                    connect_scroll[sender] => move |_, _, dy| {
-                        sender.input(SketchBoardInput::new_scroll_event(dy));
-                        glib::Propagation::Stop
-                    },
-                },
-
                 add_controller = gtk::EventControllerKey {
                     connect_key_pressed[sender] => move |controller, key, code, modifier | {
                         if let Some(im_context) = controller.im_context() {


### PR DESCRIPTION
Closes: #434 

Apparently two identical blocks coming from two different PRs. I missed it because the diff of the second PR hid the block that was already present.