### PR TITLE
feat: docked toolbars in window, overlay toolbars in fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Options:
 Satty ships with [minimal builtin CSS](https://github.com/Satty-org/Satty/tree/main/assets/default.css) which can be overridden by `$XDG_CONFIG_HOME/satty/overrides.css`. Adwaita defaults for headerbar (`@headerbar_fg_color` and `@headerbar_bg_color`) which Satty uses <sup>NEXTRELEASE</sup> may lack transparency, here's an override example:
 
 ```css
+.outer_box,
 .toolbar {
     color: #000000;
     background-color: #ddddddaa;

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -2,9 +2,14 @@
     min-width: 65rem;
     min-height: 10rem;
 }
+
+.outer_box {
+    background-color: @headerbar_bg_color;
+}
+
 .toolbar {
     color: @headerbar_fg_color;
-    background: @headerbar_bg_color;
+    background-color: @headerbar_bg_color;
 }
 .toast {
     color: #f9f9f9;
@@ -12,5 +17,11 @@
     border-radius: 6px;
     margin-top: 50px;
 }
-.toolbar-bottom { border-radius: 6px 6px 0px 0px; }
-.toolbar-top { border-radius: 0px 0px 6px 6px; }
+
+.outer_box .toolbar-bottom,
+.outer_box .toolbar-top {
+    border-radius: 0px 0px 0px 0px;
+}
+
+.overlay .toolbar-bottom { border-radius: 6px 6px 0px 0px; }
+.overlay .toolbar-top { border-radius: 0px 0px 6px 6px; }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use relm4::{
 };
 
 use anyhow::{anyhow, Context, Result};
-
 use satty_cli::command_line::{Fullscreen, Resize};
 
 use sketch_board::SketchBoardOutput;
@@ -58,6 +57,8 @@ struct App {
     sketch_board: Controller<SketchBoard>,
     tools_toolbar: Controller<ToolsToolbar>,
     style_toolbar: Controller<StyleToolbar>,
+    outer_box: gtk::Box,
+    overlay: gtk::Overlay,
 }
 
 #[derive(Debug)]
@@ -68,6 +69,7 @@ enum AppInput {
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
     ScaleFactorChanged,
+    FullscreenChanged(bool),
 }
 
 #[derive(Debug)]
@@ -210,18 +212,22 @@ impl Component for App {
                 None => None
             },
 
+            #[local_ref]
+            outer_box_clone -> gtk::Box {
+                add_css_class: "outer_box",
+                append = model.tools_toolbar.widget(),
+                #[local_ref]
+                overlay_clone -> gtk::Overlay {
+                    add_css_class: "overlay",
+                    model.sketch_board.widget(),
+                },
+                append = model.style_toolbar.widget(),
+            },
+
             connect_show[sender] => move |_| {
                 generate_profile_output!("gui show event");
                 sender.input(AppInput::Realized);
             },
-
-            gtk::Overlay {
-                add_overlay = model.tools_toolbar.widget(),
-
-                add_overlay = model.style_toolbar.widget(),
-
-                model.sketch_board.widget(),
-            }
         }
     }
 
@@ -260,6 +266,21 @@ impl Component for App {
                 self.sketch_board
                     .sender()
                     .emit(SketchBoardInput::ScaleFactorChanged);
+            }
+            AppInput::FullscreenChanged(fullscreen) => {
+                let tools = self.tools_toolbar.widget();
+                let style = self.style_toolbar.widget();
+                if fullscreen {
+                    self.outer_box.remove(tools);
+                    self.outer_box.remove(style);
+                    self.overlay.add_overlay(tools);
+                    self.overlay.add_overlay(style);
+                } else {
+                    self.overlay.remove_overlay(tools);
+                    self.overlay.remove_overlay(style);
+                    self.outer_box.prepend(tools);
+                    self.outer_box.append(style);
+                }
             }
         }
     }
@@ -306,37 +327,55 @@ impl Component for App {
             .launch(())
             .forward(sketch_board.sender(), SketchBoardInput::ToolbarEvent);
 
+        let outer_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        let outer_box_clone = outer_box.clone();
+        let overlay = gtk::Overlay::new();
+        let overlay_clone = overlay.clone();
+
         // Model
         let model = App {
             sketch_board,
             tools_toolbar,
             style_toolbar,
             image_dimensions,
+            outer_box,
+            overlay,
         };
 
         let widgets = view_output!();
 
         if APP_CONFIG.read().focus_toggles_toolbars() {
             let motion_controller = gtk::EventControllerMotion::builder().build();
-            let sender_clone = sender.clone();
-            let sender_clone2 = sender.clone();
 
+            let sender_clone = sender.clone();
             motion_controller.connect_enter(move |_, _, _| {
                 sender_clone.input(AppInput::SetToolbarsDisplay(true));
             });
+
+            let sender_clone = sender.clone();
             motion_controller.connect_leave(move |_| {
-                sender_clone2.input(AppInput::SetToolbarsDisplay(false));
+                sender_clone.input(AppInput::SetToolbarsDisplay(false));
             });
 
             root.add_controller(motion_controller);
         }
 
+        let sender_clone = sender.clone();
         root.connect_map(move |r| {
-            let sender_clone3 = sender.clone();
+            let sender_clone = sender_clone.clone();
             if let Some(surface) = r.surface() {
                 surface.connect_notify_local(Some("scale-factor"), move |_, _| {
-                    sender_clone3.input(AppInput::ScaleFactorChanged);
+                    sender_clone.input(AppInput::ScaleFactorChanged);
                 });
+            }
+        });
+
+        let sender_clone = sender.clone();
+        root.connect_notify(Some("fullscreened"), move |window, _| {
+            if window.is_fullscreen() {
+                sender_clone.input(AppInput::FullscreenChanged(true));
+            } else {
+                sender_clone.input(AppInput::FullscreenChanged(false));
             }
         });
 


### PR DESCRIPTION
Closes: #49

~Not closing because there's some followup GUI revamp discussion in there.~

Note that this PR includes PR #398. I try to avoid this, but it really makes no sense otherwise in this particular case.

This PR adds an outer box which the toolbars reside in. When switching to fullscreen, toolbars are put to the overlay, when going back to window, the toolbars get docked into the outer box again.


~I should probably attach a video, but I'm too lazy now.~

the CSS in the PR is better than in the recording, the toolbar and box should get the same bg colour by default. This is just from my testing here.

https://github.com/user-attachments/assets/68d235cd-b7a9-49d9-ad9c-9737ce239d11

