### PR TITLE
fix: add shortcut for GTK inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 - <kbd>Esc</kbd>: as configured (see below), default: exit (may be masked by active tool)
 - <kbd>Delete</kbd> reset (clear) <sup>experimental</sup> <sup>0.20.1</sup>
 - <kbd>Ctrl+C</kbd>: Save to clipboard (may be masked by active tool)
+- <kbd>Ctrl+Shift+D</kbd> or <kbd>Ctrl+Shift+I</kbd>: Open GTK inspector if not already opened
 - <kbd>Ctrl+S</kbd>: Save to specified output file
 - <kbd>Ctrl+Shift+S</kbd>: Save using file dialog <sup>0.20.0</sup>
 - <kbd>Ctrl+Alt+C</kbd>: Copy last saved filepath to clipboard <sup>0.20.1</sup>

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1023,6 +1023,21 @@ impl Component for SketchBoard {
                                 self.renderer
                                     .request_render(&[Action::CopyFilepathToClipboard]);
                                 ToolUpdateResult::Unmodified
+                            } else if (ke.is_one_of(Key::d, KeyMappingId::UsD)
+                                || ke.is_one_of(Key::i, KeyMappingId::UsI))
+                                && ke.modifier
+                                    == (ModifierType::CONTROL_MASK | ModifierType::SHIFT_MASK)
+                            {
+                                /* GTK does not appear to offer any tracking for this, so
+                                we'd have to track the state ourselves. But since the user may
+                                just choose to close the inspector window, doing so adds little
+                                benefit.
+
+                                Just enable it everytime, and let the user close the window if they
+                                so wish.
+                                 */
+                                gtk::Window::set_interactive_debugging(true);
+                                ToolUpdateResult::Unmodified
                             } else if (ke.is_one_of(Key::leftarrow, KeyMappingId::ArrowLeft)
                                 || ke.is_one_of(Key::rightarrow, KeyMappingId::ArrowRight)
                                 || ke.is_one_of(Key::uparrow, KeyMappingId::ArrowUp)


### PR DESCRIPTION
Closes: #427

Before this fix, we mask GTK's own shortcuts (Ctrl+Shift+D and Ctrl+Shift+I).

There is no easy way to prevent this with how we handle shortcuts.

Instead, handle those shortcuts explicitly and actively enable GTK inspector.

Since there is no good way to check whether it's currently enabled, toggle would require an additional bool in sketchboard, which could become inconsistent if the user closes the inspector window. Instead, just enable without toggle, the user then has to close the inspector window if they want to get rid of it.