### PR TITLE
feat: add pixelate and pseudo-pixelate

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Default single-key shortcuts:
 - <kbd>t</kbd>: Text tool
 - <kbd>m</kbd>: Numbered Marker tool
 - <kbd>u</kbd>: Blur tool
+- <kbd>x</kbd>: Pixelate tool
 - <kbd>g</kbd>: Highlight tool
 
 ### Tool Modifiers and Keys
@@ -79,6 +80,7 @@ Default single-key shortcuts:
 - Highlight: Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below), hold <kbd>Shift</kbd> for a square (if the default mode is block) or a straight line (if the default mode is freehand)
 - Line: Hold <kbd>Shift</kbd> to make line snap to 15° steps
 - Rectangle: Hold <kbd>Alt</kbd> to center the rectangle around origin, hold <kbd>Shift</kbd> for a square
+- Pixelate: Hold <kbd>Alt</kbd> to use pixelation that takes data from outside the selection as a source. <sup>NEXTRELEASE</sup>
 - Text:
   - Press <kbd>Shift+Enter</kbd> to insert line break.
   - Combine <kbd>Ctrl</kbd> with <kbd>Left</kbd> or <kbd>Right</kbd> for word jump or <kbd>Ctrl</kbd> with <kbd>Backspace</kbd> or <kbd>Delete</kbd> for word delete.
@@ -120,7 +122,7 @@ early-exit = true
 early-exit-save-as = true
 # Draw corners of rectangles round if the value is greater than 0 (0 disables rounded corners)
 corner-roundness = 12
-# Select the tool on startup [possible values: pointer, crop, line, arrow, rectangle, text, marker, blur, brush]
+# Select the tool on startup [possible values: pointer, crop, line, arrow, rectangle, text, marker, blur, pixelate, brush]
 initial-tool = "brush"
 # Configure the command to be called on copy, for example `wl-copy`
 copy-command = "wl-copy"
@@ -189,6 +191,8 @@ ellipse = "e"
 text = "t"
 marker = "m"
 blur = "u"
+# NEXTRELEASE
+pixelate = "x"
 highlight = "g"
 
 # Font to use for text annotations
@@ -266,7 +270,7 @@ Options:
       --corner-roundness <CORNER_ROUNDNESS>
           Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
-          Select the tool on startup [aliases: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
+          Select the tool on startup [aliases: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, pixelate, highlight, brush]
       --copy-command <COPY_COMMAND>
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
@@ -444,3 +448,8 @@ Made with [contrib.rocks](https://contrib.rocks).
 The source code is released under the MPL-2.0 license.
 
 The Font 'Roboto Regular' from Google is released under Apache-2.0 license.
+
+## Credits
+
+- Pixelate "independent mode" was inspired by https://github.com/flameshot-org/flameshot/pull/3765/changes
+

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Highlight:
 - Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below).
 - Hold <kbd>Shift</kbd> in freehand mode for a straight 15° aligned line. Stop at some position and release and hold <kbd>Shift</kbd> again to achieve perfectly aligned turns.
 
+Additional note on fringe inpaint, pixelate and fringe inpaint + pixelate <sup>NEXTRELEASE</sup>:
+
+Due to having to consider a blocksize, there's a remainder in almost all situations. We determine a vertical and horizontal anchor based on the origin, the remainder is located on the opposite sides. To change the location of the remainder, draw the rectangle in a different direction. This does not apply to center based rectangles drawn with <kbd>Alt</kbd>, in this instance the anchor is always top left.
+
 #### Overwriting Keybindings <sup>NEXTRELEASE</sup>
 
 Shortcuts can be overwritten in the config by 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Default single-key shortcuts:
 - <kbd>t</kbd>: Text tool
 - <kbd>m</kbd>: Numbered Marker tool
 - <kbd>u</kbd>: Blur tool
+- <kbd>x</kbd>: Pixelate tool
 - <kbd>g</kbd>: Highlight tool
 
 ### Tool Modifiers and Keys
@@ -135,6 +136,9 @@ Marker:
 Highlight: 
 - Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below).
 - Hold <kbd>Shift</kbd> in freehand mode for a straight 15° aligned line. Stop at some position and release and hold <kbd>Shift</kbd> again to achieve perfectly aligned turns.
+
+Pixelate:
+- Hold <kbd>Alt</kbd> to use pixelation that takes data from outside the selection as a source. <sup>NEXTRELEASE</sup>
 
 #### Overwriting Keybindings <sup>NEXTRELEASE</sup>
 
@@ -381,7 +385,7 @@ Options:
       --corner-roundness <CORNER_ROUNDNESS>
           Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
-          Select the tool on startup [alias: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
+          Select the tool on startup [alias: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, pixelate, highlight, brush]
       --copy-command <COPY_COMMAND>
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
@@ -561,3 +565,8 @@ Made with [contrib.rocks](https://contrib.rocks).
 The source code is released under the MPL-2.0 license.
 
 The Font 'Roboto Regular' from Google is released under Apache-2.0 license.
+
+## Credits
+
+- Pixelate "independent mode" was inspired by https://github.com/flameshot-org/flameshot/pull/3765/changes
+

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Default single-key shortcuts:
 - <kbd>t</kbd>: Text tool
 - <kbd>m</kbd>: Numbered Marker tool
 - <kbd>u</kbd>: Blur tool
+- <kbd>x</kbd>: Pixelate tool
 - <kbd>g</kbd>: Highlight tool
 
 ### Pointer Tool <sup>NEXTRELEASE</sup>
@@ -146,6 +147,9 @@ Marker:
 Highlight: 
 - Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below).
 - Hold <kbd>Shift</kbd> in freehand mode for a straight 15° aligned line. Stop at some position and release and hold <kbd>Shift</kbd> again to achieve perfectly aligned turns.
+
+Pixelate:
+- Hold <kbd>Alt</kbd> to use pixelation that takes data from outside the selection as a source. <sup>NEXTRELEASE</sup>
 
 #### Overwriting Keybindings <sup>NEXTRELEASE</sup>
 
@@ -394,7 +398,7 @@ Options:
       --corner-roundness <CORNER_ROUNDNESS>
           Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
-          Select the tool on startup [alias: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
+          Select the tool on startup [alias: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, pixelate, highlight, brush]
       --copy-command <COPY_COMMAND>
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
@@ -574,3 +578,8 @@ Made with [contrib.rocks](https://contrib.rocks).
 The source code is released under the MPL-2.0 license.
 
 The Font 'Roboto Regular' from Google is released under Apache-2.0 license.
+
+## Credits
+
+- Pixelate "independent mode" was inspired by https://github.com/flameshot-org/flameshot/pull/3765/changes
+

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Newly created annotations can be autoselected if enabled in the config.
 Arrow and line:
 - <kbd>Shift</kbd> to make tool snap to 15° steps.
 
-Rectangle, ellipse, blur <sup>0.22.0</sup> and highlight block mode<sup>0.22.0</sup>: 
+Rectangle, ellipse, blur <sup>0.22.0</sup>, highlight block mode<sup>0.22.0</sup>, pixelate<sup>NEXTRELASE</sup>, fringe-pixelate<sup>NEXTRELEASE</sup>, fringe<sup>NEXTRELEASE</sup>: 
 - <kbd>Alt</kbd> to center the tool around origin.
 - <kbd>Shift</kbd> to make width and high uniform - results in square resp. circle.
 - Hold both to combine them.
@@ -147,9 +147,6 @@ Marker:
 Highlight: 
 - Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below).
 - Hold <kbd>Shift</kbd> in freehand mode for a straight 15° aligned line. Stop at some position and release and hold <kbd>Shift</kbd> again to achieve perfectly aligned turns.
-
-Pixelate:
-- Hold <kbd>Alt</kbd> to use pixelation that takes data from outside the selection as a source. <sup>NEXTRELEASE</sup>
 
 #### Overwriting Keybindings <sup>NEXTRELEASE</sup>
 
@@ -398,7 +395,7 @@ Options:
       --corner-roundness <CORNER_ROUNDNESS>
           Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
-          Select the tool on startup [alias: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, pixelate, highlight, brush]
+          Select the tool on startup [alias: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, pixelate, fringe-pixelate, fringe, highlight, brush]
       --copy-command <COPY_COMMAND>
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
@@ -581,5 +578,5 @@ The Font 'Roboto Regular' from Google is released under Apache-2.0 license.
 
 ## Credits
 
-- Pixelate "independent mode" was inspired by https://github.com/flameshot-org/flameshot/pull/3765/changes
+- Fringe-Pixelate was inspired by https://github.com/flameshot-org/flameshot/pull/3765/changes
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Default single-key shortcuts:
 - <kbd>t</kbd>: Text tool
 - <kbd>m</kbd>: Numbered Marker tool
 - <kbd>u</kbd>: Blur tool
-- <kbd>x</kbd>: Pixelate tool
+- <kbd>x</kbd>: Fringe inpaint+Pixelate tool
 - <kbd>g</kbd>: Highlight tool
 
 ### Pointer Tool <sup>NEXTRELEASE</sup>

--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,7 @@ fn main() -> Result<(), io::Error> {
             "paint-bucket-regular",
             "page-fit-regular",
             "resize-large-regular",
+            "tetris-app-regular",
         ],
     );
 

--- a/build.rs
+++ b/build.rs
@@ -78,6 +78,7 @@ fn main() -> Result<(), io::Error> {
             "resize-large-regular",
             "arrow-counterclockwise-regular",
             "caret-down-right-filled",
+            "tetris-app-regular",
         ],
     );
 

--- a/build.rs
+++ b/build.rs
@@ -78,7 +78,8 @@ fn main() -> Result<(), io::Error> {
             "resize-large-regular",
             "arrow-counterclockwise-regular",
             "caret-down-right-filled",
-            "tetris-app-regular",
+            "eye-off-regular",
+            "checkerboard"
         ],
     );
 

--- a/build.rs
+++ b/build.rs
@@ -80,6 +80,7 @@ fn main() -> Result<(), io::Error> {
             "caret-down-right-filled",
             "eye-off-regular",
             "checkerboard",
+            "tetris-app-regular",
         ],
     );
 

--- a/build.rs
+++ b/build.rs
@@ -80,6 +80,7 @@ fn main() -> Result<(), io::Error> {
             "dismiss-regular",
             "checkmark-regular",
             "caret-down-right-filled",
+            "tetris-app-regular",
         ],
     );
 

--- a/build.rs
+++ b/build.rs
@@ -79,7 +79,7 @@ fn main() -> Result<(), io::Error> {
             "arrow-counterclockwise-regular",
             "caret-down-right-filled",
             "eye-off-regular",
-            "checkerboard"
+            "checkerboard",
         ],
     );
 

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -221,6 +221,7 @@ pub enum Tools {
     Text,
     Marker,
     Blur,
+    Pixelate,
     Highlight,
     Brush,
 }
@@ -254,6 +255,7 @@ impl std::fmt::Display for Tools {
             Text => "text",
             Marker => "marker",
             Blur => "blur",
+            Pixelate => "pixelate",
             Highlight => "highlight",
             Brush => "brush",
         };

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -247,6 +247,7 @@ pub enum Tools {
     Text,
     Marker,
     Blur,
+    Pixelate,
     Highlight,
     Brush,
 }
@@ -280,6 +281,7 @@ impl std::fmt::Display for Tools {
             Text => "text",
             Marker => "marker",
             Blur => "blur",
+            Pixelate => "pixelate",
             Highlight => "highlight",
             Brush => "brush",
         };

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -248,6 +248,7 @@ pub enum Tools {
     Marker,
     Blur,
     Pixelate,
+    PseudoPixelate,
     Highlight,
     Brush,
 }
@@ -282,6 +283,7 @@ impl std::fmt::Display for Tools {
             Marker => "marker",
             Blur => "blur",
             Pixelate => "pixelate",
+            PseudoPixelate => "pseudo-pixelate",
             Highlight => "highlight",
             Brush => "brush",
         };

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -248,7 +248,8 @@ pub enum Tools {
     Marker,
     Blur,
     Pixelate,
-    PseudoPixelate,
+    FringePixelate,
+    Fringe,
     Highlight,
     Brush,
 }
@@ -283,7 +284,8 @@ impl std::fmt::Display for Tools {
             Marker => "marker",
             Blur => "blur",
             Pixelate => "pixelate",
-            PseudoPixelate => "pseudo-pixelate",
+            FringePixelate => "fringe-pixelate",
+            Fringe => "fringe",
             Highlight => "highlight",
             Brush => "brush",
         };

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -124,6 +124,7 @@ impl Keybinds {
         self.update_keybind(file_keybinds.text, Tools::Text);
         self.update_keybind(file_keybinds.marker, Tools::Marker);
         self.update_keybind(file_keybinds.blur, Tools::Blur);
+        self.update_keybind(file_keybinds.pixelate, Tools::Pixelate);
         self.update_keybind(file_keybinds.highlight, Tools::Highlight);
     }
 }
@@ -141,6 +142,7 @@ impl Default for Keybinds {
         shortcuts.insert('t', Tools::Text);
         shortcuts.insert('m', Tools::Marker);
         shortcuts.insert('u', Tools::Blur);
+        shortcuts.insert('x', Tools::Pixelate);
         shortcuts.insert('g', Tools::Highlight);
 
         Self { shortcuts }
@@ -735,6 +737,7 @@ struct KeybindsFile {
     text: Option<String>,
     marker: Option<String>,
     blur: Option<String>,
+    pixelate: Option<String>,
     highlight: Option<String>,
 }
 

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -44,6 +44,7 @@ pub struct FemtoVGArea {
 }
 
 pub struct FemtoVgAreaMut {
+    source_image: Option<Rc<ImgVec<RGBA8>>>,
     background_image: Pixbuf,
     background_image_id: Option<femtovg::ImageId>,
     transparent_background_id: Option<femtovg::ImageId>,
@@ -181,6 +182,7 @@ impl FemtoVGArea {
     ) {
         let initial_scale = APP_CONFIG.read().input_scale().unwrap_or(0.0);
         self.inner().replace(FemtoVgAreaMut {
+            source_image: None,
             background_image,
             background_image_id: None,
             transparent_background_id: None,
@@ -366,6 +368,36 @@ impl FemtoVgAreaMut {
             .push(HistoryEntry::Drawable(drawable.clone_box()));
         self.drawables.push(drawable);
         self.redo_stack.clear();
+    }
+
+    fn ensure_source_image(&mut self) -> Rc<ImgVec<RGBA8>> {
+        if self.source_image.is_none() {
+            self.source_image = Some(Rc::new(Self::pixbuf_to_imgvec(&self.background_image)));
+        }
+        self.source_image.clone().unwrap()
+    }
+
+    fn pixbuf_to_imgvec(pixbuf: &Pixbuf) -> ImgVec<RGBA8> {
+        let width = pixbuf.width() as usize;
+        let height = pixbuf.height() as usize;
+        let stride = pixbuf.rowstride() as usize;
+        let has_alpha = pixbuf.has_alpha();
+
+        let mut buf = Vec::<RGBA8>::with_capacity(width * height);
+        let src = unsafe { pixbuf.pixels() };
+        for row in 0..height {
+            let base = row * stride;
+            for col in 0..width {
+                let p = base + col * if has_alpha { 4 } else { 3 };
+                buf.push(RGBA8::new(
+                    src[p],
+                    src[p + 1],
+                    src[p + 2],
+                    if has_alpha { src[p + 3] } else { 255 },
+                ));
+            }
+        }
+        ImgVec::new(buf, width, height)
     }
 
     pub fn last_drawable_index(&self) -> Option<usize> {
@@ -598,6 +630,8 @@ impl FemtoVgAreaMut {
         outside_bg_color: femtovg::Color,
         onscreen: bool,
     ) -> Result<()> {
+        let source_image = self.ensure_source_image();
+
         // clear canvas
         canvas.clear_rect(0, 0, canvas.width(), canvas.height(), outside_bg_color);
 
@@ -621,7 +655,7 @@ impl FemtoVgAreaMut {
             if self.hidden_drawable_index != Some(i)
                 && d.get_rendering_mode() == RenderingMode::Blur
             {
-                d.draw(canvas, font, bounds)?;
+                d.draw_baselayer(canvas, &source_image, font, bounds)?;
             }
         }
 
@@ -630,7 +664,7 @@ impl FemtoVgAreaMut {
             && let Some(preview) = self.active_tool.borrow().get_drawable()
             && preview.get_rendering_mode() == RenderingMode::Blur
         {
-            preview.draw(canvas, font, bounds)?;
+            preview.draw_baselayer(canvas, &source_image, font, bounds)?;
             draw_active_tool = false;
         }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -278,7 +278,7 @@ impl ShortcutRegistry {
         registry.add_key_binding("m", SC::SelectTool(Tools::Marker));
         registry.add_key_binding("u", SC::SelectTool(Tools::Blur));
         registry.add_key_binding("g", SC::SelectTool(Tools::Highlight));
-        registry.add_key_binding("x", SC::SelectTool(Tools::PseudoPixelate));
+        registry.add_key_binding("x", SC::SelectTool(Tools::FringePixelate));
         registry.add_key_binding("<Control>c", SC::RunAction(A::SaveToClipboard));
         registry.add_key_binding("<Control><Alt>c", SC::RunAction(A::CopyFilepathToClipboard));
         registry.add_key_binding("<Control>s", SC::RunAction(A::SaveToFile));

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -278,6 +278,7 @@ impl ShortcutRegistry {
         registry.add_key_binding("m", SC::SelectTool(Tools::Marker));
         registry.add_key_binding("u", SC::SelectTool(Tools::Blur));
         registry.add_key_binding("g", SC::SelectTool(Tools::Highlight));
+        registry.add_key_binding("x", SC::SelectTool(Tools::PseudoPixelate));
         registry.add_key_binding("<Control>c", SC::RunAction(A::SaveToClipboard));
         registry.add_key_binding("<Control><Alt>c", SC::RunAction(A::CopyFilepathToClipboard));
         registry.add_key_binding("<Control>s", SC::RunAction(A::SaveToFile));

--- a/src/style.rs
+++ b/src/style.rs
@@ -281,4 +281,12 @@ impl Size {
             Size::Large => 45.0 * size_factor,
         }
     }
+
+    pub fn to_blocksize(self, size_factor: f32) -> usize {
+        match self {
+            Size::Small => 4 * (size_factor as usize).max(1),
+            Size::Medium => 8 * (size_factor as usize).max(1),
+            Size::Large => 16 * (size_factor as usize).max(1),
+        }
+    }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -36,6 +36,7 @@ mod ellipse;
 mod highlight;
 mod line;
 mod marker;
+mod pixelate;
 mod pointer;
 mod rectangle;
 mod text;
@@ -167,6 +168,7 @@ pub use crop::CropTool;
 pub use ellipse::EllipseTool;
 pub use highlight::{HighlightTool, Highlighters};
 pub use line::LineTool;
+pub use pixelate::PixelateTool;
 pub use rectangle::RectangleTool;
 pub use text::TextTool;
 
@@ -186,6 +188,7 @@ pub enum Tools {
     Blur = 8,
     Highlight = 9,
     Brush = 10,
+    Pixelate = 11,
 }
 
 impl Tools {
@@ -202,6 +205,7 @@ impl Tools {
             Tools::Marker => "Numbered Marker",
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
+            Tools::Pixelate => "Pixelate",
         }
     }
 }
@@ -221,6 +225,7 @@ impl Display for Tools {
             Self::Blur => write!(f, "blur"),
             Self::Highlight => write!(f, "highlight"),
             Self::Brush => write!(f, "brush"),
+            Self::Pixelate => write!(f, "pixelate"),
         }
     }
 }
@@ -250,6 +255,10 @@ impl ToolsManager {
         );
         tools.insert(Tools::Text, Rc::new(RefCell::new(TextTool::default())));
         tools.insert(Tools::Blur, Rc::new(RefCell::new(BlurTool::default())));
+        tools.insert(
+            Tools::Pixelate,
+            Rc::new(RefCell::new(PixelateTool::default())),
+        );
         tools.insert(
             Tools::Highlight,
             Rc::new(RefCell::new(HighlightTool::default())),
@@ -305,6 +314,7 @@ impl FromVariant for Tools {
             8 => Some(Tools::Blur),
             9 => Some(Tools::Highlight),
             10 => Some(Tools::Brush),
+            11 => Some(Tools::Pixelate),
             _ => None,
         })
     }
@@ -322,6 +332,7 @@ impl From<command_line::Tools> for Tools {
             command_line::Tools::Text => Self::Text,
             command_line::Tools::Marker => Self::Marker,
             command_line::Tools::Blur => Self::Blur,
+            command_line::Tools::Pixelate => Self::Pixelate,
             command_line::Tools::Highlight => Self::Highlight,
             command_line::Tools::Brush => Self::Brush,
         }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -267,8 +267,8 @@ pub use crop::CropTool;
 pub use ellipse::EllipseTool;
 pub use highlight::{HighlightTool, Highlighters};
 pub use line::LineTool;
-pub use pointer::PointerTool;
 pub use pixelate::PixelateTool;
+pub use pointer::PointerTool;
 pub use rectangle::RectangleTool;
 pub use text::{Text, TextTool};
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -40,6 +40,7 @@ mod ellipse;
 mod highlight;
 mod line;
 mod marker;
+mod pixelate;
 mod pointer;
 mod rectangle;
 mod text;
@@ -267,6 +268,7 @@ pub use ellipse::EllipseTool;
 pub use highlight::{HighlightTool, Highlighters};
 pub use line::LineTool;
 pub use pointer::PointerTool;
+pub use pixelate::PixelateTool;
 pub use rectangle::RectangleTool;
 pub use text::{Text, TextTool};
 
@@ -297,6 +299,7 @@ pub enum Tools {
     Blur = 8,
     Highlight = 9,
     Brush = 10,
+    Pixelate = 11,
 }
 
 impl fmt::Display for Tools {
@@ -313,6 +316,7 @@ impl fmt::Display for Tools {
             Tools::Marker => "Marker",
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
+            Tools::Pixelate => "Pixelate",
         };
         write!(f, "{}", name)
     }
@@ -338,6 +342,7 @@ impl FromStr for Tools {
             "blur" => Ok(Self::Blur),
             "highlight" => Ok(Self::Highlight),
             "brush" => Ok(Self::Brush),
+            "pixelate" => Ok(Self::Pixelate),
             _ => Err(ParseCommandError),
         }
     }
@@ -367,6 +372,10 @@ impl ToolsManager {
         let text_tool = Rc::new(RefCell::new(TextTool::default()));
         tools.insert(Tools::Text, text_tool.clone());
         tools.insert(Tools::Blur, Rc::new(RefCell::new(BlurTool::default())));
+        tools.insert(
+            Tools::Pixelate,
+            Rc::new(RefCell::new(PixelateTool::default())),
+        );
         tools.insert(
             Tools::Highlight,
             Rc::new(RefCell::new(HighlightTool::default())),
@@ -435,6 +444,7 @@ impl FromVariant for Tools {
             8 => Some(Tools::Blur),
             9 => Some(Tools::Highlight),
             10 => Some(Tools::Brush),
+            11 => Some(Tools::Pixelate),
             _ => None,
         })
     }
@@ -452,6 +462,7 @@ impl From<command_line::Tools> for Tools {
             command_line::Tools::Text => Self::Text,
             command_line::Tools::Marker => Self::Marker,
             command_line::Tools::Blur => Self::Blur,
+            command_line::Tools::Pixelate => Self::Pixelate,
             command_line::Tools::Highlight => Self::Highlight,
             command_line::Tools::Brush => Self::Brush,
         }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -192,6 +192,11 @@ pub trait Drawable: DrawableClone + Debug + AsAny {
     fn get_rendering_mode(&self) -> RenderingMode {
         RenderingMode::Default
     }
+
+    fn is_renderable(&self) -> bool {
+        true
+    }
+
     fn bounds_only_valid_after_redraw(&self) -> bool {
         false
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -10,6 +10,8 @@ use std::{
 };
 
 use anyhow::Result;
+use femtovg::imgref::ImgVec;
+use femtovg::rgb::RGBA8;
 use femtovg::{Canvas, FontId, renderer::OpenGl};
 use relm4::gtk::gdk_pixbuf::{
     glib::{Variant, VariantTy},
@@ -187,6 +189,16 @@ where
 pub trait Drawable: DrawableClone + Debug + AsAny {
     fn draw(&self, canvas: &mut Canvas<OpenGl>, font: FontId, bounds: (Vec2D, Vec2D))
     -> Result<()>;
+    fn draw_baselayer(
+        &self,
+        canvas: &mut Canvas<OpenGl>,
+        image: &ImgVec<RGBA8>,
+        font: FontId,
+        bounds: (Vec2D, Vec2D),
+    ) -> Result<()> {
+        let _ = image;
+        self.draw(canvas, font, bounds)
+    }
     fn handle_undo(&mut self) {}
     fn handle_redo(&mut self) {}
     fn get_rendering_mode(&self) -> RenderingMode {
@@ -324,8 +336,8 @@ impl fmt::Display for Tools {
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
             Tools::Pixelate => "Pixelate",
-            Tools::FringePixelate => "Fringe-Pixelate",
-            Tools::Fringe => "Fringe",
+            Tools::FringePixelate => "Fringe inpaint+Pixelate",
+            Tools::Fringe => "Fringe inpaint",
         };
         write!(f, "{}", name)
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -33,6 +33,7 @@ mod ellipse;
 mod highlight;
 mod line;
 mod marker;
+mod pixelate;
 mod pointer;
 mod rectangle;
 mod text;
@@ -177,6 +178,7 @@ pub use crop::CropTool;
 pub use ellipse::EllipseTool;
 pub use highlight::{HighlightTool, Highlighters};
 pub use line::LineTool;
+pub use pixelate::PixelateTool;
 pub use rectangle::RectangleTool;
 pub use text::TextTool;
 
@@ -196,6 +198,7 @@ pub enum Tools {
     Blur = 8,
     Highlight = 9,
     Brush = 10,
+    Pixelate = 11,
 }
 
 impl fmt::Display for Tools {
@@ -212,6 +215,7 @@ impl fmt::Display for Tools {
             Tools::Marker => "Marker",
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
+            Tools::Pixelate => "Pixelate",
         };
         write!(f, "{}", name)
     }
@@ -237,6 +241,7 @@ impl FromStr for Tools {
             "blur" => Ok(Self::Blur),
             "highlight" => Ok(Self::Highlight),
             "brush" => Ok(Self::Brush),
+            "pixelate" => Ok(Self::Pixelate),
             _ => Err(ParseCommandError),
         }
     }
@@ -268,6 +273,10 @@ impl ToolsManager {
         );
         tools.insert(Tools::Text, Rc::new(RefCell::new(TextTool::default())));
         tools.insert(Tools::Blur, Rc::new(RefCell::new(BlurTool::default())));
+        tools.insert(
+            Tools::Pixelate,
+            Rc::new(RefCell::new(PixelateTool::default())),
+        );
         tools.insert(
             Tools::Highlight,
             Rc::new(RefCell::new(HighlightTool::default())),
@@ -333,6 +342,7 @@ impl FromVariant for Tools {
             8 => Some(Tools::Blur),
             9 => Some(Tools::Highlight),
             10 => Some(Tools::Brush),
+            11 => Some(Tools::Pixelate),
             _ => None,
         })
     }
@@ -350,6 +360,7 @@ impl From<command_line::Tools> for Tools {
             command_line::Tools::Text => Self::Text,
             command_line::Tools::Marker => Self::Marker,
             command_line::Tools::Blur => Self::Blur,
+            command_line::Tools::Pixelate => Self::Pixelate,
             command_line::Tools::Highlight => Self::Highlight,
             command_line::Tools::Brush => Self::Brush,
         }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -300,6 +300,7 @@ pub enum Tools {
     Highlight = 9,
     Brush = 10,
     Pixelate = 11,
+    PseudoPixelate = 12,
 }
 
 impl fmt::Display for Tools {
@@ -317,6 +318,7 @@ impl fmt::Display for Tools {
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
             Tools::Pixelate => "Pixelate",
+            Tools::PseudoPixelate => "Pseudo-Pixelate",
         };
         write!(f, "{}", name)
     }
@@ -343,6 +345,7 @@ impl FromStr for Tools {
             "highlight" => Ok(Self::Highlight),
             "brush" => Ok(Self::Brush),
             "pixelate" => Ok(Self::Pixelate),
+            "pseudo-pixelate" => Ok(Self::PseudoPixelate),
             _ => Err(ParseCommandError),
         }
     }
@@ -375,6 +378,10 @@ impl ToolsManager {
         tools.insert(
             Tools::Pixelate,
             Rc::new(RefCell::new(PixelateTool::default())),
+        );
+        tools.insert(
+            Tools::PseudoPixelate,
+            Rc::new(RefCell::new(PixelateTool::new_pseudo())),
         );
         tools.insert(
             Tools::Highlight,
@@ -445,6 +452,7 @@ impl FromVariant for Tools {
             9 => Some(Tools::Highlight),
             10 => Some(Tools::Brush),
             11 => Some(Tools::Pixelate),
+            12 => Some(Tools::PseudoPixelate),
             _ => None,
         })
     }
@@ -463,6 +471,7 @@ impl From<command_line::Tools> for Tools {
             command_line::Tools::Marker => Self::Marker,
             command_line::Tools::Blur => Self::Blur,
             command_line::Tools::Pixelate => Self::Pixelate,
+            command_line::Tools::PseudoPixelate => Self::PseudoPixelate,
             command_line::Tools::Highlight => Self::Highlight,
             command_line::Tools::Brush => Self::Brush,
         }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -261,6 +261,8 @@ pub enum ToolUpdateResult {
     RedrawAndStopPropagation,
 }
 
+use self::{brush::BrushTool, marker::MarkerTool};
+use crate::tools::pixelate::PixelateMode;
 pub use arrow::ArrowTool;
 pub use blur::BlurTool;
 pub use crop::CropTool;
@@ -271,8 +273,6 @@ pub use pixelate::PixelateTool;
 pub use pointer::PointerTool;
 pub use rectangle::RectangleTool;
 pub use text::{Text, TextTool};
-
-use self::{brush::BrushTool, marker::MarkerTool};
 
 thread_local! {
     static CROP_TOOL_SINGLETON: OnceCell<Rc<RefCell<CropTool>>> = const { OnceCell::new() };
@@ -300,7 +300,8 @@ pub enum Tools {
     Highlight = 9,
     Brush = 10,
     Pixelate = 11,
-    PseudoPixelate = 12,
+    FringePixelate = 12,
+    Fringe = 13,
 }
 
 impl fmt::Display for Tools {
@@ -318,7 +319,8 @@ impl fmt::Display for Tools {
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
             Tools::Pixelate => "Pixelate",
-            Tools::PseudoPixelate => "Pseudo-Pixelate",
+            Tools::FringePixelate => "Fringe-Pixelate",
+            Tools::Fringe => "Fringe",
         };
         write!(f, "{}", name)
     }
@@ -345,7 +347,8 @@ impl FromStr for Tools {
             "highlight" => Ok(Self::Highlight),
             "brush" => Ok(Self::Brush),
             "pixelate" => Ok(Self::Pixelate),
-            "pseudo-pixelate" => Ok(Self::PseudoPixelate),
+            "fringe-pixelate" => Ok(Self::FringePixelate),
+            "fringe" => Ok(Self::Fringe),
             _ => Err(ParseCommandError),
         }
     }
@@ -377,11 +380,19 @@ impl ToolsManager {
         tools.insert(Tools::Blur, Rc::new(RefCell::new(BlurTool::default())));
         tools.insert(
             Tools::Pixelate,
-            Rc::new(RefCell::new(PixelateTool::default())),
+            Rc::new(RefCell::new(PixelateTool::with_mode(
+                PixelateMode::Pixelate,
+            ))),
         );
         tools.insert(
-            Tools::PseudoPixelate,
-            Rc::new(RefCell::new(PixelateTool::new_pseudo())),
+            Tools::FringePixelate,
+            Rc::new(RefCell::new(PixelateTool::with_mode(
+                PixelateMode::FringePixelate,
+            ))),
+        );
+        tools.insert(
+            Tools::Fringe,
+            Rc::new(RefCell::new(PixelateTool::with_mode(PixelateMode::Fringe))),
         );
         tools.insert(
             Tools::Highlight,
@@ -452,7 +463,8 @@ impl FromVariant for Tools {
             9 => Some(Tools::Highlight),
             10 => Some(Tools::Brush),
             11 => Some(Tools::Pixelate),
-            12 => Some(Tools::PseudoPixelate),
+            12 => Some(Tools::FringePixelate),
+            13 => Some(Tools::Fringe),
             _ => None,
         })
     }
@@ -471,7 +483,8 @@ impl From<command_line::Tools> for Tools {
             command_line::Tools::Marker => Self::Marker,
             command_line::Tools::Blur => Self::Blur,
             command_line::Tools::Pixelate => Self::Pixelate,
-            command_line::Tools::PseudoPixelate => Self::PseudoPixelate,
+            command_line::Tools::FringePixelate => Self::FringePixelate,
+            command_line::Tools::Fringe => Self::Fringe,
             command_line::Tools::Highlight => Self::Highlight,
             command_line::Tools::Brush => Self::Brush,
         }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -199,6 +199,7 @@ pub enum Tools {
     Highlight = 9,
     Brush = 10,
     Pixelate = 11,
+    PseudoPixelate = 12,
 }
 
 impl fmt::Display for Tools {
@@ -216,6 +217,7 @@ impl fmt::Display for Tools {
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
             Tools::Pixelate => "Pixelate",
+            Tools::PseudoPixelate => "Pseudo-Pixelate",
         };
         write!(f, "{}", name)
     }
@@ -242,6 +244,7 @@ impl FromStr for Tools {
             "highlight" => Ok(Self::Highlight),
             "brush" => Ok(Self::Brush),
             "pixelate" => Ok(Self::Pixelate),
+            "pseudo-pixelate" => Ok(Self::PseudoPixelate),
             _ => Err(ParseCommandError),
         }
     }
@@ -276,6 +279,10 @@ impl ToolsManager {
         tools.insert(
             Tools::Pixelate,
             Rc::new(RefCell::new(PixelateTool::default())),
+        );
+        tools.insert(
+            Tools::PseudoPixelate,
+            Rc::new(RefCell::new(PixelateTool::new_pseudo())),
         );
         tools.insert(
             Tools::Highlight,
@@ -343,6 +350,7 @@ impl FromVariant for Tools {
             9 => Some(Tools::Highlight),
             10 => Some(Tools::Brush),
             11 => Some(Tools::Pixelate),
+            12 => Some(Tools::PseudoPixelate),
             _ => None,
         })
     }
@@ -361,6 +369,7 @@ impl From<command_line::Tools> for Tools {
             command_line::Tools::Marker => Self::Marker,
             command_line::Tools::Blur => Self::Blur,
             command_line::Tools::Pixelate => Self::Pixelate,
+            command_line::Tools::PseudoPixelate => Self::PseudoPixelate,
             command_line::Tools::Highlight => Self::Highlight,
             command_line::Tools::Brush => Self::Brush,
         }

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -1,0 +1,363 @@
+use std::cell::RefCell;
+
+use crate::{
+    math::{self, Vec2D},
+    sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
+    style::Style,
+    tools::Cow,
+};
+use anyhow::Result;
+use femtovg::imgref::Img;
+use femtovg::rgb::RGBA8;
+use femtovg::{Color, ImageFlags, ImageId, Paint, Path, rgb::Rgba};
+use relm4::gtk::gdk::ModifierType;
+use relm4::{Sender, gtk::gdk::Key};
+
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
+
+static BLOCKSIZE: usize = 32;
+
+#[derive(Clone, Debug)]
+pub struct Pixelate {
+    top_left: Vec2D,
+    size: Option<Vec2D>,
+    editing: bool,
+    independent_mode: bool,
+    cached_image: RefCell<Option<ImageId>>,
+}
+
+impl Pixelate {
+    fn pixelate(
+        canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+        pos: Vec2D,
+        size: Vec2D,
+        independent_mode: bool,
+    ) -> Result<Option<ImageId>> {
+        let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
+        let transformed_size = size * canvas.transform().average_scale();
+
+        let pos_x = transformed_pos.0 as usize;
+        let pos_y = transformed_pos.1 as usize;
+        let width = (transformed_size.x as usize / BLOCKSIZE) * BLOCKSIZE;
+        let height = (transformed_size.y as usize / BLOCKSIZE) * BLOCKSIZE;
+
+        if width == 0 || height == 0 {
+            return Ok(None);
+        }
+
+        let img = canvas.screenshot()?;
+        let buf = if independent_mode {
+            Self::pixelate_independent(canvas, pos_x, pos_y, width, height)?
+        } else {
+            let (buf, _, _) = img
+                .sub_image(pos_x, pos_y, width, height)
+                .to_contiguous_buf();
+            Some(buf)
+        };
+
+        if let Some(b) = buf
+            && let Some(dest_img) = Self::pixelate_regular(b, width, height)?
+        {
+            let dst_image_id = canvas.create_image(dest_img.as_ref(), ImageFlags::empty())?;
+            Ok(Some(dst_image_id))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn pixelate_independent(
+        canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+        pos_x: usize,
+        pos_y: usize,
+        width: usize,
+        height: usize,
+    ) -> Result<Option<Cow<'_, [RGBA8]>>> {
+        //TODO: no fringe, no luck!
+        if pos_x < 1
+            || pos_y < 1
+            || canvas.width() as usize <= pos_x + width
+            || canvas.height() as usize <= pos_y + height
+        {
+            return Ok(None);
+        }
+
+        let img = canvas.screenshot()?;
+
+        let (buf_north, _, _) = img
+            .sub_image(pos_x, pos_y - 1, width, 1)
+            .to_contiguous_buf();
+        let (buf_south, _, _) = img
+            .sub_image(pos_x, pos_y + height + 1, width, 1)
+            .to_contiguous_buf();
+        let (buf_west, _, _) = img
+            .sub_image(pos_x - 1, pos_y, 1, height)
+            .to_contiguous_buf();
+        let (buf_east, _, _) = img
+            .sub_image(pos_x + width + 1, pos_y, 1, height)
+            .to_contiguous_buf();
+
+        let mut buf_new = vec![Rgba::new(0, 0, 0, 0); width * height];
+
+        for y in 0..height {
+            for x in 0..width {
+                let pix_north = buf_north[x];
+                let pix_south = buf_south[x];
+                let pix_west = buf_west[y];
+                let pix_east = buf_east[y];
+
+                let weight_n: f32 = (height - y) as f32 / (height as f32);
+                let weight_s: f32 = y as f32 / (height as f32);
+                let weight_w: f32 = (width - x) as f32 / (width as f32);
+                let weight_e: f32 = x as f32 / (width as f32);
+
+                let new_pixel = RGBA8 {
+                    r: (pix_north.r as f32 * weight_n
+                        + pix_south.r as f32 * weight_s
+                        + pix_west.r as f32 * weight_w
+                        + pix_east.r as f32 * weight_e) as u8,
+                    g: (pix_north.g as f32 * weight_n
+                        + pix_south.g as f32 * weight_s
+                        + pix_west.g as f32 * weight_w
+                        + pix_east.g as f32 * weight_e) as u8,
+                    b: (pix_north.b as f32 * weight_n
+                        + pix_south.b as f32 * weight_s
+                        + pix_west.b as f32 * weight_w
+                        + pix_east.b as f32 * weight_e) as u8,
+                    a: 255,
+                };
+
+                buf_new[y * width + x] = new_pixel;
+            }
+        }
+
+        Ok(Some(buf_new.into()))
+    }
+
+    fn pixelate_regular(
+        input_buf: Cow<[RGBA8]>,
+        width: usize,
+        height: usize,
+    ) -> Result<Option<Img<Vec<Rgba<u8>>>>> {
+        let mut buf_new = vec![Rgba::new(0, 0, 0, 0); width * height];
+
+        let blocks_x = width / BLOCKSIZE;
+        let blocks_y = height / BLOCKSIZE;
+
+        for block_y in 0..blocks_y {
+            for block_x in 0..blocks_x {
+                let x0 = block_x * BLOCKSIZE;
+                let y0 = block_y * BLOCKSIZE;
+                let x1 = x0 + BLOCKSIZE;
+                let y1 = y0 + BLOCKSIZE;
+
+                let mut r: u64 = 0;
+                let mut g: u64 = 0;
+                let mut b: u64 = 0;
+                let mut counter = 0;
+                for y in y0..y1 {
+                    for x in x0..x1 {
+                        let pixel = input_buf[x + y * width];
+                        r += pixel.r as u64;
+                        g += pixel.g as u64;
+                        b += pixel.b as u64;
+                        counter += 1;
+                    }
+                }
+                counter = counter.max(1);
+
+                let new_pixel = RGBA8 {
+                    r: (r / counter) as u8,
+                    g: (g / counter) as u8,
+                    b: (b / counter) as u8,
+                    a: 255,
+                };
+
+                for y in y0..y1 {
+                    for x in x0..x1 {
+                        buf_new[y * width + x] = new_pixel;
+                    }
+                }
+            }
+        }
+
+        let dst_image = Img::new(buf_new, width, height);
+        Ok(Some(dst_image))
+    }
+}
+
+impl Drawable for Pixelate {
+    fn draw(
+        &self,
+        canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+        _font: femtovg::FontId,
+        bounds: (Vec2D, Vec2D),
+    ) -> Result<()> {
+        let size = match self.size {
+            Some(s) => s,
+            None => return Ok(()), // early exit if none
+        };
+        let (pos, size) = math::rect_ensure_in_bounds(
+            math::rect_ensure_positive_size(self.top_left, size),
+            bounds,
+        );
+        if self.editing {
+            // set style
+            let mut color = if self.independent_mode {
+                Color::white()
+            } else {
+                Color::black()
+            };
+            color.set_alphaf(0.6);
+            let paint = Paint::color(color);
+
+            // make rect
+            let mut path = Path::new();
+            path.rect(pos.x, pos.y, size.x, size.y);
+
+            // draw
+            canvas.fill_path(&path, &paint);
+        } else {
+            if size.x < BLOCKSIZE as f32 || size.y < BLOCKSIZE as f32 {
+                return Ok(());
+            }
+
+            canvas.save();
+            canvas.flush();
+
+            // create new cached image
+            if self.cached_image.borrow().is_none()
+                && let Some(x) = Self::pixelate(canvas, pos, size, self.independent_mode)?
+            {
+                self.cached_image.borrow_mut().replace(x);
+            }
+
+            if self.cached_image.borrow().is_some() {
+                let mut path = Path::new();
+                path.rect(pos.x, pos.y, size.x, size.y);
+
+                canvas.fill_path(
+                    &path,
+                    &Paint::image(
+                        self.cached_image.borrow().unwrap(), // this unwrap is safe because we placed it above
+                        pos.x,
+                        pos.y,
+                        size.x,
+                        size.y,
+                        0f32,
+                        1f32,
+                    ),
+                );
+                canvas.restore();
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct PixelateTool {
+    pixelate: Option<Pixelate>,
+    input_enabled: bool,
+    sender: Option<Sender<SketchBoardInput>>,
+}
+
+impl Tool for PixelateTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Pixelate
+    }
+
+    fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
+        match event.type_ {
+            MouseEventType::BeginDrag => {
+                if event.button == MouseButton::Middle {
+                    return ToolUpdateResult::Unmodified;
+                }
+
+                // start new
+                self.pixelate = Some(Pixelate {
+                    top_left: event.pos,
+                    size: None,
+                    editing: true,
+                    independent_mode: event.modifier.intersects(ModifierType::ALT_MASK),
+                    cached_image: RefCell::new(None),
+                });
+
+                ToolUpdateResult::Redraw
+            }
+            MouseEventType::EndDrag => {
+                if event.button == MouseButton::Middle {
+                    return ToolUpdateResult::Unmodified;
+                }
+
+                if let Some(a) = &mut self.pixelate {
+                    if event.pos == Vec2D::zero() {
+                        self.pixelate = None;
+
+                        ToolUpdateResult::Redraw
+                    } else {
+                        a.size = Some(event.pos);
+                        a.independent_mode = event.modifier.intersects(ModifierType::ALT_MASK);
+                        a.editing = false;
+
+                        let result = a.clone_box();
+                        self.pixelate = None;
+
+                        ToolUpdateResult::Commit(result)
+                    }
+                } else {
+                    ToolUpdateResult::Unmodified
+                }
+            }
+            MouseEventType::UpdateDrag => {
+                if event.button == MouseButton::Middle {
+                    return ToolUpdateResult::Unmodified;
+                }
+
+                if let Some(a) = &mut self.pixelate {
+                    if event.pos == Vec2D::zero() {
+                        return ToolUpdateResult::Unmodified;
+                    }
+                    a.independent_mode = event.modifier.intersects(ModifierType::ALT_MASK);
+                    a.size = Some(event.pos);
+
+                    ToolUpdateResult::Redraw
+                } else {
+                    ToolUpdateResult::Unmodified
+                }
+            }
+            _ => ToolUpdateResult::Unmodified,
+        }
+    }
+
+    fn handle_key_event(&mut self, event: crate::sketch_board::KeyEventMsg) -> ToolUpdateResult {
+        if event.key == Key::Escape && self.pixelate.is_some() {
+            self.pixelate = None;
+            ToolUpdateResult::Redraw
+        } else {
+            ToolUpdateResult::Unmodified
+        }
+    }
+
+    fn handle_style_event(&mut self, _style: Style) -> ToolUpdateResult {
+        ToolUpdateResult::Unmodified
+    }
+
+    fn get_drawable(&self) -> Option<&dyn Drawable> {
+        match &self.pixelate {
+            Some(d) => Some(d),
+            None => None,
+        }
+    }
+
+    fn set_sender(&mut self, sender: Sender<SketchBoardInput>) {
+        self.sender = Some(sender);
+    }
+}

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -28,10 +28,10 @@ pub struct Pixelate {
 
 impl Pixelate {
     fn pixelate(
+        &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         pos: Vec2D,
         size: Vec2D,
-        independent_mode: bool,
     ) -> Result<Option<ImageId>> {
         let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
         let transformed_size = size * canvas.transform().average_scale();
@@ -46,8 +46,8 @@ impl Pixelate {
         }
 
         let img = canvas.screenshot()?;
-        let buf = if independent_mode {
-            Self::pixelate_independent(canvas, pos_x, pos_y, width, height)?
+        let buf = if self.independent_mode {
+            Self::fill_area_from_fringes(canvas, pos_x, pos_y, width, height)?
         } else {
             let (buf, _, _) = img
                 .sub_image(pos_x, pos_y, width, height)
@@ -65,14 +65,14 @@ impl Pixelate {
         }
     }
 
-    fn pixelate_independent(
+    fn fill_area_from_fringes(
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         pos_x: usize,
         pos_y: usize,
         width: usize,
         height: usize,
     ) -> Result<Option<Cow<'_, [RGBA8]>>> {
-        //TODO: no fringe, no luck!
+        //TODO: missing fringe, no luck!
         if pos_x < 1
             || pos_y < 1
             || canvas.width() as usize <= pos_x + width
@@ -229,7 +229,7 @@ impl Drawable for Pixelate {
 
             // create new cached image
             if self.cached_image.borrow().is_none()
-                && let Some(x) = Self::pixelate(canvas, pos, size, self.independent_mode)?
+                && let Some(x) = self.pixelate(canvas, pos, size)?
             {
                 self.cached_image.borrow_mut().replace(x);
             }

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -111,18 +111,21 @@ impl Pixelate {
                 let weight_e: f32 = x as f32 / (width as f32);
 
                 let new_pixel = RGBA8 {
-                    r: (pix_north.r as f32 * weight_n
+                    r: ((pix_north.r as f32 * weight_n
                         + pix_south.r as f32 * weight_s
                         + pix_west.r as f32 * weight_w
-                        + pix_east.r as f32 * weight_e) as u8,
-                    g: (pix_north.g as f32 * weight_n
+                        + pix_east.r as f32 * weight_e)
+                        / 2.0) as u8,
+                    g: ((pix_north.g as f32 * weight_n
                         + pix_south.g as f32 * weight_s
                         + pix_west.g as f32 * weight_w
-                        + pix_east.g as f32 * weight_e) as u8,
-                    b: (pix_north.b as f32 * weight_n
+                        + pix_east.g as f32 * weight_e)
+                        / 2.0) as u8,
+                    b: ((pix_north.b as f32 * weight_n
                         + pix_south.b as f32 * weight_s
                         + pix_west.b as f32 * weight_w
-                        + pix_east.b as f32 * weight_e) as u8,
+                        + pix_east.b as f32 * weight_e)
+                        / 2.0) as u8,
                     a: 255,
                 };
 

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -1,5 +1,9 @@
 use std::cell::RefCell;
 
+use super::{
+    Drawable, DrawableClone, RenderingMode, Tool, ToolUpdateResult, Tools, hit_test_rectangle,
+};
+use crate::tools::drag_box::{DragBox, draw_center_marker};
 use crate::{
     math::{self, Vec2D},
     sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
@@ -10,21 +14,29 @@ use anyhow::Result;
 use femtovg::imgref::Img;
 use femtovg::rgb::RGBA8;
 use femtovg::{Color, ImageFlags, ImageId, Paint, Path, rgb::Rgba};
+use relm4::adw::gdk::ModifierType;
 use relm4::{Sender, gtk::gdk::Key};
-
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Debug)]
 pub struct Pixelate {
+    origin: Vec2D,
     top_left: Vec2D,
     size: Option<Vec2D>,
     style: Style,
+    centered: bool,
     editing: bool,
     pseudo_mode: bool,
     cached_image: RefCell<Option<ImageId>>,
 }
 
 impl Pixelate {
+    fn calculate_shape(&mut self, pos: Vec2D, modifier: ModifierType) {
+        let drag_box = DragBox::from_origin_delta(self.origin, pos, modifier);
+        self.centered = drag_box.centered;
+        self.top_left = drag_box.top_left;
+        self.size = Some(drag_box.size);
+    }
+
     fn pixelate(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
@@ -194,6 +206,44 @@ impl Pixelate {
 }
 
 impl Drawable for Pixelate {
+    fn get_rendering_mode(&self) -> RenderingMode {
+        RenderingMode::Blur
+    }
+
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let size = self.size?;
+        Some(math::ensure_bounding_box(
+            self.top_left,
+            self.top_left + size,
+        ))
+    }
+
+    fn hit_test(&self, pos: Vec2D, tolerance: f32) -> bool {
+        hit_test_rectangle(pos, self.top_left, self.size, tolerance, true)
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.top_left += delta;
+        // invalidate cached blur image since position changed
+        *self.cached_image.borrow_mut() = None;
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        let (tl, br) = math::ensure_bounding_box(tl, br);
+        self.top_left = tl;
+        self.size = Some(br - tl);
+        *self.cached_image.borrow_mut() = None;
+    }
+
+    fn get_style(&self) -> Option<&Style> {
+        Some(&self.style)
+    }
+
+    fn get_style_mut(&mut self) -> Option<&mut Style> {
+        *self.cached_image.borrow_mut() = None;
+        Some(&mut self.style)
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
@@ -214,6 +264,9 @@ impl Drawable for Pixelate {
         );
         let can_perform = size.x >= blocksize as f32 && size.y >= blocksize as f32;
         if self.editing {
+            if self.centered {
+                draw_center_marker(canvas, self.origin);
+            }
             // set style
             let mut color = if can_perform {
                 Color::white()
@@ -321,8 +374,10 @@ impl Tool for PixelateTool {
 
                 // start new
                 self.pixelate = Some(Pixelate {
+                    origin: event.pos,
                     top_left: event.pos,
                     size: None,
+                    centered: false,
                     editing: true,
                     style: self.style,
                     cached_image: RefCell::new(None),
@@ -342,7 +397,7 @@ impl Tool for PixelateTool {
 
                         ToolUpdateResult::Redraw
                     } else {
-                        a.size = Some(event.pos);
+                        a.calculate_shape(event.pos, event.modifier);
                         a.editing = false;
 
                         let result = a.clone_box();
@@ -363,7 +418,7 @@ impl Tool for PixelateTool {
                     if event.pos == Vec2D::zero() {
                         return ToolUpdateResult::Unmodified;
                     }
-                    a.size = Some(event.pos);
+                    a.calculate_shape(event.pos, event.modifier);
 
                     ToolUpdateResult::Redraw
                 } else {

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -385,4 +385,8 @@ impl Tool for PixelateTool {
     fn set_sender(&mut self, sender: Sender<SketchBoardInput>) {
         self.sender = Some(sender);
     }
+
+    fn active(&self) -> bool {
+        self.pixelate.is_some()
+    }
 }

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -90,13 +90,13 @@ impl Pixelate {
             .sub_image(pos_x, pos_y - 1, width, 1)
             .to_contiguous_buf();
         let (buf_south, _, _) = img
-            .sub_image(pos_x, pos_y + height + 1, width, 1)
+            .sub_image(pos_x, pos_y + height, width, 1)
             .to_contiguous_buf();
         let (buf_west, _, _) = img
             .sub_image(pos_x - 1, pos_y, 1, height)
             .to_contiguous_buf();
         let (buf_east, _, _) = img
-            .sub_image(pos_x + width + 1, pos_y, 1, height)
+            .sub_image(pos_x + width, pos_y, 1, height)
             .to_contiguous_buf();
 
         let mut buf_new = vec![Rgba::new(0, 0, 0, 0); width * height];

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -10,9 +10,10 @@ use crate::{
     tools::Cow,
 };
 use anyhow::Result;
-use femtovg::imgref::Img;
+use femtovg::imgref::{Img, ImgVec};
+use femtovg::renderer::OpenGl;
 use femtovg::rgb::RGBA8;
-use femtovg::{Color, ImageFlags, ImageId, Paint, Path, rgb::Rgba};
+use femtovg::{Canvas, Color, FontId, ImageFlags, ImageId, Paint, Path, rgb::Rgba};
 use relm4::adw::gdk::ModifierType;
 use relm4::gtk::gdk::Cursor;
 use relm4::gtk::prelude::WidgetExt;
@@ -65,33 +66,38 @@ impl Pixelate {
     fn pixelate(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+        image: &ImgVec<RGBA8>,
         pos: Vec2D,
         size: Vec2D,
     ) -> Result<Option<(ImageId, Vec2D, Vec2D)>> {
-        let transform = canvas.transform();
-        let transformed_pos = transform.transform_point(pos.x, pos.y);
-        let average_scale = transform.average_scale();
-        let transformed_size = size * average_scale;
-
         let blocksize = self
             .style
             .size
             .to_blocksize(self.style.annotation_size_factor);
 
-        let pos_x = transformed_pos.0.round() as usize;
-        let pos_y = transformed_pos.1.round() as usize;
-        let width = (transformed_size.x.round() as usize / blocksize) * blocksize;
-        let height = (transformed_size.y.round() as usize / blocksize) * blocksize;
+        let size_x = size.x.round() as usize;
+        let size_y = size.y.round() as usize;
+        let width = (size_x / blocksize) * blocksize;
+        let height = (size_y / blocksize) * blocksize;
 
         if width == 0 || height == 0 {
             return Ok(None);
         }
 
-        let img = canvas.screenshot()?;
+        // consider how the rectangle was dragged, due to tbe blocksize there's always a remainder
+        // use this so we get more control about which side the remainder ends up.
+        let anchor_right = !self.centered && self.origin.x > pos.x + size.x / 2.0;
+        let anchor_bottom = !self.centered && self.origin.y > pos.y + size.y / 2.0;
+        let base_x = pos.x.round() as usize + if anchor_right { size_x - width } else { 0 };
+        let base_y = pos.y.round() as usize + if anchor_bottom { size_y - height } else { 0 };
+
+        let pos_x = base_x.min(image.width().saturating_sub(width));
+        let pos_y = base_y.min(image.height().saturating_sub(height));
+
         let buf = if self.is_fringe() {
-            Self::fill_area_from_fringes(canvas, pos_x, pos_y, width, height)?
+            Self::fill_area_from_fringes(image, pos_x, pos_y, width, height)?
         } else {
-            let (buf, _, _) = img
+            let (buf, _, _) = image
                 .sub_image(pos_x, pos_y, width, height)
                 .to_contiguous_buf();
             Some(Cow::Owned(buf.into_owned()))
@@ -111,40 +117,28 @@ impl Pixelate {
         };
 
         let dst_image_id = canvas.create_image(dest_img.as_ref(), ImageFlags::empty())?;
-        let origin = transform.transform_point(0.0, 0.0);
-        let paint_pos = Vec2D::new(
-            (pos_x as f32 - origin.0) / average_scale,
-            (pos_y as f32 - origin.1) / average_scale,
-        );
-        let paint_size = Vec2D::new(width as f32 / average_scale, height as f32 / average_scale);
+        let paint_pos = Vec2D::new(pos_x as f32, pos_y as f32);
+        let paint_size = Vec2D::new(width as f32, height as f32);
         Ok(Some((dst_image_id, paint_pos, paint_size)))
     }
 
     fn fill_area_from_fringes(
-        canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+        image: &ImgVec<RGBA8>,
         pos_x: usize,
         pos_y: usize,
         width: usize,
         height: usize,
     ) -> Result<Option<Cow<'_, [RGBA8]>>> {
-        let img = canvas.screenshot()?;
-
-        /*eprintln!(
-            "pos_x={pos_x}, pos_y={pos_y}, width={width}, height={height}, img: {:?} {:?}",
-            img.width(),
-            img.height()
-        );*/
-
         let buf_north = if pos_y >= 1 {
-            let (b, _, _) = img
+            let (b, _, _) = image
                 .sub_image(pos_x, pos_y - 1, width, 1)
                 .to_contiguous_buf();
             b
         } else {
             Cow::Owned(vec![RGBA8::new(128, 128, 128, 128); width])
         };
-        let buf_south = if pos_y + height < canvas.height() as usize {
-            let (b, _, _) = img
+        let buf_south = if pos_y + height < image.height() {
+            let (b, _, _) = image
                 .sub_image(pos_x, pos_y + height, width, 1)
                 .to_contiguous_buf();
             b
@@ -152,15 +146,15 @@ impl Pixelate {
             Cow::Owned(vec![RGBA8::new(128, 128, 128, 128); width])
         };
         let buf_west = if pos_x >= 1 {
-            let (b, _, _) = img
+            let (b, _, _) = image
                 .sub_image(pos_x - 1, pos_y, 1, height)
                 .to_contiguous_buf();
             b
         } else {
             Cow::Owned(vec![RGBA8::new(128, 128, 128, 128); height])
         };
-        let buf_east = if pos_x + width <= canvas.width() as usize {
-            let (b, _, _) = img
+        let buf_east = if pos_x + width < image.width() {
+            let (b, _, _) = image
                 .sub_image(pos_x + width, pos_y, 1, height)
                 .to_contiguous_buf();
             b
@@ -306,14 +300,25 @@ impl Drawable for Pixelate {
 
     fn draw(
         &self,
-        canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+        _canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         _font: femtovg::FontId,
+        _bounds: (Vec2D, Vec2D),
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn draw_baselayer(
+        &self,
+        canvas: &mut Canvas<OpenGl>,
+        image: &ImgVec<RGBA8>,
+        _font: FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
         let size = match self.size {
             Some(s) => s,
             None => return Ok(()), // early exit if none
         };
+
         let blocksize = self
             .style
             .size
@@ -322,73 +327,54 @@ impl Drawable for Pixelate {
             math::rect_ensure_positive_size(self.top_left, size),
             bounds,
         );
-        let big_enough = if self.is_pixelate() {
-            size.x >= blocksize as f32 && size.y >= blocksize as f32
-        } else {
-            size.x.abs() > f32::EPSILON && size.y.abs() > f32::EPSILON
-        };
+        let big_enough = size.x >= blocksize as f32 && size.y >= blocksize as f32;
+        self.renderable.set(big_enough);
 
-        let can_perform = big_enough;
-        self.renderable.set(can_perform);
         if self.editing {
             if self.centered {
                 draw_center_marker(canvas, self.origin);
             }
-            // set style
-            let mut color = if can_perform {
-                Color::white()
-            } else {
-                Color::rgb(255, 0, 0)
-            };
-            let border_color = if can_perform {
-                Color::black()
-            } else {
-                Color::rgb(0, 255, 255)
-            };
+            let mut color = Color::white();
+            let border_color = Color::black();
             color.set_alphaf(0.6);
             let paint = Paint::color(color);
             let paint_border = Paint::color(border_color);
 
-            // make rect
             let mut path = Path::new();
             path.rect(pos.x, pos.y, size.x, size.y);
 
-            // draw
             canvas.fill_path(&path, &paint);
             canvas.stroke_path(&path, &paint_border);
-        } else {
-            if !can_perform {
-                return Ok(());
-            }
+            return Ok(());
+        } else if !big_enough {
+            return Ok(());
+        }
 
-            canvas.save();
-            canvas.flush();
+        canvas.save();
+        canvas.flush();
 
-            // create new cached image
-            if self.cached_image.borrow().is_none()
-                && let Some(x) = self.pixelate(canvas, pos, size)?
-            {
-                self.cached_image.borrow_mut().replace(x);
-            }
+        if self.cached_image.borrow().is_none()
+            && let Some(x) = self.pixelate(canvas, image, pos, size)?
+        {
+            self.cached_image.borrow_mut().replace(x);
+        }
 
-            if let Some((image_id, paint_pos, paint_size)) = *self.cached_image.borrow() {
-                let mut path = Path::new();
-                path.rect(paint_pos.x, paint_pos.y, paint_size.x, paint_size.y);
-
-                canvas.fill_path(
-                    &path,
-                    &Paint::image(
-                        image_id,
-                        paint_pos.x,
-                        paint_pos.y,
-                        paint_size.x,
-                        paint_size.y,
-                        0f32,
-                        1f32,
-                    ),
-                );
-                canvas.restore();
-            }
+        if let Some((image_id, paint_pos, paint_size)) = *self.cached_image.borrow() {
+            let mut path = Path::new();
+            path.rect(paint_pos.x, paint_pos.y, paint_size.x, paint_size.y);
+            canvas.fill_path(
+                &path,
+                &Paint::image(
+                    image_id,
+                    paint_pos.x,
+                    paint_pos.y,
+                    paint_size.x,
+                    paint_size.y,
+                    0f32,
+                    1f32,
+                ),
+            );
+            canvas.restore();
         }
         Ok(())
     }

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -1,7 +1,8 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use super::{
-    Drawable, DrawableClone, RenderingMode, Tool, ToolUpdateResult, Tools, hit_test_rectangle,
+    Drawable, DrawableClone, InputContext, RenderingMode, Tool, ToolUpdateResult, Tools,
+    hit_test_rectangle,
 };
 use crate::tools::drag_box::{DragBox, draw_center_marker};
 use crate::{
@@ -15,7 +16,9 @@ use femtovg::imgref::Img;
 use femtovg::rgb::RGBA8;
 use femtovg::{Color, ImageFlags, ImageId, Paint, Path, rgb::Rgba};
 use relm4::adw::gdk::ModifierType;
-use relm4::{Sender, gtk::gdk::Key};
+use relm4::gtk::gdk::Cursor;
+use relm4::gtk::prelude::WidgetExt;
+use relm4::{Sender, gtk, gtk::gdk::Key};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PixelateMode {
@@ -35,9 +38,50 @@ pub struct Pixelate {
     editing: bool,
     mode: PixelateMode,
     cached_image: RefCell<Option<ImageId>>,
+    renderable: Cell<bool>,
 }
 
 impl Pixelate {
+    fn is_pixelate(&self) -> bool {
+        matches!(
+            self.mode,
+            PixelateMode::Pixelate | PixelateMode::FringePixelate
+        )
+    }
+
+    fn is_fringe(&self) -> bool {
+        matches!(
+            self.mode,
+            PixelateMode::Fringe | PixelateMode::FringePixelate
+        )
+    }
+
+    fn fringe_area_in_bounds(
+        &self,
+        canvas: &femtovg::Canvas<femtovg::renderer::OpenGl>,
+        pos: Vec2D,
+        size: Vec2D,
+    ) -> bool {
+        let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
+        let average_scale = canvas.transform().average_scale();
+        let transformed_size = size * average_scale;
+
+        let blocksize = self
+            .style
+            .size
+            .to_blocksize(self.style.annotation_size_factor);
+
+        let pos_x = transformed_pos.0 as usize;
+        let pos_y = transformed_pos.1 as usize;
+        let width = (transformed_size.x as usize / blocksize) * blocksize;
+        let height = (transformed_size.y as usize / blocksize) * blocksize;
+
+        pos_x >= 1
+            && pos_y >= 1
+            && pos_x + width < canvas.width() as usize
+            && pos_y + height < canvas.height() as usize
+    }
+
     fn calculate_shape(&mut self, pos: Vec2D, modifier: ModifierType) {
         let drag_box = DragBox::from_origin_delta(self.origin, pos, modifier);
         self.centered = drag_box.centered;
@@ -70,30 +114,26 @@ impl Pixelate {
         }
 
         let img = canvas.screenshot()?;
-        let buf = match self.mode {
-            PixelateMode::FringePixelate | PixelateMode::Fringe => {
-                Self::fill_area_from_fringes(canvas, pos_x, pos_y, width, height)?
-            }
-            PixelateMode::Pixelate => {
-                let (buf, _, _) = img
-                    .sub_image(pos_x, pos_y, width, height)
-                    .to_contiguous_buf();
-                Some(Cow::Owned(buf.into_owned()))
-            }
+        let buf = if self.is_fringe() {
+            Self::fill_area_from_fringes(canvas, pos_x, pos_y, width, height)?
+        } else {
+            let (buf, _, _) = img
+                .sub_image(pos_x, pos_y, width, height)
+                .to_contiguous_buf();
+            Some(Cow::Owned(buf.into_owned()))
         };
 
         let Some(b) = buf else {
             return Ok(None);
         };
 
-        let dest_img = match self.mode {
-            PixelateMode::Fringe => Img::new(b.into_owned(), width, height),
-            PixelateMode::Pixelate | PixelateMode::FringePixelate => {
-                match Self::pixelate_regular(b, width, height, blocksize)? {
-                    Some(img) => img,
-                    None => return Ok(None),
-                }
+        let dest_img = if self.is_pixelate() {
+            match Self::pixelate_regular(b, width, height, blocksize)? {
+                Some(img) => img,
+                None => return Ok(None),
             }
+        } else {
+            Img::new(b.into_owned(), width, height)
         };
 
         let dst_image_id = canvas.create_image(dest_img.as_ref(), ImageFlags::empty())?;
@@ -107,7 +147,8 @@ impl Pixelate {
         width: usize,
         height: usize,
     ) -> Result<Option<Cow<'_, [RGBA8]>>> {
-        //TODO: missing fringe, no luck!
+        // this shouldn't happen, because we check if draw can be performed before this runs.
+        // since .sub_image panics, leave this in anyway.
         if pos_x < 1
             || pos_y < 1
             || canvas.width() as usize <= pos_x + width
@@ -281,7 +322,15 @@ impl Drawable for Pixelate {
             math::rect_ensure_positive_size(self.top_left, size),
             bounds,
         );
-        let can_perform = size.x >= blocksize as f32 && size.y >= blocksize as f32;
+        let big_enough = if self.is_pixelate() {
+            size.x >= blocksize as f32 && size.y >= blocksize as f32
+        } else {
+            size.x.abs() > f32::EPSILON && size.y.abs() > f32::EPSILON
+        };
+        let fringe_ok = !self.is_fringe() || self.fringe_area_in_bounds(canvas, pos, size);
+
+        let can_perform = big_enough && fringe_ok;
+        self.renderable.set(can_perform);
         if self.editing {
             if self.centered {
                 draw_center_marker(canvas, self.origin);
@@ -353,6 +402,7 @@ pub struct PixelateTool {
     input_enabled: bool,
     sender: Option<Sender<SketchBoardInput>>,
     mode: PixelateMode,
+    cursor_widget: Option<gtk::Widget>,
 }
 
 impl PixelateTool {
@@ -363,6 +413,32 @@ impl PixelateTool {
             input_enabled: false,
             sender: None,
             mode,
+            cursor_widget: None,
+        }
+    }
+
+    fn update_drag_cursor(&self) {
+        let Some(widget) = &self.cursor_widget else {
+            return;
+        };
+
+        let Some(p) = self.pixelate.as_ref() else {
+            return;
+        };
+
+        if p.renderable.get() {
+            widget.set_cursor(None);
+        } else {
+            let cursor = ["not-allowed", "no-drop"]
+                .iter()
+                .find_map(|name| Cursor::from_name(name, None));
+            widget.set_cursor(cursor.as_ref());
+        }
+    }
+
+    fn clear_cursor(&self) {
+        if let Some(widget) = &self.cursor_widget {
+            widget.set_cursor(None);
         }
     }
 }
@@ -401,6 +477,7 @@ impl Tool for PixelateTool {
                     style: self.style,
                     cached_image: RefCell::new(None),
                     mode: self.mode,
+                    renderable: Cell::new(false),
                 });
 
                 ToolUpdateResult::Redraw
@@ -410,6 +487,7 @@ impl Tool for PixelateTool {
                     return ToolUpdateResult::Unmodified;
                 }
 
+                self.clear_cursor();
                 if let Some(a) = &mut self.pixelate {
                     if event.pos == Vec2D::zero() {
                         self.pixelate = None;
@@ -438,6 +516,7 @@ impl Tool for PixelateTool {
                         return ToolUpdateResult::Unmodified;
                     }
                     a.calculate_shape(event.pos, event.modifier);
+                    self.update_drag_cursor();
 
                     ToolUpdateResult::Redraw
                 } else {
@@ -475,5 +554,10 @@ impl Tool for PixelateTool {
 
     fn active(&self) -> bool {
         self.pixelate.is_some()
+    }
+
+    fn set_im_context(&mut self, context: Option<InputContext>) {
+        self.cursor_widget = context.map(|ctx| ctx.widget);
+        self.clear_cursor();
     }
 }

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -266,6 +266,10 @@ impl Pixelate {
 }
 
 impl Drawable for Pixelate {
+    fn is_renderable(&self) -> bool {
+        self.renderable.get()
+    }
+
     fn get_rendering_mode(&self) -> RenderingMode {
         RenderingMode::Blur
     }
@@ -489,12 +493,11 @@ impl Tool for PixelateTool {
 
                 self.clear_cursor();
                 if let Some(a) = &mut self.pixelate {
-                    if event.pos == Vec2D::zero() {
+                    a.calculate_shape(event.pos, event.modifier);
+                    if event.pos == Vec2D::zero() || !a.renderable.get() {
                         self.pixelate = None;
-
                         ToolUpdateResult::Redraw
                     } else {
-                        a.calculate_shape(event.pos, event.modifier);
                         a.editing = false;
 
                         let result = a.clone_box();

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -1,5 +1,3 @@
-use std::cell::{Cell, RefCell};
-
 use super::{
     Drawable, DrawableClone, InputContext, RenderingMode, Tool, ToolUpdateResult, Tools,
     hit_test_rectangle,
@@ -19,6 +17,7 @@ use relm4::adw::gdk::ModifierType;
 use relm4::gtk::gdk::Cursor;
 use relm4::gtk::prelude::WidgetExt;
 use relm4::{Sender, gtk, gtk::gdk::Key};
+use std::cell::{Cell, RefCell};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PixelateMode {
@@ -37,7 +36,7 @@ pub struct Pixelate {
     centered: bool,
     editing: bool,
     mode: PixelateMode,
-    cached_image: RefCell<Option<ImageId>>,
+    cached_image: RefCell<Option<(ImageId, Vec2D, Vec2D)>>,
     renderable: Cell<bool>,
 }
 
@@ -56,32 +55,6 @@ impl Pixelate {
         )
     }
 
-    fn fringe_area_in_bounds(
-        &self,
-        canvas: &femtovg::Canvas<femtovg::renderer::OpenGl>,
-        pos: Vec2D,
-        size: Vec2D,
-    ) -> bool {
-        let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
-        let average_scale = canvas.transform().average_scale();
-        let transformed_size = size * average_scale;
-
-        let blocksize = self
-            .style
-            .size
-            .to_blocksize(self.style.annotation_size_factor);
-
-        let pos_x = transformed_pos.0 as usize;
-        let pos_y = transformed_pos.1 as usize;
-        let width = (transformed_size.x as usize / blocksize) * blocksize;
-        let height = (transformed_size.y as usize / blocksize) * blocksize;
-
-        pos_x >= 1
-            && pos_y >= 1
-            && pos_x + width < canvas.width() as usize
-            && pos_y + height < canvas.height() as usize
-    }
-
     fn calculate_shape(&mut self, pos: Vec2D, modifier: ModifierType) {
         let drag_box = DragBox::from_origin_delta(self.origin, pos, modifier);
         self.centered = drag_box.centered;
@@ -94,9 +67,10 @@ impl Pixelate {
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         pos: Vec2D,
         size: Vec2D,
-    ) -> Result<Option<ImageId>> {
-        let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
-        let average_scale = canvas.transform().average_scale();
+    ) -> Result<Option<(ImageId, Vec2D, Vec2D)>> {
+        let transform = canvas.transform();
+        let transformed_pos = transform.transform_point(pos.x, pos.y);
+        let average_scale = transform.average_scale();
         let transformed_size = size * average_scale;
 
         let blocksize = self
@@ -104,10 +78,10 @@ impl Pixelate {
             .size
             .to_blocksize(self.style.annotation_size_factor);
 
-        let pos_x = transformed_pos.0 as usize;
-        let pos_y = transformed_pos.1 as usize;
-        let width = (transformed_size.x as usize / blocksize) * blocksize;
-        let height = (transformed_size.y as usize / blocksize) * blocksize;
+        let pos_x = transformed_pos.0.round() as usize;
+        let pos_y = transformed_pos.1.round() as usize;
+        let width = (transformed_size.x.round() as usize / blocksize) * blocksize;
+        let height = (transformed_size.y.round() as usize / blocksize) * blocksize;
 
         if width == 0 || height == 0 {
             return Ok(None);
@@ -137,7 +111,13 @@ impl Pixelate {
         };
 
         let dst_image_id = canvas.create_image(dest_img.as_ref(), ImageFlags::empty())?;
-        Ok(Some(dst_image_id))
+        let origin = transform.transform_point(0.0, 0.0);
+        let paint_pos = Vec2D::new(
+            (pos_x as f32 - origin.0) / average_scale,
+            (pos_y as f32 - origin.1) / average_scale,
+        );
+        let paint_size = Vec2D::new(width as f32 / average_scale, height as f32 / average_scale);
+        Ok(Some((dst_image_id, paint_pos, paint_size)))
     }
 
     fn fill_area_from_fringes(
@@ -147,30 +127,46 @@ impl Pixelate {
         width: usize,
         height: usize,
     ) -> Result<Option<Cow<'_, [RGBA8]>>> {
-        // this shouldn't happen, because we check if draw can be performed before this runs.
-        // since .sub_image panics, leave this in anyway.
-        if pos_x < 1
-            || pos_y < 1
-            || canvas.width() as usize <= pos_x + width
-            || canvas.height() as usize <= pos_y + height
-        {
-            return Ok(None);
-        }
-
         let img = canvas.screenshot()?;
 
-        let (buf_north, _, _) = img
-            .sub_image(pos_x, pos_y - 1, width, 1)
-            .to_contiguous_buf();
-        let (buf_south, _, _) = img
-            .sub_image(pos_x, pos_y + height, width, 1)
-            .to_contiguous_buf();
-        let (buf_west, _, _) = img
-            .sub_image(pos_x - 1, pos_y, 1, height)
-            .to_contiguous_buf();
-        let (buf_east, _, _) = img
-            .sub_image(pos_x + width, pos_y, 1, height)
-            .to_contiguous_buf();
+        /*eprintln!(
+            "pos_x={pos_x}, pos_y={pos_y}, width={width}, height={height}, img: {:?} {:?}",
+            img.width(),
+            img.height()
+        );*/
+
+        let buf_north = if pos_y >= 1 {
+            let (b, _, _) = img
+                .sub_image(pos_x, pos_y - 1, width, 1)
+                .to_contiguous_buf();
+            b
+        } else {
+            Cow::Owned(vec![RGBA8::new(128, 128, 128, 128); width])
+        };
+        let buf_south = if pos_y + height < canvas.height() as usize {
+            let (b, _, _) = img
+                .sub_image(pos_x, pos_y + height, width, 1)
+                .to_contiguous_buf();
+            b
+        } else {
+            Cow::Owned(vec![RGBA8::new(128, 128, 128, 128); width])
+        };
+        let buf_west = if pos_x >= 1 {
+            let (b, _, _) = img
+                .sub_image(pos_x - 1, pos_y, 1, height)
+                .to_contiguous_buf();
+            b
+        } else {
+            Cow::Owned(vec![RGBA8::new(128, 128, 128, 128); height])
+        };
+        let buf_east = if pos_x + width <= canvas.width() as usize {
+            let (b, _, _) = img
+                .sub_image(pos_x + width, pos_y, 1, height)
+                .to_contiguous_buf();
+            b
+        } else {
+            Cow::Owned(vec![RGBA8::new(128, 128, 128, 128); height])
+        };
 
         let mut buf_new = vec![Rgba::new(0, 0, 0, 0); width * height];
 
@@ -331,9 +327,8 @@ impl Drawable for Pixelate {
         } else {
             size.x.abs() > f32::EPSILON && size.y.abs() > f32::EPSILON
         };
-        let fringe_ok = !self.is_fringe() || self.fringe_area_in_bounds(canvas, pos, size);
 
-        let can_perform = big_enough && fringe_ok;
+        let can_perform = big_enough;
         self.renderable.set(can_perform);
         if self.editing {
             if self.centered {
@@ -376,18 +371,18 @@ impl Drawable for Pixelate {
                 self.cached_image.borrow_mut().replace(x);
             }
 
-            if self.cached_image.borrow().is_some() {
+            if let Some((image_id, paint_pos, paint_size)) = *self.cached_image.borrow() {
                 let mut path = Path::new();
-                path.rect(pos.x, pos.y, size.x, size.y);
+                path.rect(paint_pos.x, paint_pos.y, paint_size.x, paint_size.y);
 
                 canvas.fill_path(
                     &path,
                     &Paint::image(
-                        self.cached_image.borrow().unwrap(), // this unwrap is safe because we placed it above
-                        pos.x,
-                        pos.y,
-                        size.x,
-                        size.y,
+                        image_id,
+                        paint_pos.x,
+                        paint_pos.y,
+                        paint_size.x,
+                        paint_size.y,
                         0f32,
                         1f32,
                     ),

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -32,7 +32,8 @@ impl Pixelate {
         size: Vec2D,
     ) -> Result<Option<ImageId>> {
         let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
-        let transformed_size = size * canvas.transform().average_scale();
+        let average_scale = canvas.transform().average_scale();
+        let transformed_size = size * average_scale;
 
         let blocksize = self
             .style
@@ -211,11 +212,22 @@ impl Drawable for Pixelate {
             math::rect_ensure_positive_size(self.top_left, size),
             bounds,
         );
+        let can_perform = size.x >= blocksize as f32 && size.y >= blocksize as f32;
         if self.editing {
             // set style
-            let mut color = Color::white();
+            let mut color = if can_perform {
+                Color::white()
+            } else {
+                Color::rgb(255, 0, 0)
+            };
+            let border_color = if can_perform {
+                Color::black()
+            } else {
+                Color::rgb(0, 255, 255)
+            };
             color.set_alphaf(0.6);
             let paint = Paint::color(color);
+            let paint_border = Paint::color(border_color);
 
             // make rect
             let mut path = Path::new();
@@ -223,8 +235,9 @@ impl Drawable for Pixelate {
 
             // draw
             canvas.fill_path(&path, &paint);
+            canvas.stroke_path(&path, &paint_border);
         } else {
-            if size.x < blocksize as f32 || size.y < blocksize as f32 {
+            if !can_perform {
                 return Ok(());
             }
 

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -17,6 +17,14 @@ use femtovg::{Color, ImageFlags, ImageId, Paint, Path, rgb::Rgba};
 use relm4::adw::gdk::ModifierType;
 use relm4::{Sender, gtk::gdk::Key};
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PixelateMode {
+    #[default]
+    Pixelate,
+    FringePixelate,
+    Fringe,
+}
+
 #[derive(Clone, Debug)]
 pub struct Pixelate {
     origin: Vec2D,
@@ -25,7 +33,7 @@ pub struct Pixelate {
     style: Style,
     centered: bool,
     editing: bool,
-    pseudo_mode: bool,
+    mode: PixelateMode,
     cached_image: RefCell<Option<ImageId>>,
 }
 
@@ -62,23 +70,34 @@ impl Pixelate {
         }
 
         let img = canvas.screenshot()?;
-        let buf = if self.pseudo_mode {
-            Self::fill_area_from_fringes(canvas, pos_x, pos_y, width, height)?
-        } else {
-            let (buf, _, _) = img
-                .sub_image(pos_x, pos_y, width, height)
-                .to_contiguous_buf();
-            Some(buf)
+        let buf = match self.mode {
+            PixelateMode::FringePixelate | PixelateMode::Fringe => {
+                Self::fill_area_from_fringes(canvas, pos_x, pos_y, width, height)?
+            }
+            PixelateMode::Pixelate => {
+                let (buf, _, _) = img
+                    .sub_image(pos_x, pos_y, width, height)
+                    .to_contiguous_buf();
+                Some(Cow::Owned(buf.into_owned()))
+            }
         };
 
-        if let Some(b) = buf
-            && let Some(dest_img) = Self::pixelate_regular(b, width, height, blocksize)?
-        {
-            let dst_image_id = canvas.create_image(dest_img.as_ref(), ImageFlags::empty())?;
-            Ok(Some(dst_image_id))
-        } else {
-            Ok(None)
-        }
+        let Some(b) = buf else {
+            return Ok(None);
+        };
+
+        let dest_img = match self.mode {
+            PixelateMode::Fringe => Img::new(b.into_owned(), width, height),
+            PixelateMode::Pixelate | PixelateMode::FringePixelate => {
+                match Self::pixelate_regular(b, width, height, blocksize)? {
+                    Some(img) => img,
+                    None => return Ok(None),
+                }
+            }
+        };
+
+        let dst_image_id = canvas.create_image(dest_img.as_ref(), ImageFlags::empty())?;
+        Ok(Some(dst_image_id))
     }
 
     fn fill_area_from_fringes(
@@ -333,17 +352,17 @@ pub struct PixelateTool {
     style: Style,
     input_enabled: bool,
     sender: Option<Sender<SketchBoardInput>>,
-    pseudo_mode: bool,
+    mode: PixelateMode,
 }
 
 impl PixelateTool {
-    pub fn new_pseudo() -> Self {
+    pub fn with_mode(mode: PixelateMode) -> Self {
         PixelateTool {
             pixelate: None,
             style: Style::default(),
             input_enabled: false,
             sender: None,
-            pseudo_mode: true,
+            mode,
         }
     }
 }
@@ -358,10 +377,10 @@ impl Tool for PixelateTool {
     }
 
     fn get_tool_type(&self) -> super::Tools {
-        if self.pseudo_mode {
-            Tools::PseudoPixelate
-        } else {
-            Tools::Pixelate
+        match self.mode {
+            PixelateMode::Pixelate => Tools::Pixelate,
+            PixelateMode::FringePixelate => Tools::FringePixelate,
+            PixelateMode::Fringe => Tools::Fringe,
         }
     }
 
@@ -381,7 +400,7 @@ impl Tool for PixelateTool {
                     editing: true,
                     style: self.style,
                     cached_image: RefCell::new(None),
-                    pseudo_mode: self.pseudo_mode,
+                    mode: self.mode,
                 });
 
                 ToolUpdateResult::Redraw

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -10,19 +10,17 @@ use anyhow::Result;
 use femtovg::imgref::Img;
 use femtovg::rgb::RGBA8;
 use femtovg::{Color, ImageFlags, ImageId, Paint, Path, rgb::Rgba};
-use relm4::gtk::gdk::ModifierType;
 use relm4::{Sender, gtk::gdk::Key};
 
 use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
-
-static BLOCKSIZE: usize = 32;
 
 #[derive(Clone, Debug)]
 pub struct Pixelate {
     top_left: Vec2D,
     size: Option<Vec2D>,
+    style: Style,
     editing: bool,
-    independent_mode: bool,
+    pseudo_mode: bool,
     cached_image: RefCell<Option<ImageId>>,
 }
 
@@ -36,17 +34,22 @@ impl Pixelate {
         let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
         let transformed_size = size * canvas.transform().average_scale();
 
+        let blocksize = self
+            .style
+            .size
+            .to_blocksize(self.style.annotation_size_factor);
+
         let pos_x = transformed_pos.0 as usize;
         let pos_y = transformed_pos.1 as usize;
-        let width = (transformed_size.x as usize / BLOCKSIZE) * BLOCKSIZE;
-        let height = (transformed_size.y as usize / BLOCKSIZE) * BLOCKSIZE;
+        let width = (transformed_size.x as usize / blocksize) * blocksize;
+        let height = (transformed_size.y as usize / blocksize) * blocksize;
 
         if width == 0 || height == 0 {
             return Ok(None);
         }
 
         let img = canvas.screenshot()?;
-        let buf = if self.independent_mode {
+        let buf = if self.pseudo_mode {
             Self::fill_area_from_fringes(canvas, pos_x, pos_y, width, height)?
         } else {
             let (buf, _, _) = img
@@ -56,7 +59,7 @@ impl Pixelate {
         };
 
         if let Some(b) = buf
-            && let Some(dest_img) = Self::pixelate_regular(b, width, height)?
+            && let Some(dest_img) = Self::pixelate_regular(b, width, height, blocksize)?
         {
             let dst_image_id = canvas.create_image(dest_img.as_ref(), ImageFlags::empty())?;
             Ok(Some(dst_image_id))
@@ -140,18 +143,19 @@ impl Pixelate {
         input_buf: Cow<[RGBA8]>,
         width: usize,
         height: usize,
+        blocksize: usize,
     ) -> Result<Option<Img<Vec<Rgba<u8>>>>> {
         let mut buf_new = vec![Rgba::new(0, 0, 0, 0); width * height];
 
-        let blocks_x = width / BLOCKSIZE;
-        let blocks_y = height / BLOCKSIZE;
+        let blocks_x = width / blocksize;
+        let blocks_y = height / blocksize;
 
         for block_y in 0..blocks_y {
             for block_x in 0..blocks_x {
-                let x0 = block_x * BLOCKSIZE;
-                let y0 = block_y * BLOCKSIZE;
-                let x1 = x0 + BLOCKSIZE;
-                let y1 = y0 + BLOCKSIZE;
+                let x0 = block_x * blocksize;
+                let y0 = block_y * blocksize;
+                let x1 = x0 + blocksize;
+                let y1 = y0 + blocksize;
 
                 let mut r: u64 = 0;
                 let mut g: u64 = 0;
@@ -199,17 +203,17 @@ impl Drawable for Pixelate {
             Some(s) => s,
             None => return Ok(()), // early exit if none
         };
+        let blocksize = self
+            .style
+            .size
+            .to_blocksize(self.style.annotation_size_factor);
         let (pos, size) = math::rect_ensure_in_bounds(
             math::rect_ensure_positive_size(self.top_left, size),
             bounds,
         );
         if self.editing {
             // set style
-            let mut color = if self.independent_mode {
-                Color::white()
-            } else {
-                Color::black()
-            };
+            let mut color = Color::white();
             color.set_alphaf(0.6);
             let paint = Paint::color(color);
 
@@ -220,7 +224,7 @@ impl Drawable for Pixelate {
             // draw
             canvas.fill_path(&path, &paint);
         } else {
-            if size.x < BLOCKSIZE as f32 || size.y < BLOCKSIZE as f32 {
+            if size.x < blocksize as f32 || size.y < blocksize as f32 {
                 return Ok(());
             }
 
@@ -260,8 +264,22 @@ impl Drawable for Pixelate {
 #[derive(Default)]
 pub struct PixelateTool {
     pixelate: Option<Pixelate>,
+    style: Style,
     input_enabled: bool,
     sender: Option<Sender<SketchBoardInput>>,
+    pseudo_mode: bool,
+}
+
+impl PixelateTool {
+    pub fn new_pseudo() -> Self {
+        PixelateTool {
+            pixelate: None,
+            style: Style::default(),
+            input_enabled: false,
+            sender: None,
+            pseudo_mode: true,
+        }
+    }
 }
 
 impl Tool for PixelateTool {
@@ -274,7 +292,11 @@ impl Tool for PixelateTool {
     }
 
     fn get_tool_type(&self) -> super::Tools {
-        Tools::Pixelate
+        if self.pseudo_mode {
+            Tools::PseudoPixelate
+        } else {
+            Tools::Pixelate
+        }
     }
 
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
@@ -289,8 +311,9 @@ impl Tool for PixelateTool {
                     top_left: event.pos,
                     size: None,
                     editing: true,
-                    independent_mode: event.modifier.intersects(ModifierType::ALT_MASK),
+                    style: self.style,
                     cached_image: RefCell::new(None),
+                    pseudo_mode: self.pseudo_mode,
                 });
 
                 ToolUpdateResult::Redraw
@@ -307,7 +330,6 @@ impl Tool for PixelateTool {
                         ToolUpdateResult::Redraw
                     } else {
                         a.size = Some(event.pos);
-                        a.independent_mode = event.modifier.intersects(ModifierType::ALT_MASK);
                         a.editing = false;
 
                         let result = a.clone_box();
@@ -328,7 +350,6 @@ impl Tool for PixelateTool {
                     if event.pos == Vec2D::zero() {
                         return ToolUpdateResult::Unmodified;
                     }
-                    a.independent_mode = event.modifier.intersects(ModifierType::ALT_MASK);
                     a.size = Some(event.pos);
 
                     ToolUpdateResult::Redraw
@@ -349,7 +370,8 @@ impl Tool for PixelateTool {
         }
     }
 
-    fn handle_style_event(&mut self, _style: Style) -> ToolUpdateResult {
+    fn handle_style_event(&mut self, style: Style) -> ToolUpdateResult {
+        self.style = style;
         ToolUpdateResult::Unmodified
     }
 

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -304,6 +304,7 @@ impl PointerTool {
             "nesw-resize" => Some(&["nesw-resize", "top-right-corner"]),
             "ns-resize" => Some(&["ns-resize", "top-center"]),
             "ew-resize" => Some(&["ew-resize", "middle-left"]),
+            "not-allowed" => Some(&["not-allowed", "no-drop"]),
             _ => None,
         };
         cursor_candidates.and_then(|candidates| {
@@ -313,14 +314,36 @@ impl PointerTool {
         })
     }
 
+    fn resize_cursor_name(handle: ResizeHandle) -> &'static str {
+        type RH = ResizeHandle;
+        match handle {
+            RH::TopLeft | RH::BottomRight => "nwse-resize",
+            RH::TopRight | RH::BottomLeft => "nesw-resize",
+            RH::TopCenter | RH::BottomCenter => "ns-resize",
+            RH::MiddleLeft | RH::MiddleRight => "ew-resize",
+        }
+    }
+
     fn set_hover_cursor(&mut self, pos: Vec2D) {
         let Some(widget) = &self.cursor_widget else {
             return;
         };
 
+        let not_renderable = self.preview.as_ref().is_some_and(|p| !p.is_renderable());
+
         let cursor = if let DragState::Moving { .. } = self.drag_state {
             self.last_drag_state = true;
-            self.get_cursor("grabbing")
+            if not_renderable {
+                self.get_cursor("not-allowed")
+            } else {
+                self.get_cursor("grabbing")
+            }
+        } else if let DragState::Resizing { handle, .. } = self.drag_state {
+            if not_renderable {
+                self.get_cursor("not-allowed")
+            } else {
+                self.get_cursor(Self::resize_cursor_name(handle))
+            }
         } else if matches!(self.drag_state, DragState::None) && self.last_drag_state {
             if let Some(sender) = &self.sender {
                 sender.emit(SketchBoardInput::RefreshMouseCursor(pos));
@@ -328,13 +351,7 @@ impl PointerTool {
             self.last_drag_state = false;
             None
         } else if let Some(handle) = self.hit_test_handles(pos) {
-            type RH = ResizeHandle;
-            match handle {
-                RH::TopLeft | RH::BottomRight => self.get_cursor("nwse-resize"),
-                RH::TopRight | RH::BottomLeft => self.get_cursor("nesw-resize"),
-                RH::TopCenter | RH::BottomCenter => self.get_cursor("ns-resize"),
-                RH::MiddleLeft | RH::MiddleRight => self.get_cursor("ew-resize"),
-            }
+            self.get_cursor(Self::resize_cursor_name(handle))
         } else {
             None
         };
@@ -627,7 +644,9 @@ impl Tool for PointerTool {
                         orig_bounds,
                     } => {
                         let delta = event.pos;
-                        let result = if delta.is_zero() {
+                        let not_renderable =
+                            self.preview.as_ref().is_some_and(|p| !p.is_renderable());
+                        let result = if delta.is_zero() || not_renderable {
                             // Click with no movement: just show selection overlay
                             self.update_selection_bounds(orig_bounds.0, orig_bounds.1);
                             self.preview = None;
@@ -652,7 +671,9 @@ impl Tool for PointerTool {
                         orig_bounds,
                     } => {
                         let delta = event.pos;
-                        let result = if delta.is_zero() {
+                        let not_renderable =
+                            self.preview.as_ref().is_some_and(|p| !p.is_renderable());
+                        let result = if delta.is_zero() || not_renderable {
                             self.update_selection_bounds(orig_bounds.0, orig_bounds.1);
                             self.preview = None;
                             ToolUpdateResult::Redraw

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -249,6 +249,14 @@ impl SimpleComponent for ToolsToolbar {
                 // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Blur,
             },
+            #[name(pixelate_button)]
+            gtk::ToggleButton {
+                set_focusable: false,
+                set_hexpand: false,
+
+                set_icon_name: "tetris-app-regular",
+                ActionablePlus::set_action::<ToolsAction>: Tools::Pixelate,
+            },
             #[name(highlight_button)]
             gtk::ToggleButton {
                 set_focusable: false,
@@ -341,6 +349,7 @@ impl SimpleComponent for ToolsToolbar {
             (Tools::Text, widgets.text_button.clone()),
             (Tools::Marker, widgets.marker_button.clone()),
             (Tools::Blur, widgets.blur_button.clone()),
+            (Tools::Pixelate, widgets.pixelate_button.clone()),
             (Tools::Highlight, widgets.highlight_button.clone()),
         ]);
 

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -303,7 +303,7 @@ impl SimpleComponent for ToolsToolbar {
                     tool: Tools::Blur,
                     icon_name: "drop-regular".into(),
                     tooltip: None,
-                }
+                },
             ],
             vec![GroupableTool {
                 tool: Tools::Highlight,

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -296,12 +296,12 @@ impl SimpleComponent for ToolsToolbar {
             vec![
                 GroupableTool {
                     tool: Tools::PseudoPixelate,
-                    icon_name: "tetris-app-regular".into(),
+                    icon_name: "eye-off-regular".into(),
                     tooltip: None,
                 },
                 GroupableTool {
                     tool: Tools::Pixelate,
-                    icon_name: "tetris-app-regular".into(),
+                    icon_name: "checkerboard".into(),
                     tooltip: None,
                 },
                 GroupableTool {

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -295,6 +295,11 @@ impl SimpleComponent for ToolsToolbar {
             }],
             vec![
                 GroupableTool {
+                    tool: Tools::PseudoPixelate,
+                    icon_name: "tetris-app-regular".into(),
+                    tooltip: None,
+                },
+                GroupableTool {
                     tool: Tools::Pixelate,
                     icon_name: "tetris-app-regular".into(),
                     tooltip: None,

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -296,6 +296,11 @@ impl SimpleComponent for ToolsToolbar {
             }],
             vec![
                 GroupableTool {
+                    tool: Tools::PseudoPixelate,
+                    icon_name: "tetris-app-regular".into(),
+                    tooltip: None,
+                },
+                GroupableTool {
                     tool: Tools::Pixelate,
                     icon_name: "tetris-app-regular".into(),
                     tooltip: None,

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -293,11 +293,18 @@ impl SimpleComponent for ToolsToolbar {
                 icon_name: "number-circle-1-regular".into(),
                 tooltip: None,
             }],
-            vec![GroupableTool {
-                tool: Tools::Blur,
-                icon_name: "drop-regular".into(),
-                tooltip: None,
-            }],
+            vec![
+                GroupableTool {
+                    tool: Tools::Pixelate,
+                    icon_name: "tetris-app-regular".into(),
+                    tooltip: None,
+                },
+                GroupableTool {
+                    tool: Tools::Blur,
+                    icon_name: "drop-regular".into(),
+                    tooltip: None,
+                }
+            ],
             vec![GroupableTool {
                 tool: Tools::Highlight,
                 icon_name: "highlight-regular".into(),

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -304,7 +304,7 @@ impl SimpleComponent for ToolsToolbar {
                     tool: Tools::Blur,
                     icon_name: "drop-regular".into(),
                     tooltip: None,
-                }
+                },
             ],
             vec![GroupableTool {
                 tool: Tools::Highlight,

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -295,13 +295,18 @@ impl SimpleComponent for ToolsToolbar {
             }],
             vec![
                 GroupableTool {
-                    tool: Tools::PseudoPixelate,
+                    tool: Tools::FringePixelate,
                     icon_name: "eye-off-regular".into(),
                     tooltip: None,
                 },
                 GroupableTool {
                     tool: Tools::Pixelate,
                     icon_name: "checkerboard".into(),
+                    tooltip: None,
+                },
+                GroupableTool {
+                    tool: Tools::Fringe,
+                    icon_name: "tetris-app-regular".into(),
                     tooltip: None,
                 },
                 GroupableTool {

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -294,11 +294,18 @@ impl SimpleComponent for ToolsToolbar {
                 icon_name: "number-circle-1-regular".into(),
                 tooltip: None,
             }],
-            vec![GroupableTool {
-                tool: Tools::Blur,
-                icon_name: "drop-regular".into(),
-                tooltip: None,
-            }],
+            vec![
+                GroupableTool {
+                    tool: Tools::Pixelate,
+                    icon_name: "tetris-app-regular".into(),
+                    tooltip: None,
+                },
+                GroupableTool {
+                    tool: Tools::Blur,
+                    icon_name: "drop-regular".into(),
+                    tooltip: None,
+                }
+            ],
             vec![GroupableTool {
                 tool: Tools::Highlight,
                 icon_name: "highlight-regular".into(),


### PR DESCRIPTION
Closes: #90

### TL;DR: What's the holdup?

~2026-09-03
I hit a snag. This was initially copied from blur and thus inherited its shortcomings, e.g. #602. Blur, like this, needs to work on the underlying image, rather than using canvas to create a screenshot of it. At least, we need to create the groundwork in order to allow both, right now `draw()` just has the canvas, not the image.~

### in case you actually do want to read

This implements a pixelate tool with two modes
- regular mode with a normal block pixelation, this is, depending on selected area and image resolution, reversible
- fringe inpaint+pixelate that takes data from _outside_ the selected area and applies distance weighting. The original area is entirely overwritten by the interpolated data. Then, the regular pixelation function creates a block-pixelate look from this.

Also adds "fringe inpaint" as a standalone tool because it was easy to add that.

Dragging the rect to outside of the visible area could cause panics, this was because `canvas.screenshot()` only contains the viewport. Now for inpainting, you'd still kinda want to use data from outside of the viewport, and to a lesser degree this applies for the pixelation algorithm. We address this by passing an image to new signature `draw_baselayer`.

Tasks
- [x] figure out a better icon - help needed please. for both pixelate and pseudo-pixelate
- [x] reach out to flameshot guys regarding credits/licence
- [x] double check if south and east buffers aren't actually off by one
- [x] figure out if BLOCKSIZE is good at a value of 32. This may actually need to be adjustable. Follows size+annotation-size-factor now. Annotation-size-factor gets rounded to 1, S is 4, M is 8, L is 16. These values may need some fine tuning in the future.
- [x] find a user friendly solution for "selected area too small to pixelate". Shows different colours for rectangle now. But perhaps needs more conditions, e.g. when there's no fringe, the pixelation can fail as well. Perhaps use different cursors here.
- [x] this user friendly solution must also be applied to resizing/moving via pointer
- [x] alt is probably not a good way to switch between pixelate and pseudo-pixelate, it's inconsistent with other tools. implement as variant mode on top of #600. Now removed in favour of distinct tool entries.
- [x] indicate editing consistent with #444
- [x] rework on top of #607 - rebased now but we need to consider the layer we draw on and make this movable
- [x] address out of sight areas
- [x] rework fringe to use the available fringes
- [x] if fringes are missing, use the other ones. also, only use intersection of image and selection bounds.

Known limitations:
- could use some noise, leave that for followup
- stacking several instances of the drawables introduced here will not really stack but always apply onto the base image. We'll leave this for #602 to fix.

This PR was inspired by
- https://github.com/flameshot-org/flameshot/pull/3765/changes
- #468 by kikeijuu (superseded by this PR)

Regarding the credits, the idea with taking "fringes" was taken from said PR, but I reimplemented the gist of it according to my understanding. I did, for example, skip any additional noise which might be suitable for adding later. Also, actually iterating the source (fringes) and target data (overwritten area) works a bit different due to the objects used. I don't think we need to talk about a separate licence for this bit, but we'll see what the flameshot guys say about this. This is being discussed in https://github.com/flameshot-org/flameshot/issues/4926

https://github.com/user-attachments/assets/77d167ba-ac39-4d4b-b6cc-fd7edec8ac0a

