### PR TITLE
feat: add actions-on-double-click option (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ primary-highlighter = "block"
 # Disable notifications
 disable-notifications = false
 # Actions to trigger on right click (order is important)
-# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-right-click = []
 # Actions to trigger on Enter key (order is important)
-# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-enter = ["save-to-clipboard"]
 # Actions to trigger on Escape key (order is important)
-# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-escape = ["exit"]
 # Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
 # Deprecated: use actions-on-enter instead
@@ -276,11 +276,11 @@ Options:
       --auto-copy
           Automatically copy to clipboard after every annotation change (NEXTRELEASE)
       --actions-on-enter <ACTIONS_ON_ENTER>
-          Actions to perform when pressing Enter [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Actions to perform when pressing Enter [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
       --actions-on-escape <ACTIONS_ON_ESCAPE>
-          Actions to perform when pressing Escape [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Actions to perform when pressing Escape [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
       --actions-on-right-click <ACTIONS_ON_RIGHT_CLICK>
-          Actions to perform when hitting the copy Button [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Actions to perform when hitting the copy Button [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
   -d, --default-hide-toolbars
           Hide toolbars by default
       --focus-toggles-toolbars
@@ -316,7 +316,7 @@ Options:
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>
-          Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
+          Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
   -h, --help
           Print help
   -V, --version

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ actions-on-enter = ["save-to-clipboard"]
 # Actions to trigger on Escape key (order is important)
 # [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-escape = ["exit"]
+# experimental: Actions to trigger on double-click (order is important)
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
+actions-on-double-click = []
 # Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
 # Deprecated: use actions-on-enter instead
 action-on-enter = "save-to-clipboard"
@@ -281,6 +284,8 @@ Options:
           Actions to perform when pressing Escape [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
       --actions-on-right-click <ACTIONS_ON_RIGHT_CLICK>
           Actions to perform when hitting the copy Button [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
+      --actions-on-double-click <ACTIONS_ON_DOUBLE_CLICK>
+          Experimental (NEXTRELEASE): Actions to perform on double-click [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
   -d, --default-hide-toolbars
           Hide toolbars by default
       --focus-toggles-toolbars

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -232,6 +232,8 @@ pub enum Action {
     SaveToFileAs,
     CopyFilepathToClipboard,
     Exit,
+    Undo,
+    UndoOrExit,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -90,6 +90,10 @@ pub struct CommandLine {
     #[arg(long, value_delimiter = ',')]
     pub actions_on_right_click: Option<Vec<Action>>,
 
+    /// Experimental (NEXTRELEASE): Actions to perform on double-click
+    #[arg(long, value_delimiter = ',')]
+    pub actions_on_double_click: Option<Vec<Action>>,
+
     /// Hide toolbars by default
     #[arg(short, long)]
     pub default_hide_toolbars: bool,

--- a/config.toml
+++ b/config.toml
@@ -26,13 +26,13 @@ primary-highlighter = "block"
 # Disable notifications
 disable-notifications = false
 # Actions to trigger on right click (order is important)
-# [possible values: save-to-clipboard, save-to-file, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-right-click = []
 # Actions to trigger on Enter key (order is important)
-# [possible values: save-to-clipboard, save-to-file, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-enter = ["save-to-clipboard"]
 # Actions to trigger on Escape key (order is important)
-# [possible values: save-to-clipboard, save-to-file, exit]
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-escape = ["exit"]
 # Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
 # Deprecated: use actions-on-enter instead

--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,9 @@ actions-on-enter = ["save-to-clipboard"]
 # Actions to trigger on Escape key (order is important)
 # [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
 actions-on-escape = ["exit"]
+# experimental: Actions to trigger on double-click (order is important)
+# [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit, undo, undo-or-exit]
+actions-on-double-click = []
 # Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
 # Deprecated: use actions-on-enter instead
 action-on-enter = "save-to-clipboard"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -54,6 +54,7 @@ pub struct Configuration {
     actions_on_enter: Vec<Action>,
     actions_on_escape: Vec<Action>,
     actions_on_right_click: Vec<Action>,
+    actions_on_double_click: Vec<Action>,
     color_palette: ColorPalette,
     default_hide_toolbars: bool,
     focus_toggles_toolbars: bool,
@@ -325,6 +326,9 @@ impl Configuration {
         if let Some(v) = general.actions_on_right_click {
             self.actions_on_right_click = v;
         }
+        if let Some(v) = general.actions_on_double_click {
+            self.actions_on_double_click = v;
+        }
         if let Some(v) = general.default_hide_toolbars {
             self.default_hide_toolbars = v;
         }
@@ -461,6 +465,9 @@ impl Configuration {
         if let Some(v) = command_line.actions_on_right_click {
             self.actions_on_right_click = v.iter().cloned().map(Into::into).collect();
         }
+        if let Some(v) = command_line.actions_on_double_click {
+            self.actions_on_double_click = v.iter().cloned().map(Into::into).collect();
+        }
         if let Some(v) = command_line.font_family {
             self.font.family = Some(v);
         }
@@ -591,6 +598,10 @@ impl Configuration {
         self.actions_on_right_click.clone()
     }
 
+    pub fn actions_on_double_click(&self) -> Vec<Action> {
+        self.actions_on_double_click.clone()
+    }
+
     pub fn color_palette(&self) -> &ColorPalette {
         &self.color_palette
     }
@@ -681,6 +692,7 @@ impl Default for Configuration {
             actions_on_enter: vec![],
             actions_on_escape: vec![Action::Exit],
             actions_on_right_click: vec![],
+            actions_on_double_click: vec![],
             color_palette: ColorPalette::default(),
             default_hide_toolbars: false,
             focus_toggles_toolbars: false,
@@ -769,6 +781,7 @@ struct ConfigurationFileGeneral {
     actions_on_enter: Option<Vec<Action>>,
     actions_on_escape: Option<Vec<Action>>,
     actions_on_right_click: Option<Vec<Action>>,
+    actions_on_double_click: Option<Vec<Action>>,
     default_hide_toolbars: Option<bool>,
     focus_toggles_toolbars: Option<bool>,
     default_fill_shapes: Option<bool>,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -232,6 +232,8 @@ pub enum Action {
     SaveToFileAs,
     CopyFilepathToClipboard,
     Exit,
+    Undo,
+    UndoOrExit,
 }
 
 impl From<CommandLineAction> for Action {
@@ -242,6 +244,8 @@ impl From<CommandLineAction> for Action {
             CommandLineAction::SaveToFileAs => Self::SaveToFileAs,
             CommandLineAction::CopyFilepathToClipboard => Self::CopyFilepathToClipboard,
             CommandLineAction::Exit => Self::Exit,
+            CommandLineAction::Undo => Self::Undo,
+            CommandLineAction::UndoOrExit => Self::UndoOrExit,
         }
     }
 }

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1131,6 +1131,16 @@ impl Component for SketchBoard {
                                     self.process_actions(
                                         &APP_CONFIG.read().actions_on_right_click(),
                                     )
+                                } else if me.type_ == MouseEventType::Click
+                                    && me.button == MouseButton::Primary
+                                    && me.n_pressed >= 2
+                                {
+                                    let actions = APP_CONFIG.read().actions_on_double_click();
+                                    if !actions.is_empty() {
+                                        self.process_actions(&actions)
+                                    } else {
+                                        active_tool_result
+                                    }
                                 } else if let Some(result) = ie.handle_mouse_event(&self.renderer) {
                                     result
                                 } else {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -193,12 +193,9 @@ impl InputEvent {
         if let InputEvent::Mouse(me) = self {
             match me.type_ {
                 MouseEventType::Click => {
-                    if me.button == MouseButton::Secondary {
-                        renderer.request_render(&APP_CONFIG.read().actions_on_right_click());
-                        None
-                    } else {
-                        None
-                    }
+                    // Right-click is handled in update() where
+                    // we have access to handle_undo() and full SketchBoard state.
+                    None
                 }
                 MouseEventType::EndDrag | MouseEventType::UpdateDrag => {
                     if me.button == MouseButton::Middle {
@@ -283,6 +280,32 @@ impl SketchBoard {
         };
         self.renderer.request_render(actions);
         rv
+    }
+
+    fn process_actions(&mut self, actions: &[Action]) -> ToolUpdateResult {
+        let mut render_actions = Vec::new();
+        let mut result = ToolUpdateResult::Unmodified;
+        for action in actions {
+            match action {
+                Action::Undo => {
+                    if !matches!(self.handle_undo(), ToolUpdateResult::Unmodified) {
+                        result = ToolUpdateResult::Redraw;
+                    }
+                }
+                Action::UndoOrExit => {
+                    if matches!(self.handle_undo(), ToolUpdateResult::Unmodified) {
+                        self.handle_exit();
+                        return result;
+                    }
+                    result = ToolUpdateResult::Redraw;
+                }
+                other => render_actions.push(*other),
+            }
+        }
+        if !render_actions.is_empty() {
+            self.renderer.request_render(&render_actions);
+        }
+        result
     }
 
     fn handle_render_result_with_pixbuf(
@@ -1079,9 +1102,10 @@ impl Component for SketchBoard {
                                     } else {
                                         APP_CONFIG.read().actions_on_enter()
                                     };
-                                    self.renderer.request_render(&actions);
-                                };
-                                active_tool_result
+                                    self.process_actions(&actions)
+                                } else {
+                                    active_tool_result
+                                }
                             } else {
                                 active_tool_result
                             }
@@ -1100,7 +1124,19 @@ impl Component for SketchBoard {
                         ToolUpdateResult::StopPropagation
                         | ToolUpdateResult::RedrawAndStopPropagation => active_tool_result,
                         _ => {
-                            if let Some(result) = ie.handle_mouse_event(&self.renderer) {
+                            if let InputEvent::Mouse(ref me) = ie {
+                                if me.type_ == MouseEventType::Click
+                                    && me.button == MouseButton::Secondary
+                                {
+                                    self.process_actions(
+                                        &APP_CONFIG.read().actions_on_right_click(),
+                                    )
+                                } else if let Some(result) = ie.handle_mouse_event(&self.renderer) {
+                                    result
+                                } else {
+                                    active_tool_result
+                                }
+                            } else if let Some(result) = ie.handle_mouse_event(&self.renderer) {
                                 result
                             } else {
                                 active_tool_result


### PR DESCRIPTION
## Summary

- Add `--actions-on-double-click` as a new configurable action list (experimental)
- When not configured, double-click does nothing (no fallback to `actions-on-enter`)
- Marked experimental since #89 may provide a more generic mechanism
- Depends on #487 (undo action) for `process_actions` infrastructure

Closes #486
Related discussion: #481