### PR TITLE
feat: indicate active editing in toolbar

### DIFF
--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -29,3 +29,7 @@
 
 .overlay .toolbar-bottom { border-radius: 6px 6px 0px 0px; }
 .overlay .toolbar-top { border-radius: 0px 0px 6px 6px; }
+
+button.editing {
+    color: @accent_color;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ enum AppInput {
     ScaleFactorChanged,
     FullscreenChanged(bool),
     DimensionsUpdate(Option<(i32, i32)>),
+    ToolEditingChanged(bool),
 }
 
 #[derive(Debug)]
@@ -302,6 +303,11 @@ impl Component for App {
                     .sender()
                     .emit(StyleToolbarInput::DimensionsChanged(d));
             }
+            AppInput::ToolEditingChanged(editing) => {
+                self.tools_toolbar
+                    .sender()
+                    .emit(ToolsToolbarInput::SetToolEditing(editing));
+            }
         }
     }
 
@@ -338,6 +344,9 @@ impl Component for App {
                     }
                     SketchBoardOutput::DimensionsUpdate(dimensions) => {
                         AppInput::DimensionsUpdate(dimensions)
+                    }
+                    SketchBoardOutput::ToolEditingChanged(editing) => {
+                        AppInput::ToolEditingChanged(editing)
                     }
                 });
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -51,6 +51,7 @@ pub enum SketchBoardOutput {
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
     DimensionsUpdate(Option<(i32, i32)>),
+    ToolEditingChanged(bool),
 }
 
 #[derive(Debug, Clone)]
@@ -243,6 +244,7 @@ impl InputEvent {
 pub struct SketchBoard {
     renderer: FemtoVGArea,
     active_tool: Rc<RefCell<dyn Tool>>,
+    tool_edit_mode: bool,
     tools: ToolsManager,
     style: Style,
     im_context: gtk::IMMulticontext,
@@ -1060,6 +1062,7 @@ impl Component for SketchBoard {
 
     fn update(&mut self, msg: SketchBoardInput, sender: ComponentSender<Self>, _root: &Self::Root) {
         // handle resize ourselves, pass everything else to tool
+        let sender_clone = sender.clone();
         let result = match msg {
             SketchBoardInput::InputEvent(mut ie) => {
                 if let InputEvent::Key(ke) = ie {
@@ -1230,6 +1233,14 @@ impl Component for SketchBoard {
             }
         };
 
+        let editing = self.active_tool.borrow().active();
+        if editing != self.tool_edit_mode {
+            self.tool_edit_mode = editing;
+            sender_clone
+                .output_sender()
+                .emit(SketchBoardOutput::ToolEditingChanged(editing));
+        }
+
         match result {
             ToolUpdateResult::Commit(drawable) => {
                 self.renderer.commit(drawable);
@@ -1258,6 +1269,7 @@ impl Component for SketchBoard {
         let mut model = Self {
             renderer: FemtoVGArea::default(),
             active_tool: tools.get(&config.initial_tool()),
+            tool_edit_mode: false,
             style: Style::default(),
             tools,
             im_context,

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -37,6 +37,10 @@ impl Tool for ArrowTool {
         self.input_enabled = value;
     }
 
+    fn active(&self) -> bool {
+        self.arrow.is_some()
+    }
+
     fn get_tool_type(&self) -> super::Tools {
         Tools::Arrow
     }
@@ -107,9 +111,19 @@ impl Tool for ArrowTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.arrow.is_some() {
-            self.arrow = None;
-            ToolUpdateResult::Redraw
+        if let Some(arrow) = &self.arrow {
+            match event.key {
+                Key::Escape => {
+                    self.arrow = None;
+                    ToolUpdateResult::Redraw
+                }
+                Key::Return if arrow.end.is_some() => {
+                    let result = arrow.clone_box();
+                    self.arrow = None;
+                    ToolUpdateResult::Commit(result)
+                }
+                _ => ToolUpdateResult::Unmodified,
+            }
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -111,19 +111,9 @@ impl Tool for ArrowTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if let Some(arrow) = &self.arrow {
-            match event.key {
-                Key::Escape => {
-                    self.arrow = None;
-                    ToolUpdateResult::Redraw
-                }
-                Key::Return if arrow.end.is_some() => {
-                    let result = arrow.clone_box();
-                    self.arrow = None;
-                    ToolUpdateResult::Commit(result)
-                }
-                _ => ToolUpdateResult::Unmodified,
-            }
+        if event.key == Key::Escape && self.arrow.is_some() {
+            self.arrow = None;
+            ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -161,6 +161,10 @@ impl Tool for BlurTool {
         self.input_enabled = value;
     }
 
+    fn active(&self) -> bool {
+        self.blur.is_some()
+    }
+
     fn get_tool_type(&self) -> super::Tools {
         Tools::Blur
     }
@@ -227,9 +231,20 @@ impl Tool for BlurTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.blur.is_some() {
-            self.blur = None;
-            ToolUpdateResult::Redraw
+        if let Some(blur) = &mut self.blur {
+            match event.key {
+                Key::Escape => {
+                    self.blur = None;
+                    ToolUpdateResult::Redraw
+                }
+                Key::Return if blur.size.is_some() => {
+                    blur.editing = false;
+                    let result = blur.clone_box();
+                    self.blur = None;
+                    ToolUpdateResult::Commit(result)
+                }
+                _ => ToolUpdateResult::Unmodified,
+            }
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -231,20 +231,9 @@ impl Tool for BlurTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if let Some(blur) = &mut self.blur {
-            match event.key {
-                Key::Escape => {
-                    self.blur = None;
-                    ToolUpdateResult::Redraw
-                }
-                Key::Return if blur.size.is_some() => {
-                    blur.editing = false;
-                    let result = blur.clone_box();
-                    self.blur = None;
-                    ToolUpdateResult::Commit(result)
-                }
-                _ => ToolUpdateResult::Unmodified,
-            }
+        if event.key == Key::Escape && self.blur.is_some() {
+            self.blur = None;
+            ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -146,6 +146,10 @@ impl Tool for BrushTool {
         ToolUpdateResult::Unmodified
     }
 
+    fn active(&self) -> bool {
+        self.drawable.is_some()
+    }
+
     fn set_sender(&mut self, sender: Sender<SketchBoardInput>) {
         self.sender = Some(sender);
     }

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -406,6 +406,14 @@ impl CropTool {
 }
 
 impl Tool for CropTool {
+    fn active(&self) -> bool {
+        if let Some(c) = &self.crop {
+            c.active
+        } else {
+            false
+        }
+    }
+
     fn input_enabled(&self) -> bool {
         self.input_enabled
     }

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -118,6 +118,10 @@ impl Tool for EllipseTool {
         self.input_enabled = value;
     }
 
+    fn active(&self) -> bool {
+        self.ellipse.is_some()
+    }
+
     fn get_tool_type(&self) -> super::Tools {
         Tools::Ellipse
     }
@@ -182,9 +186,20 @@ impl Tool for EllipseTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.ellipse.is_some() {
-            self.ellipse = None;
-            ToolUpdateResult::Redraw
+        if let Some(ellipse) = &mut self.ellipse {
+            match event.key {
+                Key::Escape => {
+                    self.ellipse = None;
+                    ToolUpdateResult::Redraw
+                }
+                Key::Return if ellipse.radii.is_some() => {
+                    ellipse.finishing = true;
+                    let result = ellipse.clone_box();
+                    self.ellipse = None;
+                    ToolUpdateResult::Commit(result)
+                }
+                _ => ToolUpdateResult::Unmodified,
+            }
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -186,20 +186,9 @@ impl Tool for EllipseTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if let Some(ellipse) = &mut self.ellipse {
-            match event.key {
-                Key::Escape => {
-                    self.ellipse = None;
-                    ToolUpdateResult::Redraw
-                }
-                Key::Return if ellipse.radii.is_some() => {
-                    ellipse.finishing = true;
-                    let result = ellipse.clone_box();
-                    self.ellipse = None;
-                    ToolUpdateResult::Commit(result)
-                }
-                _ => ToolUpdateResult::Unmodified,
-            }
+        if event.key == Key::Escape && self.ellipse.is_some() {
+            self.ellipse = None;
+            ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -164,6 +164,10 @@ impl Tool for HighlightTool {
         self.input_enabled = value;
     }
 
+    fn active(&self) -> bool {
+        self.highlighter.is_some()
+    }
+
     fn get_tool_type(&self) -> super::Tools {
         Tools::Highlight
     }
@@ -296,9 +300,19 @@ impl Tool for HighlightTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.highlighter.is_some() {
-            self.highlighter = None;
-            return ToolUpdateResult::Redraw;
+        if self.highlighter.is_some() {
+            match event.key {
+                Key::Escape => {
+                    self.highlighter = None;
+                    return ToolUpdateResult::Redraw;
+                }
+                Key::Return => {
+                    let result = self.highlighter.as_ref().unwrap().clone_box();
+                    self.highlighter = None;
+                    return ToolUpdateResult::Commit(result);
+                }
+                _ => {}
+            }
         }
         ToolUpdateResult::Unmodified
     }

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -300,19 +300,9 @@ impl Tool for HighlightTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if self.highlighter.is_some() {
-            match event.key {
-                Key::Escape => {
-                    self.highlighter = None;
-                    return ToolUpdateResult::Redraw;
-                }
-                Key::Return => {
-                    let result = self.highlighter.as_ref().unwrap().clone_box();
-                    self.highlighter = None;
-                    return ToolUpdateResult::Commit(result);
-                }
-                _ => {}
-            }
+        if event.key == Key::Escape && self.highlighter.is_some() {
+            self.highlighter = None;
+            return ToolUpdateResult::Redraw;
         }
         ToolUpdateResult::Unmodified
     }

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -63,6 +63,10 @@ impl Tool for LineTool {
         self.input_enabled = value;
     }
 
+    fn active(&self) -> bool {
+        self.line.is_some()
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {
@@ -125,9 +129,19 @@ impl Tool for LineTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.line.is_some() {
-            self.line = None;
-            ToolUpdateResult::Redraw
+        if let Some(line) = &self.line {
+            match event.key {
+                Key::Escape => {
+                    self.line = None;
+                    ToolUpdateResult::Redraw
+                }
+                Key::Return if line.direction.is_some() => {
+                    let result = line.clone_box();
+                    self.line = None;
+                    ToolUpdateResult::Commit(result)
+                }
+                _ => ToolUpdateResult::Unmodified,
+            }
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -129,19 +129,9 @@ impl Tool for LineTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if let Some(line) = &self.line {
-            match event.key {
-                Key::Escape => {
-                    self.line = None;
-                    ToolUpdateResult::Redraw
-                }
-                Key::Return if line.direction.is_some() => {
-                    let result = line.clone_box();
-                    self.line = None;
-                    ToolUpdateResult::Commit(result)
-                }
-                _ => ToolUpdateResult::Unmodified,
-            }
+        if event.key == Key::Escape && self.line.is_some() {
+            self.line = None;
+            ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -117,6 +117,10 @@ impl Tool for RectangleTool {
         self.input_enabled = value;
     }
 
+    fn active(&self) -> bool {
+        self.rectangle.is_some()
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {
@@ -176,9 +180,20 @@ impl Tool for RectangleTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if event.key == Key::Escape && self.rectangle.is_some() {
-            self.rectangle = None;
-            ToolUpdateResult::Redraw
+        if let Some(rectangle) = &mut self.rectangle {
+            match event.key {
+                Key::Escape => {
+                    self.rectangle = None;
+                    ToolUpdateResult::Redraw
+                }
+                Key::Return if rectangle.size.is_some() => {
+                    rectangle.finishing = true;
+                    let result = rectangle.clone_box();
+                    self.rectangle = None;
+                    ToolUpdateResult::Commit(result)
+                }
+                _ => ToolUpdateResult::Unmodified,
+            }
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -180,20 +180,9 @@ impl Tool for RectangleTool {
     }
 
     fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
-        if let Some(rectangle) = &mut self.rectangle {
-            match event.key {
-                Key::Escape => {
-                    self.rectangle = None;
-                    ToolUpdateResult::Redraw
-                }
-                Key::Return if rectangle.size.is_some() => {
-                    rectangle.finishing = true;
-                    let result = rectangle.clone_box();
-                    self.rectangle = None;
-                    ToolUpdateResult::Commit(result)
-                }
-                _ => ToolUpdateResult::Unmodified,
-            }
+        if event.key == Key::Escape && self.rectangle.is_some() {
+            self.rectangle = None;
+            ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
         }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -62,6 +62,7 @@ pub enum ToolsToolbarInput {
     SetVisibility(bool),
     ToggleVisibility,
     SwitchSelectedTool(Tools),
+    SetToolEditing(bool),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -299,8 +300,20 @@ impl SimpleComponent for ToolsToolbar {
                 // Change state of action, let GTK update the UI
                 self.tool_action.change_state(&tool.to_variant());
 
+                if let Some(button) = self.active_button.as_ref() {
+                    button.remove_css_class("editing");
+                }
                 if let Some(selected_tool_button) = self.tool_buttons.get(&tool) {
                     self.active_button = Some(selected_tool_button.clone());
+                }
+            }
+            ToolsToolbarInput::SetToolEditing(editing) => {
+                if let Some(button) = self.active_button.as_ref() {
+                    if editing {
+                        button.add_css_class("editing");
+                    } else {
+                        button.remove_css_class("editing");
+                    }
                 }
             }
         }
@@ -320,6 +333,10 @@ impl SimpleComponent for ToolsToolbar {
                 sender_tmp
                     .output_sender()
                     .emit(ToolbarEvent::ToolSelected(*state));
+                // also change tracked active button
+                sender_tmp
+                    .input_sender()
+                    .emit(ToolsToolbarInput::SwitchSelectedTool(*state))
             },
         );
 


### PR DESCRIPTION
This adds a highlight (using adwaita @accent_color) for the button for a tool that is actively editing. This works for:

     - arrow
     - blur
     - brush
     - crop
     - ellipse
     - highlight
     - line
     - rectangle
     - text (already has everything that's needed)

This is mostly an indicator for tools that have states like crop or text, but can also work for the others while drawing.

editing
<img width="1200" height="692" alt="satty-20260302-185854" src="https://github.com/user-attachments/assets/d08e20e6-c984-4fe4-9a87-959e05d0aa64" />

not editing
<img width="1194" height="694" alt="satty-20260302-185903" src="https://github.com/user-attachments/assets/3ab2de11-beff-4d10-84a8-e7bbb56d826a" />
