### PR TITLE
fix: Ctrl+Y for DE by removing layout-independent keys

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1077,7 +1077,9 @@ impl Component for SketchBoard {
                         ToolUpdateResult::StopPropagation
                         | ToolUpdateResult::RedrawAndStopPropagation => active_tool_result,
                         _ => {
-                            if ke.is_one_of(Key::z, KeyMappingId::UsZ)
+                            if ke.key == Key::y && ke.modifier == ModifierType::CONTROL_MASK {
+                                self.handle_redo()
+                            } else if ke.is_one_of(Key::z, KeyMappingId::UsZ)
                                 && ke.modifier == ModifierType::CONTROL_MASK
                             {
                                 self.handle_undo()


### PR DESCRIPTION
Remove layout-independent key mappings that caused "Ctrl+Y" to malfunction in the DE locale. On German keyboards, the 'Z' and 'Y' keys are swapped. Because of this, 'Y' was incorrectly matching KeyMappingId::UsZ, triggering an "Undo" instead of a "Redo".

Global layout adjustments like this should be handled at the system or framework level rather than per application.