### PR TITLE
feat: add Undo and UndoOrExit action variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ primary-highlighter = "block"
 # Disable notifications
 disable-notifications = false
 # Actions to trigger on right click (order is important)
-# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-right-click = []
 # Actions to trigger on Enter key (order is important)
-# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-enter = ["save-to-clipboard"]
 # Actions to trigger on Escape key (order is important)
-# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-escape = ["exit"]
 # Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
 # Deprecated: use actions-on-enter instead
@@ -276,11 +276,11 @@ Options:
       --auto-copy
           Automatically copy to clipboard after every annotation change (NEXTRELEASE)
       --actions-on-enter <ACTIONS_ON_ENTER>
-          Actions to perform when pressing Enter [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Actions to perform when pressing Enter [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
       --actions-on-escape <ACTIONS_ON_ESCAPE>
-          Actions to perform when pressing Escape [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Actions to perform when pressing Escape [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
       --actions-on-right-click <ACTIONS_ON_RIGHT_CLICK>
-          Actions to perform when hitting the copy Button [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Actions to perform when hitting the copy Button [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
   -d, --default-hide-toolbars
           Hide toolbars by default
       --focus-toggles-toolbars
@@ -316,7 +316,7 @@ Options:
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>
-          Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
   -h, --help
           Print help
   -V, --version

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -232,6 +232,8 @@ pub enum Action {
     SaveToFileAs,
     CopyFilepathToClipboard,
     Exit,
+    Undo,
+    UndoOrExit,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/config.toml
+++ b/config.toml
@@ -26,13 +26,13 @@ primary-highlighter = "block"
 # Disable notifications
 disable-notifications = false
 # Actions to trigger on right click (order is important)
-# [possible values: save-to-clipboard, save-to-file, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-right-click = []
 # Actions to trigger on Enter key (order is important)
-# [possible values: save-to-clipboard, save-to-file, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-enter = ["save-to-clipboard"]
 # Actions to trigger on Escape key (order is important)
-# [possible values: save-to-clipboard, save-to-file, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-escape = ["exit"]
 # Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
 # Deprecated: use actions-on-enter instead

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -232,6 +232,8 @@ pub enum Action {
     SaveToFileAs,
     CopyFilepathToClipboard,
     Exit,
+    Undo,
+    UndoOrExit,
 }
 
 impl From<CommandLineAction> for Action {
@@ -242,6 +244,8 @@ impl From<CommandLineAction> for Action {
             CommandLineAction::SaveToFileAs => Self::SaveToFileAs,
             CommandLineAction::CopyFilepathToClipboard => Self::CopyFilepathToClipboard,
             CommandLineAction::Exit => Self::Exit,
+            CommandLineAction::Undo => Self::Undo,
+            CommandLineAction::UndoOrExit => Self::UndoOrExit,
         }
     }
 }

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -193,12 +193,9 @@ impl InputEvent {
         if let InputEvent::Mouse(me) = self {
             match me.type_ {
                 MouseEventType::Click => {
-                    if me.button == MouseButton::Secondary {
-                        renderer.request_render(&APP_CONFIG.read().actions_on_right_click());
-                        None
-                    } else {
-                        None
-                    }
+                    // Right-click is handled in update() where
+                    // we have access to handle_undo() and full SketchBoard state.
+                    None
                 }
                 MouseEventType::EndDrag | MouseEventType::UpdateDrag => {
                     if me.button == MouseButton::Middle {
@@ -283,6 +280,32 @@ impl SketchBoard {
         };
         self.renderer.request_render(actions);
         rv
+    }
+
+    fn process_actions(&mut self, actions: &[Action]) -> ToolUpdateResult {
+        let mut render_actions = Vec::new();
+        let mut result = ToolUpdateResult::Unmodified;
+        for action in actions {
+            match action {
+                Action::Undo => {
+                    if !matches!(self.handle_undo(), ToolUpdateResult::Unmodified) {
+                        result = ToolUpdateResult::Redraw;
+                    }
+                }
+                Action::UndoOrExit => {
+                    if matches!(self.handle_undo(), ToolUpdateResult::Unmodified) {
+                        self.handle_exit();
+                        return result;
+                    }
+                    result = ToolUpdateResult::Redraw;
+                }
+                other => render_actions.push(*other),
+            }
+        }
+        if !render_actions.is_empty() {
+            self.renderer.request_render(&render_actions);
+        }
+        result
     }
 
     fn handle_render_result_with_pixbuf(
@@ -1079,9 +1102,10 @@ impl Component for SketchBoard {
                                     } else {
                                         APP_CONFIG.read().actions_on_enter()
                                     };
-                                    self.renderer.request_render(&actions);
-                                };
-                                active_tool_result
+                                    self.process_actions(&actions)
+                                } else {
+                                    active_tool_result
+                                }
                             } else {
                                 active_tool_result
                             }
@@ -1100,7 +1124,19 @@ impl Component for SketchBoard {
                         ToolUpdateResult::StopPropagation
                         | ToolUpdateResult::RedrawAndStopPropagation => active_tool_result,
                         _ => {
-                            if let Some(result) = ie.handle_mouse_event(&self.renderer) {
+                            if let InputEvent::Mouse(ref me) = ie {
+                                if me.type_ == MouseEventType::Click
+                                    && me.button == MouseButton::Secondary
+                                {
+                                    self.process_actions(
+                                        &APP_CONFIG.read().actions_on_right_click(),
+                                    )
+                                } else if let Some(result) = ie.handle_mouse_event(&self.renderer) {
+                                    result
+                                } else {
+                                    active_tool_result
+                                }
+                            } else if let Some(result) = ie.handle_mouse_event(&self.renderer) {
                                 result
                             } else {
                                 active_tool_result


### PR DESCRIPTION
## Summary

- Add `undo` and `undo-or-exit` as new action variants for action chains
- `undo`: plain action, no-op if nothing to undo, always continues the chain
- `undo-or-exit`: compound action — undo one step if possible, exit if nothing to undo
- Route Enter/Escape/right-click through new `process_actions` method for consistent Undo support
- No implicit control flow — compound behavior is explicit in the action name

Closes #485
Related discussion: #481