### PR TITLE
feat: make femtovg area transparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Satty ships with [minimal builtin CSS](https://github.com/Satty-org/Satty/tree/m
 }
 ```
 
-You can discover styleable elements by using the GTK inspector with env variable `GTK_DEBUG=interactive`.
+You can discover styleable elements by using the GTK inspector with env variable `GTK_DEBUG=interactive`. Also, see [wiki](https://github.com/Satty-org/Satty/wiki/Config-examples#css-overridescss) for more examples.
 
 ### IME <sup>0.20.0</sup>
 

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -7,6 +7,10 @@
     background-color: @headerbar_bg_color;
 }
 
+.inner_box {
+    background-color: #000000;
+}
+
 .toolbar {
     color: @headerbar_fg_color;
     background-color: @headerbar_bg_color;

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -404,8 +404,13 @@ impl FemtoVgAreaMut {
         canvas.reset_transform();
         canvas.set_transform(&transform);
 
-        //TODO: make background color configurable
-        self.render(canvas, font, true, femtovg::Color::black(), true)?;
+        self.render(
+            canvas,
+            font,
+            true,
+            femtovg::Color::rgbaf(0.0, 0.0, 0.0, 0.0),
+            true,
+        )?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,9 +186,17 @@ impl App {
 
         match DisplayManager::get().default_display() {
             Some(display) => {
-                gtk::style_context_add_provider_for_display(&display, &css_provider, 1);
+                gtk::style_context_add_provider_for_display(
+                    &display,
+                    &css_provider,
+                    gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+                );
                 if let Some(css_provider2) = css_provider_override {
-                    gtk::style_context_add_provider_for_display(&display, &css_provider2, 1)
+                    gtk::style_context_add_provider_for_display(
+                        &display,
+                        &css_provider2,
+                        gtk::STYLE_PROVIDER_PRIORITY_USER,
+                    );
                 }
             }
             None => println!("Cannot apply style"),

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -855,6 +855,7 @@ impl Component for SketchBoard {
 
     view! {
         gtk::Box {
+            add_css_class: "inner_box",
             #[local_ref]
             area -> FemtoVGArea {
                 set_vexpand: true,


### PR DESCRIPTION
Closes: #402

This adds transparent background to femtovg area and adds a css class "inner_box" to the GtkBox surrounding it, which is styled with black bg by default, thus allowing to override the color.

To get transparency for all of it, window, .inner_box and .outer_box woudl
 need to be styled as transparent via overrides.css.