### PR TITLE
Alllow editing of annotations: move, resize, delete, color, size, fill, text

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 
 - <kbd>Enter</kbd>: as configured (see below), default: copy-to-clipboard (may be masked by active tool)
 - <kbd>Esc</kbd>: as configured (see below), default: exit (may be masked by active tool)
-- <kbd>Delete</kbd> reset (clear) <sup>experimental</sup> <sup>0.20.1</sup>
+- <kbd>Shift+Delete</kbd> reset (clear) <sup>experimental</sup> <sup>NEXTRELEASE</sup>
 - <kbd>Ctrl+C</kbd>: Save to clipboard (may be masked by active tool)
 - <kbd>Ctrl+Shift+D</kbd> or <kbd>Ctrl+Shift+I</kbd>: Open GTK inspector if not already opened
 - <kbd>Ctrl+S</kbd>: Save to specified output file

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Default single-key shortcuts:
 - Pointer: <sup>NEXTRELEASE</sup>
   - <kbd>Click</kbd> on annotation to select and raise it to top
   - <kbd>Delete</kbd> to delete selected annotation
+  - <kbd>Double-Click</kbd> to edit selected text annotation
 - Arrow: Hold <kbd>Shift</kbd> to make arrow snap to 15° steps
 - Ellipse: Hold <kbd>Alt</kbd> to center the ellipse around origin, hold <kbd>Shift</kbd> for a circle
 - Highlight: Hold <kbd>Alt</kbd> to center the block highlight around origin <sup>NEXTRELEASE</sup>, hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below), hold <kbd>Shift</kbd> for a square (if the default mode is block) or a straight line (if the default mode is freehand)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 - <kbd>Ctrl+Z</kbd>: Undo
 - <kbd>Alt</kbd>+(<kbd>Left</kbd>/<kbd>Right</kbd>/<kbd>Up</kbd>/<kbd>Down</kbd>): Pan, also available with middle mouse button drag <sup>0.20.1</sup>
 
+#### Size Selection Shortcut
+<kbd>-</kbd>: Cycle between large, medium and small size <sup>NEXTRELEASE</sup>
+
 #### Color Selection Shortcuts <sup>0.20.1</sup>
 
 <kbd>1</kbd>, <kbd>2</kbd>, <kbd>3</kbd>, …, <kbd>9</kbd>, <kbd>0</kbd> — select nth color from the color palette

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Default single-key shortcuts:
 ### Tool Modifiers and Keys
 
 - Pointer: <sup>NEXTRELEASE</sup>
-  - <kbd>Click</kbd> on annotation to select it
+  - <kbd>Click</kbd> on annotation to select and raise it to top
   - <kbd>Delete</kbd> to delete selected annotation
 - Arrow: Hold <kbd>Shift</kbd> to make arrow snap to 15° steps
 - Ellipse: Hold <kbd>Alt</kbd> to center the ellipse around origin, hold <kbd>Shift</kbd> for a circle

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Default single-key shortcuts:
 
 - Pointer: <sup>NEXTRELEASE</sup>
   - <kbd>Click</kbd> on annotation to select and raise it to top
+  - <kbd>Alt+Click</kbd> on overlapping annotations cycles selection through them without raising them
   - <kbd>Delete</kbd> to delete selected annotation
   - <kbd>Double-Click</kbd> to edit selected text annotation
 - Arrow: Hold <kbd>Shift</kbd> to make arrow snap to 15° steps

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 
 <kbd>1</kbd>, <kbd>2</kbd>, <kbd>3</kbd>, …, <kbd>9</kbd>, <kbd>0</kbd> — select nth color from the color palette
 
+#### Toggle fill <sup>NEXTRELEASE</sup>
+
+<kbd>f</kbd>
+
 #### Tool Selection Shortcuts (configurable) <sup>0.20.0</sup>
+
 Default single-key shortcuts:
 - <kbd>p</kbd>: Pointer tool
 - <kbd>c</kbd>: Crop tool

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Default single-key shortcuts:
 
 ### Tool Modifiers and Keys
 
+- Pointer: <sup>NEXTRELEASE</sup>
+  - <kbd>Click</kbd> on annotation to select it
+  - <kbd>Delete</kbd> to delete selected annotation
 - Arrow: Hold <kbd>Shift</kbd> to make arrow snap to 15° steps
 - Ellipse: Hold <kbd>Alt</kbd> to center the ellipse around origin, hold <kbd>Shift</kbd> for a circle
 - Highlight: Hold <kbd>Alt</kbd> to center the block highlight around origin <sup>NEXTRELEASE</sup>, hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below), hold <kbd>Shift</kbd> for a square (if the default mode is block) or a straight line (if the default mode is freehand)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 ### Shortcuts
 
 - <kbd>Enter</kbd>: as configured (see below), default: copy-to-clipboard (may be masked by active tool)
-- <kbd>Esc</kbd>: as configured (see below), default: exit (may be masked by active tool)
+- <kbd>Esc</kbd> or <kbd>Ctrl-Q</kbd> <sup>NEXTRELEASE</sup>: as configured (see below), default: exit (may be masked by active tool)
 - <kbd>Delete</kbd> reset (clear) <sup>experimental</sup> <sup>0.20.1</sup>
 - <kbd>Ctrl+C</kbd>: Save to clipboard (may be masked by active tool)
 - <kbd>Ctrl+Shift+D</kbd> or <kbd>Ctrl+Shift+I</kbd>: Open GTK inspector if not already opened

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Default single-key shortcuts:
 
 - Arrow: Hold <kbd>Shift</kbd> to make arrow snap to 15° steps
 - Ellipse: Hold <kbd>Alt</kbd> to center the ellipse around origin, hold <kbd>Shift</kbd> for a circle
-- Highlight: Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below), hold <kbd>Shift</kbd> for a square (if the default mode is block) or a straight line (if the default mode is freehand)
+- Highlight: Hold <kbd>Alt</kbd> to center the block highlight around origin <sup>NEXTRELEASE</sup>, hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below), hold <kbd>Shift</kbd> for a square (if the default mode is block) or a straight line (if the default mode is freehand)
 - Line: Hold <kbd>Shift</kbd> to make line snap to 15° steps
 - Rectangle: Hold <kbd>Alt</kbd> to center the rectangle around origin, hold <kbd>Shift</kbd> for a square
 - Text:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 
 <kbd>1</kbd>, <kbd>2</kbd>, <kbd>3</kbd>, …, <kbd>9</kbd>, <kbd>0</kbd> — select nth color from the color palette
 
+If out of range select custom color <sup>NEXTRELEASE</sup>
+
 #### Tool Selection Shortcuts (configurable) <sup>0.20.0</sup>
 Default single-key shortcuts:
 - <kbd>p</kbd>: Pointer tool

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -343,6 +343,21 @@ impl FemtoVgAreaMut {
         }
     }
 
+    /// Move the drawable at `index` to the end of the stack and return its new index.
+    pub fn move_drawable_to_end(&mut self, index: usize) -> Option<usize> {
+        if index >= self.drawables.len() {
+            return None;
+        }
+
+        if index + 1 == self.drawables.len() {
+            return Some(index);
+        }
+
+        let drawable = self.drawables.remove(index);
+        self.drawables.push(drawable);
+        Some(self.drawables.len() - 1)
+    }
+
     /// Remove the drawable at `index`, shifting subsequent drawables down.
     pub fn remove_drawable(&mut self, index: usize) {
         if index < self.drawables.len() {

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -58,6 +58,7 @@ pub struct FemtoVgAreaMut {
     drag_offset: Vec2D,
     is_drag: bool,
     is_reset: bool,
+    hidden_drawable_index: Option<usize>,
 }
 
 #[glib::object_subclass]
@@ -179,6 +180,7 @@ impl FemtoVGArea {
             last_scale: 0.0,
             is_drag: false,
             is_reset: false,
+            hidden_drawable_index: None,
         });
         self.sender.borrow_mut().replace(sender);
     }
@@ -305,6 +307,52 @@ impl FemtoVgAreaMut {
     pub fn commit(&mut self, drawable: Box<dyn Drawable>) {
         self.drawables.push(drawable);
         self.redo_stack.clear();
+    }
+
+    /// Hit-test all drawables and return the index of the topmost one whose bounds contain `pos`.
+    /// A small tolerance is applied to make thin shapes (lines, arrows) easier to click.
+    pub fn hit_test(&self, pos: Vec2D) -> Option<usize> {
+        const HIT_TOLERANCE: f32 = 5.0;
+        for (i, d) in self.drawables.iter().enumerate().rev() {
+            if let Some((tl, br)) = d.bounds()
+                && pos.x >= tl.x - HIT_TOLERANCE
+                && pos.x <= br.x + HIT_TOLERANCE
+                && pos.y >= tl.y - HIT_TOLERANCE
+                && pos.y <= br.y + HIT_TOLERANCE
+            {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    /// Returns the bounds of the drawable at `index`, if it supports bounds.
+    pub fn get_drawable_bounds(&self, index: usize) -> Option<(Vec2D, Vec2D)> {
+        self.drawables.get(index).and_then(|d| d.bounds())
+    }
+
+    /// Returns a clone of the drawable at `index`.
+    pub fn get_drawable_clone(&self, index: usize) -> Option<Box<dyn Drawable>> {
+        self.drawables.get(index).map(|d| d.clone_box())
+    }
+
+    /// Replace the drawable at `index` with `drawable`.
+    pub fn replace_drawable(&mut self, index: usize, drawable: Box<dyn Drawable>) {
+        if index < self.drawables.len() {
+            self.drawables[index] = drawable;
+        }
+    }
+
+    /// Remove the drawable at `index`, shifting subsequent drawables down.
+    pub fn remove_drawable(&mut self, index: usize) {
+        if index < self.drawables.len() {
+            self.drawables.remove(index);
+        }
+    }
+
+    /// Set (or clear) the drawable index to skip during rendering (used while drag-previewing).
+    pub fn set_hidden_drawable_index(&mut self, index: Option<usize>) {
+        self.hidden_drawable_index = index;
     }
 
     pub fn undo(&mut self) -> bool {
@@ -452,7 +500,10 @@ impl FemtoVgAreaMut {
             ),
         );
         // render the whole stack
-        for d in &mut self.drawables {
+        for (i, d) in self.drawables.iter().enumerate() {
+            if self.hidden_drawable_index == Some(i) {
+                continue; // skip original while a drag preview is shown
+            }
             d.draw(canvas, font, bounds)?;
         }
 

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -309,9 +309,10 @@ impl FemtoVgAreaMut {
         self.redo_stack.clear();
     }
 
-    /// Hit-test all drawables and return the index of the topmost one whose bounds contain `pos`.
+    /// Hit-test all drawables and return all indices whose bounds contain `pos`, in order from topmost to bottommost.
     /// A small tolerance is applied to make thin shapes (lines, arrows) easier to click.
-    pub fn hit_test(&self, pos: Vec2D) -> Option<usize> {
+    pub fn hit_test(&self, pos: Vec2D) -> Vec<usize> {
+        let mut results = Vec::new();
         const HIT_TOLERANCE: f32 = 5.0;
         for (i, d) in self.drawables.iter().enumerate().rev() {
             if let Some((tl, br)) = d.bounds()
@@ -320,10 +321,10 @@ impl FemtoVgAreaMut {
                 && pos.y >= tl.y - HIT_TOLERANCE
                 && pos.y <= br.y + HIT_TOLERANCE
             {
-                return Some(i);
+                results.push(i);
             }
         }
-        None
+        results
     }
 
     /// Returns the bounds of the drawable at `index`, if it supports bounds.
@@ -514,16 +515,23 @@ impl FemtoVgAreaMut {
                 self.background_image.height() as f32,
             ),
         );
+        let mut active_tool_drawn_in_stack = false;
+
         // render the whole stack
         for (i, d) in self.drawables.iter().enumerate() {
             if self.hidden_drawable_index == Some(i) {
-                continue; // skip original while a drag preview is shown
+                // Draw the active tool preview in the original z position.
+                if let Some(preview) = self.active_tool.borrow().get_drawable() {
+                    preview.draw(canvas, font, bounds)?;
+                    active_tool_drawn_in_stack = true;
+                }
+                continue;
             }
             d.draw(canvas, font, bounds)?;
         }
 
-        // render active tool
-        if let Some(d) = self.active_tool.borrow().get_drawable() {
+        // render active tool (default: on top) when not already drawn in stack order
+        if !active_tool_drawn_in_stack && let Some(d) = self.active_tool.borrow().get_drawable() {
             d.draw(canvas, font, bounds)?;
         }
 

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -202,6 +202,14 @@ impl FemtoVGArea {
             .replace_drawable(index, drawable);
     }
 
+    pub fn move_drawable_to_end(&mut self, index: usize) -> Option<usize> {
+        self.imp()
+            .inner()
+            .as_mut()
+            .expect("Did you call init before using FemtoVgArea?")
+            .move_drawable_to_end(index)
+    }
+
     pub fn remove_drawable(&mut self, index: usize) {
         self.imp()
             .inner()

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -169,4 +169,52 @@ impl FemtoVGArea {
     pub fn resize(&self, width: i32, height: i32) {
         self.imp().resize(width, height);
     }
+
+    pub fn hit_test(&self, pos: Vec2D) -> Option<usize> {
+        self.imp()
+            .inner()
+            .as_ref()
+            .expect("Did you call init before using FemtoVgArea?")
+            .hit_test(pos)
+    }
+
+    pub fn get_drawable_bounds(&self, index: usize) -> Option<(Vec2D, Vec2D)> {
+        self.imp()
+            .inner()
+            .as_ref()
+            .expect("Did you call init before using FemtoVgArea?")
+            .get_drawable_bounds(index)
+    }
+
+    pub fn get_drawable_clone(&self, index: usize) -> Option<Box<dyn Drawable>> {
+        self.imp()
+            .inner()
+            .as_ref()
+            .expect("Did you call init before using FemtoVgArea?")
+            .get_drawable_clone(index)
+    }
+
+    pub fn replace_drawable(&mut self, index: usize, drawable: Box<dyn Drawable>) {
+        self.imp()
+            .inner()
+            .as_mut()
+            .expect("Did you call init before using FemtoVgArea?")
+            .replace_drawable(index, drawable);
+    }
+
+    pub fn remove_drawable(&mut self, index: usize) {
+        self.imp()
+            .inner()
+            .as_mut()
+            .expect("Did you call init before using FemtoVgArea?")
+            .remove_drawable(index);
+    }
+
+    pub fn set_hidden_drawable_index(&mut self, index: Option<usize>) {
+        self.imp()
+            .inner()
+            .as_mut()
+            .expect("Did you call init before using FemtoVgArea?")
+            .set_hidden_drawable_index(index);
+    }
 }

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -170,7 +170,7 @@ impl FemtoVGArea {
         self.imp().resize(width, height);
     }
 
-    pub fn hit_test(&self, pos: Vec2D) -> Option<usize> {
+    pub fn hit_test(&self, pos: Vec2D) -> Vec<usize> {
         self.imp()
             .inner()
             .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ enum AppInput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    FillToggled(bool),
     ScaleFactorChanged,
     FullscreenChanged(bool),
     DimensionsUpdate(Option<(i32, i32)>),
@@ -263,6 +264,11 @@ impl Component for App {
                         ui::toolbars::ColorButtons::Palette(index),
                     ));
             }
+            AppInput::FillToggled(fill_enabled) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetFill(fill_enabled));
+            }
             AppInput::ScaleFactorChanged => {
                 self.sketch_board
                     .sender()
@@ -322,6 +328,9 @@ impl Component for App {
                     }
                     SketchBoardOutput::ColorSwitchShortcut(index) => {
                         AppInput::ColorSwitchShortcut(index)
+                    }
+                    SketchBoardOutput::FillToggled(fill_enabled) => {
+                        AppInput::FillToggled(fill_enabled)
                     }
                     SketchBoardOutput::DimensionsUpdate(dimensions) => {
                         AppInput::DimensionsUpdate(dimensions)

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,11 +257,15 @@ impl Component for App {
                     .emit(ToolsToolbarInput::SwitchSelectedTool(tool));
             }
             AppInput::ColorSwitchShortcut(index) => {
+                let palette_len = APP_CONFIG.read().color_palette().palette().len() as u64;
+                let color_button = if index < palette_len {
+                    ui::toolbars::ColorButtons::Palette(index)
+                } else {
+                    ui::toolbars::ColorButtons::Custom
+                };
                 self.style_toolbar
                     .sender()
-                    .emit(StyleToolbarInput::ColorButtonSelected(
-                        ui::toolbars::ColorButtons::Palette(index),
-                    ));
+                    .emit(StyleToolbarInput::ColorButtonSelected(color_button));
             }
             AppInput::ScaleFactorChanged => {
                 self.sketch_board

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod tools;
 mod ui;
 
 use crate::sketch_board::{SketchBoard, SketchBoardInput};
+use crate::style::Color;
 use crate::tools::Tools;
 
 pub static START_TIME: LazyLock<chrono::DateTime<chrono::Local>> =
@@ -71,6 +72,7 @@ enum AppInput {
     ColorSwitchShortcut(u64),
     SizeCycleShortcut,
     FillToggled(bool),
+    ColorToggled(Color),
     ScaleFactorChanged,
     FullscreenChanged(bool),
     DimensionsUpdate(Option<(i32, i32)>),
@@ -279,6 +281,11 @@ impl Component for App {
                     .sender()
                     .emit(StyleToolbarInput::SetFill(fill_enabled));
             }
+            AppInput::ColorToggled(color) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetColor(color));
+            }
             AppInput::ScaleFactorChanged => {
                 self.sketch_board
                     .sender()
@@ -343,6 +350,7 @@ impl Component for App {
                     SketchBoardOutput::FillToggled(fill_enabled) => {
                         AppInput::FillToggled(fill_enabled)
                     }
+                    SketchBoardOutput::ColorToggled(color) => AppInput::ColorToggled(color),
                     SketchBoardOutput::DimensionsUpdate(dimensions) => {
                         AppInput::DimensionsUpdate(dimensions)
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ enum AppInput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    SizeCycleShortcut,
     ScaleFactorChanged,
     FullscreenChanged(bool),
     DimensionsUpdate(Option<(i32, i32)>),
@@ -263,6 +264,11 @@ impl Component for App {
                         ui::toolbars::ColorButtons::Palette(index),
                     ));
             }
+            AppInput::SizeCycleShortcut => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::CycleSize);
+            }
             AppInput::ScaleFactorChanged => {
                 self.sketch_board
                     .sender()
@@ -323,6 +329,7 @@ impl Component for App {
                     SketchBoardOutput::ColorSwitchShortcut(index) => {
                         AppInput::ColorSwitchShortcut(index)
                     }
+                    SketchBoardOutput::SizeCycleShortcut => AppInput::SizeCycleShortcut,
                     SketchBoardOutput::DimensionsUpdate(dimensions) => {
                         AppInput::DimensionsUpdate(dimensions)
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ mod tools;
 mod ui;
 
 use crate::sketch_board::{SketchBoard, SketchBoardInput};
-use crate::style::Color;
+use crate::style::{Color, Size};
 use crate::tools::Tools;
 
 pub static START_TIME: LazyLock<chrono::DateTime<chrono::Local>> =
@@ -73,6 +73,7 @@ enum AppInput {
     SizeCycleShortcut,
     FillToggled(bool),
     ColorToggled(Color),
+    SizeToggled(Size),
     ScaleFactorChanged,
     FullscreenChanged(bool),
     DimensionsUpdate(Option<(i32, i32)>),
@@ -286,6 +287,11 @@ impl Component for App {
                     .sender()
                     .emit(StyleToolbarInput::SetColor(color));
             }
+            AppInput::SizeToggled(size) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetSize(size));
+            }
             AppInput::ScaleFactorChanged => {
                 self.sketch_board
                     .sender()
@@ -347,10 +353,11 @@ impl Component for App {
                         AppInput::ColorSwitchShortcut(index)
                     }
                     SketchBoardOutput::SizeCycleShortcut => AppInput::SizeCycleShortcut,
+                    SketchBoardOutput::ColorToggled(color) => AppInput::ColorToggled(color),
+                    SketchBoardOutput::SizeToggled(size) => AppInput::SizeToggled(size),
                     SketchBoardOutput::FillToggled(fill_enabled) => {
                         AppInput::FillToggled(fill_enabled)
                     }
-                    SketchBoardOutput::ColorToggled(color) => AppInput::ColorToggled(color),
                     SketchBoardOutput::DimensionsUpdate(dimensions) => {
                         AppInput::DimensionsUpdate(dimensions)
                     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,7 +1,7 @@
 use std::{
     f32::consts::PI,
     fmt::Display,
-    ops::{Add, AddAssign, Mul, Sub, SubAssign},
+    ops::{Add, AddAssign, Div, Mul, Sub, SubAssign},
 };
 
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
@@ -155,6 +155,14 @@ impl Mul<f32> for Vec2D {
 
     fn mul(self, rhs: f32) -> Self::Output {
         Vec2D::new(self.x * rhs, self.y * rhs)
+    }
+}
+
+impl Div<f32> for Vec2D {
+    type Output = Vec2D;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        Vec2D::new(self.x / rhs, self.y / rhs)
     }
 }
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -24,7 +24,7 @@ use crate::ime::pango_adapter::spans_from_pango_attrs;
 use crate::math::Vec2D;
 use crate::notification::log_result;
 use crate::style::Style;
-use crate::tools::{PointerTool, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
+use crate::tools::{PointerTool, TextTool, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
 use crate::ui::toolbars::ToolbarEvent;
 use xdg::BaseDirectories;
 
@@ -247,6 +247,8 @@ pub struct SketchBoard {
     active_tool: Rc<RefCell<dyn Tool>>,
     tools: ToolsManager,
     pointer_tool: Rc<RefCell<PointerTool>>,
+    text_tool: Rc<RefCell<TextTool>>,
+    return_to_pointer_after_text_commit: bool,
     style: Style,
     im_context: gtk::IMMulticontext,
     last_saved_filepath: RefCell<Option<String>>,
@@ -825,6 +827,33 @@ impl SketchBoard {
         Some(ToolUpdateResult::Redraw)
     }
 
+    /// Called when the pointer tool receives a double-click (n_pressed == 2).
+    /// If the hit drawable is a Text, removes it from the canvas and re-opens it in the text tool.
+    fn handle_pointer_tool_double_click(
+        &mut self,
+        pos: Vec2D,
+        sender: &ComponentSender<Self>,
+    ) -> Option<ToolUpdateResult> {
+        let idx = self.renderer.hit_test(pos)?;
+        let drawable = self.renderer.get_drawable_clone(idx)?;
+        let (text_pos, content, style) = drawable.edit_info()?;
+
+        // Remove the committed drawable and clear selection
+        self.pointer_tool.borrow_mut().deselect();
+        self.renderer.set_hidden_drawable_index(None);
+        self.renderer.remove_drawable(idx);
+
+        // Pre-populate the text tool and switch to it
+        self.text_tool
+            .borrow_mut()
+            .load_for_editing(text_pos, &content, style);
+        self.return_to_pointer_after_text_commit = true;
+        Some(self.handle_toolbar_event(
+            crate::ui::toolbars::ToolbarEvent::ToolSelected(Tools::Text),
+            sender.clone(),
+        ))
+    }
+
     fn handle_toolbar_event(
         &mut self,
         toolbar_event: ToolbarEvent,
@@ -832,6 +861,10 @@ impl SketchBoard {
     ) -> ToolUpdateResult {
         match toolbar_event {
             ToolbarEvent::ToolSelected(tool) => {
+                if tool != Tools::Text {
+                    self.return_to_pointer_after_text_commit = false;
+                }
+
                 // deactivate old tool and save drawable, if any
                 let old_tool = self.active_tool.clone();
                 let mut deactivate_result =
@@ -1138,6 +1171,8 @@ impl Component for SketchBoard {
     }
 
     fn update(&mut self, msg: SketchBoardInput, sender: ComponentSender<Self>, _root: &Self::Root) {
+        let sender_for_post_commit = sender.clone();
+
         // handle resize ourselves, pass everything else to tool
         let result = match msg {
             SketchBoardInput::InputEvent(mut ie) => {
@@ -1274,11 +1309,15 @@ impl Component for SketchBoard {
                 } else {
                     ie.handle_event_mouse_input(&self.renderer);
 
-                    // For the pointer tool, intercept BeginDrag to perform hit-testing
-                    // before the event is dispatched to the tool itself.
+                    // For the pointer tool, intercept double-click (re-edit text) and
+                    // BeginDrag (hit-test for move/resize) before dispatching to the tool.
                     let pointer_begin_drag_result = if self.active_tool_type() == Tools::Pointer {
                         if let InputEvent::Mouse(ref me) = ie {
-                            self.handle_pointer_tool_begin_drag(me)
+                            if me.type_ == MouseEventType::Click && me.n_pressed == 2 {
+                                self.handle_pointer_tool_double_click(me.pos, &sender)
+                            } else {
+                                self.handle_pointer_tool_begin_drag(me)
+                            }
                         } else {
                             None
                         }
@@ -1361,6 +1400,17 @@ impl Component for SketchBoard {
                 if APP_CONFIG.read().auto_copy() {
                     self.renderer.request_render(&[Action::SaveToClipboard]);
                 }
+
+                if self.return_to_pointer_after_text_commit
+                    && self.active_tool_type() == Tools::Text
+                {
+                    self.return_to_pointer_after_text_commit = false;
+                    let _ = self.handle_toolbar_event(
+                        ToolbarEvent::ToolSelected(Tools::Pointer),
+                        sender_for_post_commit,
+                    );
+                }
+
                 self.refresh_screen();
             }
             ToolUpdateResult::ReplaceDrawable(index, drawable) => {
@@ -1392,11 +1442,15 @@ impl Component for SketchBoard {
 
         let pointer_tool = tools.get_pointer_tool();
 
+        let text_tool = tools.get_text_tool();
+
         let mut model = Self {
             renderer: FemtoVGArea::default(),
             active_tool: tools.get(&config.initial_tool()),
             style: Style::default(),
             pointer_tool,
+            text_tool,
+            return_to_pointer_after_text_commit: false,
             tools,
             im_context,
             last_saved_filepath: RefCell::new(None),

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1153,7 +1153,12 @@ impl Component for SketchBoard {
                                 self.renderer.store_last_offset();
                                 self.renderer.request_render(&[]);
                                 ToolUpdateResult::Unmodified
-                            } else if ke.modifier.is_empty() && ke.key == Key::Delete {
+                            } else if ke.key == Key::Delete
+                                && ke.modifier.contains(ModifierType::SHIFT_MASK)
+                                && !ke
+                                    .modifier
+                                    .intersects(ModifierType::CONTROL_MASK | ModifierType::ALT_MASK)
+                            {
                                 self.handle_reset()
                             } else if ke.modifier.is_empty()
                                 && (ke.key == Key::Escape

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -800,15 +800,16 @@ impl SketchBoard {
 
         // Check body hit
         if let Some(idx) = self.renderer.hit_test(me.pos)
+            && let Some(new_idx) = self.renderer.move_drawable_to_end(idx)
             && let (Some(drawable), Some(bounds)) = (
-                self.renderer.get_drawable_clone(idx),
-                self.renderer.get_drawable_bounds(idx),
+                self.renderer.get_drawable_clone(new_idx),
+                self.renderer.get_drawable_bounds(new_idx),
             )
         {
-            self.renderer.set_hidden_drawable_index(Some(idx));
+            self.renderer.set_hidden_drawable_index(Some(new_idx));
             self.pointer_tool
                 .borrow_mut()
-                .begin_move(idx, drawable, bounds);
+                .begin_move(new_idx, drawable, bounds);
             return Some(ToolUpdateResult::Redraw);
         }
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -798,6 +798,7 @@ impl SketchBoard {
                     self.renderer.get_drawable_bounds(idx),
                 )
             {
+                self.style.fill = drawable.get_fill();
                 self.renderer.set_hidden_drawable_index(Some(idx));
                 self.pointer_tool
                     .borrow_mut()
@@ -814,6 +815,7 @@ impl SketchBoard {
                 self.renderer.get_drawable_bounds(new_idx),
             )
         {
+            self.style.fill = drawable.get_fill();
             self.renderer.set_hidden_drawable_index(Some(new_idx));
             self.pointer_tool
                 .borrow_mut()
@@ -918,9 +920,28 @@ impl SketchBoard {
             }
             ToolbarEvent::ColorSelected(color) => {
                 self.style.color = color;
-                self.active_tool
+                let mut result = self
+                    .active_tool
                     .borrow_mut()
-                    .handle_event(ToolEvent::StyleChanged(self.style))
+                    .handle_event(ToolEvent::StyleChanged(self.style));
+
+                if self.active_tool_type() == Tools::Pointer {
+                    let selected_index = self.pointer_tool.borrow().selected_index();
+                    if let Some(index) = selected_index
+                        && let Some(mut drawable) = self.renderer.get_drawable_clone(index)
+                    {
+                        drawable.set_color(color);
+                        self.renderer.replace_drawable(index, drawable);
+                        if let Some(new_bounds) = self.renderer.get_drawable_bounds(index) {
+                            self.pointer_tool
+                                .borrow_mut()
+                                .set_selection(index, new_bounds);
+                        }
+                        result = ToolUpdateResult::Redraw;
+                    }
+                }
+
+                result
             }
             ToolbarEvent::SizeSelected(size) => {
                 self.style.size = size;
@@ -938,9 +959,28 @@ impl SketchBoard {
                 sender
                     .output_sender()
                     .emit(SketchBoardOutput::FillToggled(self.style.fill));
-                self.active_tool
+                let mut result = self
+                    .active_tool
                     .borrow_mut()
-                    .handle_event(ToolEvent::StyleChanged(self.style))
+                    .handle_event(ToolEvent::StyleChanged(self.style));
+
+                if self.active_tool_type() == Tools::Pointer {
+                    let selected_index = self.pointer_tool.borrow().selected_index();
+                    if let Some(index) = selected_index
+                        && let Some(mut drawable) = self.renderer.get_drawable_clone(index)
+                    {
+                        drawable.set_fill(!drawable.get_fill());
+                        self.renderer.replace_drawable(index, drawable);
+                        if let Some(new_bounds) = self.renderer.get_drawable_bounds(index) {
+                            self.pointer_tool
+                                .borrow_mut()
+                                .set_selection(index, new_bounds);
+                        }
+                        result = ToolUpdateResult::Redraw;
+                    }
+                }
+
+                result
             }
             ToolbarEvent::AnnotationSizeChanged(value) => {
                 self.style.annotation_size_factor = value;

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -781,6 +781,7 @@ impl SketchBoard {
     fn handle_pointer_tool_begin_drag(
         &mut self,
         me: &crate::sketch_board::MouseEventMsg,
+        sender: &ComponentSender<Self>,
     ) -> Option<ToolUpdateResult> {
         use crate::sketch_board::MouseButton;
         use crate::sketch_board::MouseEventType;
@@ -807,20 +808,74 @@ impl SketchBoard {
             }
         }
 
+        let is_alt_click = me.modifier.contains(ModifierType::ALT_MASK);
+
+        // If a drawable is already selected and the click is inside its body,
+        // keep using it instead of re-selecting another overlapping drawable.
+        if !is_alt_click {
+            let selected_idx = self.pointer_tool.borrow().selected_index();
+            if let Some(sel_idx) = selected_idx
+                && let (Some(drawable), Some((tl, br))) = (
+                    self.renderer.get_drawable_clone(sel_idx),
+                    self.renderer.get_drawable_bounds(sel_idx),
+                )
+                && me.pos.x >= tl.x
+                && me.pos.x <= br.x
+                && me.pos.y >= tl.y
+                && me.pos.y <= br.y
+            {
+                self.style.fill = drawable.get_fill();
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::FillToggled(self.style.fill));
+                self.renderer.set_hidden_drawable_index(Some(sel_idx));
+                self.pointer_tool
+                    .borrow_mut()
+                    .begin_move(sel_idx, drawable, (tl, br));
+                return Some(ToolUpdateResult::Redraw);
+            }
+        }
+
         // Check body hit
-        if let Some(idx) = self.renderer.hit_test(me.pos)
-            && let Some(new_idx) = self.renderer.move_drawable_to_end(idx)
-            && let (Some(drawable), Some(bounds)) = (
-                self.renderer.get_drawable_clone(new_idx),
-                self.renderer.get_drawable_bounds(new_idx),
-            )
-        {
-            self.style.fill = drawable.get_fill();
-            self.renderer.set_hidden_drawable_index(Some(new_idx));
-            self.pointer_tool
-                .borrow_mut()
-                .begin_move(new_idx, drawable, bounds);
-            return Some(ToolUpdateResult::Redraw);
+        let idx_to_select = if is_alt_click {
+            // Alt+Click: cycle through all overlapping objects
+            let all_hits = self.renderer.hit_test(me.pos);
+            if !all_hits.is_empty() {
+                // Get the next index in the cycle
+                self.pointer_tool
+                    .borrow_mut()
+                    .cycle_to_next_object(me.pos, all_hits)
+            } else {
+                None
+            }
+        } else {
+            // Normal click: select topmost object
+            self.renderer.hit_test(me.pos).first().copied()
+        };
+
+        if let Some(idx) = idx_to_select {
+            let sel_idx = if is_alt_click {
+                // Alt+Click: don't move to end, just use the index as-is
+                idx
+            } else {
+                // Normal click: move to end and use new index
+                self.renderer.move_drawable_to_end(idx).unwrap_or(idx)
+            };
+
+            if let (Some(drawable), Some(bounds)) = (
+                self.renderer.get_drawable_clone(sel_idx),
+                self.renderer.get_drawable_bounds(sel_idx),
+            ) {
+                self.style.fill = drawable.get_fill();
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::FillToggled(self.style.fill));
+                self.renderer.set_hidden_drawable_index(Some(sel_idx));
+                self.pointer_tool
+                    .borrow_mut()
+                    .begin_move(sel_idx, drawable, bounds);
+                return Some(ToolUpdateResult::Redraw);
+            }
         }
 
         // Clicked on empty space: deselect
@@ -836,7 +891,7 @@ impl SketchBoard {
         pos: Vec2D,
         sender: &ComponentSender<Self>,
     ) -> Option<ToolUpdateResult> {
-        let idx = self.renderer.hit_test(pos)?;
+        let idx = self.renderer.hit_test(pos).first().copied()?;
         let drawable = self.renderer.get_drawable_clone(idx)?;
         let (text_pos, content, style) = drawable.edit_info()?;
 
@@ -1356,7 +1411,7 @@ impl Component for SketchBoard {
                             if me.type_ == MouseEventType::Click && me.n_pressed == 2 {
                                 self.handle_pointer_tool_double_click(me.pos, &sender)
                             } else {
-                                self.handle_pointer_tool_begin_drag(me)
+                                self.handle_pointer_tool_begin_drag(me, &sender)
                             }
                         } else {
                             None

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -53,6 +53,7 @@ pub enum SketchBoardOutput {
     SizeCycleShortcut,
     FillToggled(bool),
     ColorToggled(crate::style::Color),
+    SizeToggled(crate::style::Size),
     DimensionsUpdate(Option<(i32, i32)>),
 }
 
@@ -256,6 +257,29 @@ pub struct SketchBoard {
 }
 
 impl SketchBoard {
+    fn sync_toolbar_style_from_drawable(
+        &mut self,
+        drawable: &dyn crate::tools::Drawable,
+        sender: &ComponentSender<Self>,
+    ) {
+        if let Some(color) = drawable.get_color() {
+            self.style.color = color;
+            sender
+                .output_sender()
+                .emit(SketchBoardOutput::ColorToggled(self.style.color));
+        }
+        if let Some(size) = drawable.get_size() {
+            self.style.size = size;
+            sender
+                .output_sender()
+                .emit(SketchBoardOutput::SizeToggled(self.style.size));
+        }
+        self.style.fill = drawable.get_fill();
+        sender
+            .output_sender()
+            .emit(SketchBoardOutput::FillToggled(self.style.fill));
+    }
+
     fn refresh_screen(&mut self) {
         self.renderer.queue_render();
     }
@@ -800,7 +824,7 @@ impl SketchBoard {
                     self.renderer.get_drawable_bounds(idx),
                 )
             {
-                self.style.fill = drawable.get_fill();
+                self.sync_toolbar_style_from_drawable(drawable.as_ref(), sender);
                 self.renderer.set_hidden_drawable_index(Some(idx));
                 self.pointer_tool
                     .borrow_mut()
@@ -825,10 +849,7 @@ impl SketchBoard {
                 && me.pos.y >= tl.y
                 && me.pos.y <= br.y
             {
-                self.style.fill = drawable.get_fill();
-                sender
-                    .output_sender()
-                    .emit(SketchBoardOutput::FillToggled(self.style.fill));
+                self.sync_toolbar_style_from_drawable(drawable.as_ref(), sender);
                 self.renderer.set_hidden_drawable_index(Some(sel_idx));
                 self.pointer_tool
                     .borrow_mut()
@@ -867,16 +888,7 @@ impl SketchBoard {
                 self.renderer.get_drawable_clone(sel_idx),
                 self.renderer.get_drawable_bounds(sel_idx),
             ) {
-                if let Some(color) = drawable.get_color() {
-                    self.style.color = color;
-                    sender
-                        .output_sender()
-                        .emit(SketchBoardOutput::ColorToggled(self.style.color));
-                }
-                self.style.fill = drawable.get_fill();
-                sender
-                    .output_sender()
-                    .emit(SketchBoardOutput::FillToggled(self.style.fill));
+                self.sync_toolbar_style_from_drawable(drawable.as_ref(), sender);
                 self.renderer.set_hidden_drawable_index(Some(sel_idx));
                 self.pointer_tool
                     .borrow_mut()
@@ -994,6 +1006,26 @@ impl SketchBoard {
                     {
                         drawable.set_color(color);
                         self.renderer.replace_drawable(index, drawable);
+                        result = ToolUpdateResult::Redraw;
+                    }
+                }
+
+                result
+            }
+            ToolbarEvent::SizeSelected(size) => {
+                self.style.size = size;
+                let mut result = self
+                    .active_tool
+                    .borrow_mut()
+                    .handle_event(ToolEvent::StyleChanged(self.style));
+
+                if self.active_tool_type() == Tools::Pointer {
+                    let selected_index = self.pointer_tool.borrow().selected_index();
+                    if let Some(index) = selected_index
+                        && let Some(mut drawable) = self.renderer.get_drawable_clone(index)
+                    {
+                        drawable.set_size(size);
+                        self.renderer.replace_drawable(index, drawable);
                         if let Some(new_bounds) = self.renderer.get_drawable_bounds(index) {
                             self.pointer_tool
                                 .borrow_mut()
@@ -1004,12 +1036,6 @@ impl SketchBoard {
                 }
 
                 result
-            }
-            ToolbarEvent::SizeSelected(size) => {
-                self.style.size = size;
-                self.active_tool
-                    .borrow_mut()
-                    .handle_event(ToolEvent::StyleChanged(self.style))
             }
             ToolbarEvent::SaveFile => self.handle_action(&[Action::SaveToFile]),
             ToolbarEvent::CopyClipboard => self.handle_action(&[Action::SaveToClipboard]),
@@ -1033,11 +1059,6 @@ impl SketchBoard {
                     {
                         drawable.set_fill(!drawable.get_fill());
                         self.renderer.replace_drawable(index, drawable);
-                        if let Some(new_bounds) = self.renderer.get_drawable_bounds(index) {
-                            self.pointer_tool
-                                .borrow_mut()
-                                .set_selection(index, new_bounds);
-                        }
                         result = ToolUpdateResult::Redraw;
                     }
                 }

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1077,7 +1077,9 @@ impl Component for SketchBoard {
                         ToolUpdateResult::StopPropagation
                         | ToolUpdateResult::RedrawAndStopPropagation => active_tool_result,
                         _ => {
-                            if ke.is_one_of(Key::z, KeyMappingId::UsZ)
+                            if ke.key == Key::y && ke.modifier == ModifierType::CONTROL_MASK {
+                                self.handle_redo()
+                            } else if ke.is_one_of(Key::z, KeyMappingId::UsZ)
                                 && ke.modifier == ModifierType::CONTROL_MASK
                             {
                                 self.handle_undo()

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -50,6 +50,7 @@ pub enum SketchBoardOutput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    SizeCycleShortcut,
     DimensionsUpdate(Option<(i32, i32)>),
 }
 
@@ -876,6 +877,8 @@ impl SketchBoard {
                     sender.input(SketchBoardInput::new_text_event(TextEventMsg::Commit(
                         txt.to_string(),
                     )));
+                } else if txt.chars().next().is_some_and(|char| char.eq(&'-')) {
+                    sender.output(SketchBoardOutput::SizeCycleShortcut).ok();
                 } else if let Some(tool) = txt
                     .chars()
                     .next()

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -24,7 +24,7 @@ use crate::ime::pango_adapter::spans_from_pango_attrs;
 use crate::math::Vec2D;
 use crate::notification::log_result;
 use crate::style::Style;
-use crate::tools::{Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
+use crate::tools::{PointerTool, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
 use crate::ui::toolbars::ToolbarEvent;
 use xdg::BaseDirectories;
 
@@ -246,6 +246,7 @@ pub struct SketchBoard {
     renderer: FemtoVGArea,
     active_tool: Rc<RefCell<dyn Tool>>,
     tools: ToolsManager,
+    pointer_tool: Rc<RefCell<PointerTool>>,
     style: Style,
     im_context: gtk::IMMulticontext,
     last_saved_filepath: RefCell<Option<String>>,
@@ -713,6 +714,8 @@ impl SketchBoard {
         if self.active_tool.borrow().active() {
             self.active_tool.borrow_mut().handle_undo()
         } else if self.renderer.undo() {
+            self.renderer.set_hidden_drawable_index(None);
+            self.pointer_tool.borrow_mut().deselect();
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
@@ -723,6 +726,8 @@ impl SketchBoard {
         if self.active_tool.borrow().active() {
             self.active_tool.borrow_mut().handle_redo()
         } else if self.renderer.redo() {
+            self.renderer.set_hidden_drawable_index(None);
+            self.pointer_tool.borrow_mut().deselect();
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
@@ -732,6 +737,8 @@ impl SketchBoard {
     fn handle_reset(&mut self) -> ToolUpdateResult {
         // can't use lazy || here
         if self.deactivate_active_tool() | self.renderer.reset() {
+            self.renderer.set_hidden_drawable_index(None);
+            self.pointer_tool.borrow_mut().deselect();
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
@@ -761,6 +768,56 @@ impl SketchBoard {
         ToolUpdateResult::Unmodified
     }
 
+    /// Pre-processes `BeginDrag` events when the Pointer tool is active.
+    /// Returns `Some(result)` to short-circuit normal tool dispatch, or `None` to fall through.
+    fn handle_pointer_tool_begin_drag(
+        &mut self,
+        me: &crate::sketch_board::MouseEventMsg,
+    ) -> Option<ToolUpdateResult> {
+        use crate::sketch_board::MouseButton;
+        use crate::sketch_board::MouseEventType;
+        if me.type_ != MouseEventType::BeginDrag || me.button == MouseButton::Middle {
+            return None;
+        }
+
+        // Check resize handle first (only when something is already selected)
+        let handle_hit = self.pointer_tool.borrow().hit_test_handle(me.pos);
+        if let Some(handle) = handle_hit {
+            let sel_idx = self.pointer_tool.borrow().selected_index();
+            if let Some(idx) = sel_idx
+                && let (Some(drawable), Some(bounds)) = (
+                    self.renderer.get_drawable_clone(idx),
+                    self.renderer.get_drawable_bounds(idx),
+                )
+            {
+                self.renderer.set_hidden_drawable_index(Some(idx));
+                self.pointer_tool
+                    .borrow_mut()
+                    .begin_resize(idx, drawable, handle, bounds);
+                return Some(ToolUpdateResult::Redraw);
+            }
+        }
+
+        // Check body hit
+        if let Some(idx) = self.renderer.hit_test(me.pos)
+            && let (Some(drawable), Some(bounds)) = (
+                self.renderer.get_drawable_clone(idx),
+                self.renderer.get_drawable_bounds(idx),
+            )
+        {
+            self.renderer.set_hidden_drawable_index(Some(idx));
+            self.pointer_tool
+                .borrow_mut()
+                .begin_move(idx, drawable, bounds);
+            return Some(ToolUpdateResult::Redraw);
+        }
+
+        // Clicked on empty space: deselect
+        self.renderer.set_hidden_drawable_index(None);
+        self.pointer_tool.borrow_mut().deselect();
+        Some(ToolUpdateResult::Redraw)
+    }
+
     fn handle_toolbar_event(
         &mut self,
         toolbar_event: ToolbarEvent,
@@ -774,6 +831,9 @@ impl SketchBoard {
                     old_tool.borrow_mut().handle_event(ToolEvent::Deactivated);
 
                 old_tool.borrow_mut().set_im_context(None);
+
+                // If we were in the pointer tool, ensure the hidden drawable is restored
+                self.renderer.set_hidden_drawable_index(None);
 
                 if let ToolUpdateResult::Commit(d) = deactivate_result {
                     self.renderer.commit(d);
@@ -1165,12 +1225,25 @@ impl Component for SketchBoard {
                                 self.renderer.request_render(&[]);
                                 ToolUpdateResult::Unmodified
                             } else if ke.key == Key::Delete
-                                && ke.modifier.contains(ModifierType::SHIFT_MASK)
                                 && !ke
                                     .modifier
                                     .intersects(ModifierType::CONTROL_MASK | ModifierType::ALT_MASK)
                             {
-                                self.handle_reset()
+                                if ke.modifier.contains(ModifierType::SHIFT_MASK) {
+                                    self.handle_reset()
+                                } else {
+                                    // If the pointer tool has a selection, delete just that item
+                                    let pointer_selection =
+                                        self.pointer_tool.borrow().selected_index();
+                                    if let Some(idx) = pointer_selection {
+                                        self.pointer_tool.borrow_mut().deselect();
+                                        self.renderer.set_hidden_drawable_index(None);
+                                        self.renderer.remove_drawable(idx);
+                                        ToolUpdateResult::Redraw
+                                    } else {
+                                        ToolUpdateResult::Unmodified
+                                    }
+                                }
                             } else if (matches!(ke.key, Key::Escape | Key::Return | Key::KP_Enter)
                                 && ke.modifier.is_empty())
                                 || (ke.key == Key::q && ke.modifier == ModifierType::CONTROL_MASK)
@@ -1193,10 +1266,38 @@ impl Component for SketchBoard {
                     }
                 } else {
                     ie.handle_event_mouse_input(&self.renderer);
-                    let active_tool_result = self
-                        .active_tool
-                        .borrow_mut()
-                        .handle_event(ToolEvent::Input(ie.clone()));
+
+                    // For the pointer tool, intercept BeginDrag to perform hit-testing
+                    // before the event is dispatched to the tool itself.
+                    let pointer_begin_drag_result = if self.active_tool_type() == Tools::Pointer {
+                        if let InputEvent::Mouse(ref me) = ie {
+                            self.handle_pointer_tool_begin_drag(me)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
+                    let active_tool_result = if let Some(r) = pointer_begin_drag_result {
+                        r
+                    } else {
+                        let result = self
+                            .active_tool
+                            .borrow_mut()
+                            .handle_event(ToolEvent::Input(ie.clone()));
+
+                        // After EndDrag for the pointer tool, always restore the hidden drawable.
+                        if self.active_tool_type() == Tools::Pointer
+                            && let InputEvent::Mouse(ref me) = ie
+                            && me.type_ == MouseEventType::EndDrag
+                            && me.button != MouseButton::Middle
+                        {
+                            self.renderer.set_hidden_drawable_index(None);
+                        }
+
+                        result
+                    };
 
                     // eprintln!("active_tool_result={:?}", active_tool_result);
 
@@ -1255,6 +1356,16 @@ impl Component for SketchBoard {
                 }
                 self.refresh_screen();
             }
+            ToolUpdateResult::ReplaceDrawable(index, drawable) => {
+                self.renderer.replace_drawable(index, drawable);
+                // Update the selection overlay bounds to reflect the new position/size.
+                if let Some(new_bounds) = self.renderer.get_drawable_bounds(index) {
+                    self.pointer_tool
+                        .borrow_mut()
+                        .set_selection(index, new_bounds);
+                }
+                self.refresh_screen();
+            }
             ToolUpdateResult::Unmodified | ToolUpdateResult::StopPropagation => (),
             ToolUpdateResult::Redraw | ToolUpdateResult::RedrawAndStopPropagation => {
                 self.refresh_screen()
@@ -1272,10 +1383,13 @@ impl Component for SketchBoard {
 
         let im_context = gtk::IMMulticontext::new();
 
+        let pointer_tool = tools.get_pointer_tool();
+
         let mut model = Self {
             renderer: FemtoVGArea::default(),
             active_tool: tools.get(&config.initial_tool()),
             style: Style::default(),
+            pointer_tool,
             tools,
             im_context,
             last_saved_filepath: RefCell::new(None),

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -52,6 +52,7 @@ pub enum SketchBoardOutput {
     ColorSwitchShortcut(u64),
     SizeCycleShortcut,
     FillToggled(bool),
+    ColorToggled(crate::style::Color),
     DimensionsUpdate(Option<(i32, i32)>),
 }
 
@@ -866,6 +867,12 @@ impl SketchBoard {
                 self.renderer.get_drawable_clone(sel_idx),
                 self.renderer.get_drawable_bounds(sel_idx),
             ) {
+                if let Some(color) = drawable.get_color() {
+                    self.style.color = color;
+                    sender
+                        .output_sender()
+                        .emit(SketchBoardOutput::ColorToggled(self.style.color));
+                }
                 self.style.fill = drawable.get_fill();
                 sender
                     .output_sender()

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -50,6 +50,7 @@ pub enum SketchBoardOutput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    FillToggled(bool),
     DimensionsUpdate(Option<(i32, i32)>),
 }
 
@@ -833,6 +834,9 @@ impl SketchBoard {
             ToolbarEvent::Reset => self.handle_reset(),
             ToolbarEvent::ToggleFill => {
                 self.style.fill = !self.style.fill;
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::FillToggled(self.style.fill));
                 self.active_tool
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))
@@ -876,6 +880,12 @@ impl SketchBoard {
                     sender.input(SketchBoardInput::new_text_event(TextEventMsg::Commit(
                         txt.to_string(),
                     )));
+                } else if txt
+                    .chars()
+                    .next()
+                    .is_some_and(|char| char.eq_ignore_ascii_case(&'f'))
+                {
+                    sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::ToggleFill));
                 } else if let Some(tool) = txt
                     .chars()
                     .next()

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -736,9 +736,15 @@ impl SketchBoard {
 
     fn handle_reset(&mut self) -> ToolUpdateResult {
         // can't use lazy || here
-        if self.deactivate_active_tool() | self.renderer.reset() {
-            self.renderer.set_hidden_drawable_index(None);
-            self.pointer_tool.borrow_mut().deselect();
+        let did_reset = self.deactivate_active_tool() | self.renderer.reset();
+
+        self.renderer.set_hidden_drawable_index(None);
+        self.pointer_tool.borrow_mut().deselect();
+
+        // Reset marker numbering after drawable undo hooks ran.
+        self.tools.get(&Tools::Marker).borrow_mut().handle_reset();
+
+        if did_reset {
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -895,13 +895,9 @@ impl SketchBoard {
                     } else {
                         hotkey_digit - 1
                     };
-                    if APP_CONFIG.read().color_palette().palette().len()
-                        >= (index_digit + 1) as usize
-                    {
-                        sender
-                            .output_sender()
-                            .emit(SketchBoardOutput::ColorSwitchShortcut(index_digit as u64));
-                    }
+                    sender
+                        .output_sender()
+                        .emit(SketchBoardOutput::ColorSwitchShortcut(index_digit as u64));
                 }
             }
             TextEventMsg::Preedit {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1155,15 +1155,14 @@ impl Component for SketchBoard {
                                 ToolUpdateResult::Unmodified
                             } else if ke.modifier.is_empty() && ke.key == Key::Delete {
                                 self.handle_reset()
-                            } else if ke.modifier.is_empty()
-                                && (ke.key == Key::Escape
-                                    || ke.key == Key::Return
-                                    || ke.key == Key::KP_Enter)
+                            } else if (matches!(ke.key, Key::Escape | Key::Return | Key::KP_Enter)
+                                && ke.modifier.is_empty())
+                                || (ke.key == Key::q && ke.modifier == ModifierType::CONTROL_MASK)
                             {
                                 // First, let the tool handle the event. If the tool does nothing, we can do our thing (otherwise require a second keyboard press)
                                 // Relying on ToolUpdateResult::Unmodified is probably not a good idea, but it's the only way at the moment. See discussion in #144
                                 if let ToolUpdateResult::Unmodified = active_tool_result {
-                                    let actions = if ke.key == Key::Escape {
+                                    let actions = if matches!(ke.key, Key::Escape | Key::q) {
                                         APP_CONFIG.read().actions_on_escape()
                                     } else {
                                         APP_CONFIG.read().actions_on_enter()

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -169,6 +169,18 @@ impl Drawable for Arrow {
         }
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        self.style.color = color;
+    }
+
+    fn get_fill(&self) -> bool {
+        self.style.fill
+    }
+
+    fn set_fill(&mut self, fill: bool) {
+        self.style.fill = fill;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -185,6 +185,14 @@ impl Drawable for Arrow {
         self.style.fill = fill;
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        self.style.size = size;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -173,6 +173,10 @@ impl Drawable for Arrow {
         self.style.color = color;
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(self.style.color)
+    }
+
     fn get_fill(&self) -> bool {
         self.style.fill
     }

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -133,6 +133,42 @@ impl Tool for ArrowTool {
 }
 
 impl Drawable for Arrow {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let end = self.end?;
+        Some((
+            Vec2D::new(self.start.x.min(end.x), self.start.y.min(end.y)),
+            Vec2D::new(self.start.x.max(end.x), self.start.y.max(end.y)),
+        ))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.start += delta;
+        if let Some(e) = &mut self.end {
+            *e += delta;
+        }
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        // Preserve the arrow direction by remembering which corner each endpoint was in.
+        // bounds() always returns (min, max), so we detect which corners start/end occupy
+        // and map them into the new bounds accordingly.
+        if let Some(end) = self.end {
+            let start_is_left = self.start.x <= end.x;
+            let start_is_top = self.start.y <= end.y;
+            self.start = Vec2D::new(
+                if start_is_left { tl.x } else { br.x },
+                if start_is_top { tl.y } else { br.y },
+            );
+            self.end = Some(Vec2D::new(
+                if start_is_left { br.x } else { tl.x },
+                if start_is_top { br.y } else { tl.y },
+            ));
+        } else {
+            self.start = tl;
+            self.end = Some(br);
+        }
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -65,6 +65,24 @@ impl Blur {
 }
 
 impl Drawable for Blur {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let size = self.size?;
+        let (tl, size) = crate::math::rect_ensure_positive_size(self.top_left, size);
+        Some((tl, tl + size))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.top_left += delta;
+        // invalidate cached blur image since position changed
+        *self.cached_image.borrow_mut() = None;
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        self.top_left = tl;
+        self.size = Some(br - tl);
+        *self.cached_image.borrow_mut() = None;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -83,6 +83,15 @@ impl Drawable for Blur {
         *self.cached_image.borrow_mut() = None;
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        self.style.size = size;
+        *self.cached_image.borrow_mut() = None;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -37,6 +37,69 @@ impl BrushDrawable {
 }
 
 impl Drawable for BrushDrawable {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let start = self.start_point?;
+        let mut min = start;
+        let mut max = start;
+        for p in self.points.iter().skip(1) {
+            let abs = Vec2D {
+                x: start.x + p.x,
+                y: start.y + p.y,
+            };
+            min.x = min.x.min(abs.x);
+            min.y = min.y.min(abs.y);
+            max.x = max.x.max(abs.x);
+            max.y = max.y.max(abs.y);
+        }
+        Some((min, max))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        if let Some(ref mut sp) = self.start_point {
+            *sp += delta;
+        }
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        // Get current bounds
+        if let Some((current_tl, current_br)) = self.bounds() {
+            let current_size = current_br - current_tl;
+            let new_size = br - tl;
+
+            // Calculate scale factors
+            let scale_x = if current_size.x.abs() > 0.001 {
+                new_size.x / current_size.x
+            } else {
+                1.0
+            };
+            let scale_y = if current_size.y.abs() > 0.001 {
+                new_size.y / current_size.y
+            } else {
+                1.0
+            };
+
+            // Scale all points relative to their current start point
+            if let Some(start) = self.start_point {
+                for p in &mut self.points {
+                    // Convert to absolute coordinates
+                    let abs_p = Vec2D {
+                        x: start.x + p.x,
+                        y: start.y + p.y,
+                    };
+                    // Translate to origin (relative to old top-left)
+                    let rel_p = abs_p - current_tl;
+                    // Scale and update point
+                    *p = Vec2D {
+                        x: rel_p.x * scale_x,
+                        y: rel_p.y * scale_y,
+                    };
+                }
+                // Update start point to new top-left
+                self.start_point = Some(tl);
+            }
+        }
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -108,6 +108,14 @@ impl Drawable for BrushDrawable {
         Some(self.style.color)
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        self.style.size = size;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -104,6 +104,10 @@ impl Drawable for BrushDrawable {
         self.style.color = color;
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(self.style.color)
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -100,6 +100,10 @@ impl Drawable for BrushDrawable {
         }
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        self.style.color = color;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -42,7 +42,7 @@ impl Drawable for Ellipse {
         self.middle = center;
         self.origin = center;
         self.radii = Some(Vec2D::new((br.x - tl.x) / 2.0, (br.y - tl.y) / 2.0));
-        self.centered = true;
+        self.centered = false;
         self.finishing = true;
     }
 

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -62,6 +62,14 @@ impl Drawable for Ellipse {
         self.style.fill = fill;
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        self.style.size = size;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -24,6 +24,28 @@ pub struct Ellipse {
 }
 
 impl Drawable for Ellipse {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let radii = self.radii?;
+        Some((
+            Vec2D::new(self.middle.x - radii.x.abs(), self.middle.y - radii.y.abs()),
+            Vec2D::new(self.middle.x + radii.x.abs(), self.middle.y + radii.y.abs()),
+        ))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.middle += delta;
+        self.origin += delta;
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        let center = Vec2D::new((tl.x + br.x) / 2.0, (tl.y + br.y) / 2.0);
+        self.middle = center;
+        self.origin = center;
+        self.radii = Some(Vec2D::new((br.x - tl.x) / 2.0, (br.y - tl.y) / 2.0));
+        self.centered = true;
+        self.finishing = true;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -50,6 +50,10 @@ impl Drawable for Ellipse {
         self.style.color = color;
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(self.style.color)
+    }
+
     fn get_fill(&self) -> bool {
         self.style.fill
     }

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -46,6 +46,18 @@ impl Drawable for Ellipse {
         self.finishing = true;
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        self.style.color = color;
+    }
+
+    fn get_fill(&self) -> bool {
+        self.style.fill
+    }
+
+    fn set_fill(&mut self, fill: bool) {
+        self.style.fill = fill;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -188,6 +188,113 @@ pub struct HighlightTool {
 }
 
 impl Drawable for HighlightKind {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        match self {
+            HighlightKind::Block(h) => {
+                let size = h.data.size?;
+                let (tl, size) = math::rect_ensure_positive_size(h.data.top_left, size);
+                Some((tl, tl + size))
+            }
+            HighlightKind::Freehand(h) => {
+                let mut min_x = f32::MAX;
+                let mut min_y = f32::MAX;
+                let mut max_x = f32::MIN;
+                let mut max_y = f32::MIN;
+                let first = h.data.points.first()?;
+                for (i, p) in h.data.points.iter().enumerate() {
+                    // First point is absolute, subsequent points are stored as offsets.
+                    let abs = if i == 0 { *p } else { *first + *p };
+                    min_x = min_x.min(abs.x);
+                    min_y = min_y.min(abs.y);
+                    max_x = max_x.max(abs.x);
+                    max_y = max_y.max(abs.y);
+                }
+                Some((Vec2D::new(min_x, min_y), Vec2D::new(max_x, max_y)))
+            }
+        }
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        match self {
+            HighlightKind::Block(h) => {
+                h.data.top_left += delta;
+            }
+            HighlightKind::Freehand(h) => {
+                if let Some(first) = h.data.points.first_mut() {
+                    *first += delta;
+                }
+            }
+        }
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        match self {
+            HighlightKind::Block(h) => {
+                h.data.top_left = tl;
+                h.data.size = Some(br - tl);
+            }
+            HighlightKind::Freehand(h) => {
+                // Resize freehand by scaling all points from current bounds to new bounds.
+                if h.data.points.is_empty() {
+                    return;
+                }
+
+                let first_abs = h.data.points[0];
+                let mut min_x = f32::MAX;
+                let mut min_y = f32::MAX;
+                let mut max_x = f32::MIN;
+                let mut max_y = f32::MIN;
+                for (i, point) in h.data.points.iter().enumerate() {
+                    let abs = if i == 0 { *point } else { first_abs + *point };
+                    min_x = min_x.min(abs.x);
+                    min_y = min_y.min(abs.y);
+                    max_x = max_x.max(abs.x);
+                    max_y = max_y.max(abs.y);
+                }
+
+                let current_tl = Vec2D::new(min_x, min_y);
+                let current_br = Vec2D::new(max_x, max_y);
+
+                let current_size = current_br - current_tl;
+                let new_size = br - tl;
+
+                let scale_x = if current_size.x.abs() > f32::EPSILON {
+                    new_size.x / current_size.x
+                } else {
+                    1.0
+                };
+                let scale_y = if current_size.y.abs() > f32::EPSILON {
+                    new_size.y / current_size.y
+                } else {
+                    1.0
+                };
+
+                let mut transformed_abs_points = Vec::with_capacity(h.data.points.len());
+
+                for (i, point) in h.data.points.iter().enumerate() {
+                    let abs = if i == 0 { *point } else { first_abs + *point };
+                    let relative = abs - current_tl;
+                    transformed_abs_points.push(Vec2D::new(
+                        tl.x + relative.x * scale_x,
+                        tl.y + relative.y * scale_y,
+                    ));
+                }
+
+                let new_first_abs = transformed_abs_points[0];
+                h.data.points[0] = new_first_abs;
+                for (target, abs) in h
+                    .data
+                    .points
+                    .iter_mut()
+                    .skip(1)
+                    .zip(transformed_abs_points.iter().skip(1))
+                {
+                    *target = *abs - new_first_abs;
+                }
+            }
+        }
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -302,6 +302,13 @@ impl Drawable for HighlightKind {
         }
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(match self {
+            HighlightKind::Block(h) => h.style.color,
+            HighlightKind::Freehand(h) => h.style.color,
+        })
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -309,6 +309,20 @@ impl Drawable for HighlightKind {
         })
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(match self {
+            HighlightKind::Block(h) => h.style.size,
+            HighlightKind::Freehand(h) => h.style.size,
+        })
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        match self {
+            HighlightKind::Block(h) => h.style.size = size,
+            HighlightKind::Freehand(h) => h.style.size = size,
+        }
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -41,8 +41,11 @@ impl From<command_line::Highlighters> for Highlighters {
 
 #[derive(Clone, Debug)]
 struct BlockHighlight {
+    origin: Vec2D,
     top_left: Vec2D,
     size: Option<Vec2D>,
+    centered: bool,
+    finishing: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -106,6 +109,15 @@ impl Highlight for Highlighter<BlockHighlight> {
 
         let (pos, size) = math::rect_ensure_positive_size(self.data.top_left, size);
 
+        if !self.data.finishing && self.data.centered {
+            let mut helpers = Path::new();
+            helpers.circle(self.data.origin.x, self.data.origin.y, 2.0);
+            canvas.stroke_path(
+                &helpers,
+                &femtovg::Paint::color(femtovg::Color::rgba(128, 128, 128, 255)),
+            );
+        }
+
         let mut shadow_path = Path::new();
         shadow_path.rounded_rect(
             pos.x,
@@ -124,6 +136,40 @@ impl Highlight for Highlighter<BlockHighlight> {
 
         canvas.fill_path(&shadow_path, &shadow_paint);
         Ok(())
+    }
+}
+
+impl BlockHighlight {
+    fn calculate_shape(&mut self, pos: Vec2D, modifier: ModifierType) {
+        self.centered = modifier & ModifierType::ALT_MASK == ModifierType::ALT_MASK;
+        match modifier & (ModifierType::ALT_MASK | ModifierType::SHIFT_MASK) {
+            v if v == ModifierType::ALT_MASK | ModifierType::SHIFT_MASK => {
+                let max_size = pos.x.abs().max(pos.y.abs());
+                self.top_left.x = self.origin.x - max_size * pos.x.signum() / 2.0;
+                self.top_left.y = self.origin.y - max_size * pos.y.signum() / 2.0;
+                self.size = Some(Vec2D {
+                    x: max_size * pos.x.signum(),
+                    y: max_size * pos.y.signum(),
+                });
+            }
+            ModifierType::ALT_MASK => {
+                self.top_left.x = self.origin.x - pos.x / 2.0;
+                self.top_left.y = self.origin.y - pos.y / 2.0;
+                self.size = Some(pos);
+            }
+            ModifierType::SHIFT_MASK => {
+                self.top_left = self.origin;
+                let max_size = pos.x.abs().max(pos.y.abs());
+                self.size = Some(Vec2D {
+                    x: max_size * pos.x.signum(),
+                    y: max_size * pos.y.signum(),
+                });
+            }
+            _ => {
+                self.top_left = self.origin;
+                self.size = Some(pos);
+            }
+        }
     }
 }
 
@@ -188,8 +234,11 @@ impl Tool for HighlightTool {
                         self.highlighter =
                             Some(HighlightKind::Block(Highlighter::<BlockHighlight> {
                                 data: BlockHighlight {
+                                    origin: event.pos,
                                     top_left: event.pos,
                                     size: None,
+                                    centered: false,
+                                    finishing: false,
                                 },
                                 style: self.style,
                             }))
@@ -224,15 +273,7 @@ impl Tool for HighlightTool {
                     HighlightKind::Block(highlighter) => {
                         // When shift is pressed when using the block highlighter, it transforms
                         // the area into a perfect square (in the direction they intended).
-                        if shift_pressed {
-                            let max_size = event.pos.x.abs().max(event.pos.y.abs());
-                            highlighter.data.size = Some(Vec2D {
-                                x: max_size * event.pos.x.signum(),
-                                y: max_size * event.pos.y.signum(),
-                            });
-                        } else {
-                            highlighter.data.size = Some(event.pos);
-                        };
+                        highlighter.data.calculate_shape(event.pos, event.modifier);
                         ToolUpdateResult::Redraw
                     }
                     HighlightKind::Freehand(highlighter) => {
@@ -283,9 +324,15 @@ impl Tool for HighlightTool {
                         ToolUpdateResult::Redraw
                     }
                 };
+
                 if event.type_ == MouseEventType::UpdateDrag {
                     return update;
-                };
+                }
+
+                if let HighlightKind::Block(highlighter) = &mut *highlighter_kind {
+                    highlighter.data.finishing = true;
+                }
+
                 let result = highlighter_kind.clone_box();
                 self.highlighter = None;
                 ToolUpdateResult::Commit(result)

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -295,6 +295,13 @@ impl Drawable for HighlightKind {
         }
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        match self {
+            HighlightKind::Block(h) => h.style.color = color,
+            HighlightKind::Freehand(h) => h.style.color = color,
+        }
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -68,6 +68,10 @@ impl Drawable for Line {
         self.style.color = color;
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(self.style.color)
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -64,6 +64,10 @@ impl Drawable for Line {
         }
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        self.style.color = color;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -29,6 +29,41 @@ pub struct Line {
 }
 
 impl Drawable for Line {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let dir = self.direction?;
+        let end = self.start + dir;
+        Some((
+            Vec2D::new(self.start.x.min(end.x), self.start.y.min(end.y)),
+            Vec2D::new(self.start.x.max(end.x), self.start.y.max(end.y)),
+        ))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.start += delta;
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        if let Some(direction) = self.direction {
+            let end = self.start + direction;
+            let start_is_left = self.start.x <= end.x;
+            let start_is_top = self.start.y <= end.y;
+            let new_start = Vec2D::new(
+                if start_is_left { tl.x } else { br.x },
+                if start_is_top { tl.y } else { br.y },
+            );
+            let new_end = Vec2D::new(
+                if start_is_left { br.x } else { tl.x },
+                if start_is_top { br.y } else { tl.y },
+            );
+
+            self.start = new_start;
+            self.direction = Some(new_end - new_start);
+        } else {
+            self.start = tl;
+            self.direction = Some(br - tl);
+        }
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -72,6 +72,14 @@ impl Drawable for Line {
         Some(self.style.color)
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        self.style.size = size;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -45,6 +45,10 @@ impl Drawable for Marker {
         self.style.color = color;
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(self.style.color)
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -41,6 +41,10 @@ impl Drawable for Marker {
         self.pos += delta;
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        self.style.color = color;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -145,6 +145,10 @@ impl Tool for MarkerTool {
         ToolUpdateResult::Unmodified
     }
 
+    fn handle_reset(&mut self) {
+        *self.next_number.borrow_mut() = 1;
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::Click => {

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -49,6 +49,25 @@ impl Drawable for Marker {
         Some(self.style.color)
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        self.style.size = size;
+
+        // Keep bounds in sync before the next draw call by updating the cached radius.
+        let font_size = self
+            .style
+            .size
+            .to_text_size(self.style.annotation_size_factor) as f32;
+        let digit_count = self.number.to_string().chars().count().max(1) as f32;
+        let approx_text_width = font_size * 0.6 * digit_count;
+        let approx_radius =
+            (approx_text_width * approx_text_width + font_size * font_size).sqrt() * 0.8;
+        self.radius.set(approx_radius);
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::f64::consts::PI;
 use std::rc::Rc;
 
@@ -23,10 +23,24 @@ pub struct Marker {
     pos: Vec2D,
     number: u16,
     style: Style,
+    /// Exact circle radius cached from the last draw call. Starts as a font-size placeholder.
+    radius: Cell<f32>,
     tool_next_number: Rc<RefCell<u16>>,
 }
 
 impl Drawable for Marker {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let r = self.radius.get();
+        Some((
+            Vec2D::new(self.pos.x - r, self.pos.y - r),
+            Vec2D::new(self.pos.x + r, self.pos.y + r),
+        ))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.pos += delta;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
@@ -89,6 +103,9 @@ impl Drawable for Marker {
                 * 2.0,
         );
 
+        self.radius
+            .set(circle_radius + self.style.annotation_size_factor);
+
         canvas.save();
         canvas.fill_path(&inner_circle_path, &circle_paint);
         canvas.stroke_path(&outer_circle_path, &circle_paint);
@@ -132,10 +149,16 @@ impl Tool for MarkerTool {
         match event.type_ {
             MouseEventType::Click => {
                 if event.button == MouseButton::Primary {
+                    let font_size = self
+                        .style
+                        .size
+                        .to_text_size(self.style.annotation_size_factor)
+                        as f32;
                     let marker = Marker {
                         pos: event.pos,
                         number: *self.next_number.borrow(),
                         style: self.style,
+                        radius: Cell::new(font_size),
                         tool_next_number: self.next_number.clone(),
                     };
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -166,6 +166,11 @@ pub trait Drawable: DrawableClone + Debug {
     fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
         let _ = (tl, br);
     }
+    /// Returns position, text content and style if this drawable is an editable text, for
+    /// re-opening it in the text tool. Returns None for all other drawable types.
+    fn edit_info(&self) -> Option<(Vec2D, String, crate::style::Style)> {
+        None
+    }
 }
 
 #[derive(Debug)]
@@ -247,6 +252,7 @@ pub struct ToolsManager {
     tools: HashMap<Tools, Rc<RefCell<dyn Tool>>>,
     crop_tool: Rc<RefCell<CropTool>>,
     pointer_tool: Rc<RefCell<PointerTool>>,
+    text_tool: Rc<RefCell<TextTool>>,
 }
 
 impl ToolsManager {
@@ -263,7 +269,8 @@ impl ToolsManager {
             Tools::Ellipse,
             Rc::new(RefCell::new(EllipseTool::default())),
         );
-        tools.insert(Tools::Text, Rc::new(RefCell::new(TextTool::default())));
+        let text_tool = Rc::new(RefCell::new(TextTool::default()));
+        tools.insert(Tools::Text, text_tool.clone());
         tools.insert(Tools::Blur, Rc::new(RefCell::new(BlurTool::default())));
         tools.insert(
             Tools::Highlight,
@@ -276,6 +283,7 @@ impl ToolsManager {
         let pointer_tool = Rc::new(RefCell::new(PointerTool::default()));
         Self {
             tools,
+            text_tool,
             crop_tool,
             pointer_tool,
         }
@@ -301,6 +309,10 @@ impl ToolsManager {
 
     pub fn get_pointer_tool(&self) -> Rc<RefCell<PointerTool>> {
         self.pointer_tool.clone()
+    }
+
+    pub fn get_text_tool(&self) -> Rc<RefCell<TextTool>> {
+        self.text_tool.clone()
     }
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -187,6 +187,14 @@ pub trait Drawable: DrawableClone + Debug {
 
     /// Updates only the drawable fill flag when supported. No-op for unsupported drawables.
     fn set_fill(&mut self, _fill: bool) {}
+
+    /// Returns the drawable size when supported.
+    fn get_size(&self) -> Option<crate::style::Size> {
+        None
+    }
+
+    /// Updates only the drawable size when supported. No-op for unsupported drawables.
+    fn set_size(&mut self, _size: crate::style::Size) {}
 }
 
 #[derive(Debug)]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -175,6 +175,11 @@ pub trait Drawable: DrawableClone + Debug {
     /// Updates only the drawable color when supported. No-op for unsupported drawables.
     fn set_color(&mut self, _color: crate::style::Color) {}
 
+    /// Returns the drawable color when supported.
+    fn get_color(&self) -> Option<crate::style::Color> {
+        None
+    }
+
     /// Returns whether the drawable is filled when supported. Returns false for unsupported drawables.
     fn get_fill(&self) -> bool {
         false

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -115,6 +115,10 @@ pub trait Tool {
         ToolUpdateResult::Unmodified
     }
 
+    fn handle_reset(&mut self) {
+        // override if your tool needs to reset a internal state, e.g. the next marker number for the marker tool
+    }
+
     fn set_im_context(&mut self, _context: Option<InputContext>) {}
 
     fn get_drawable(&self) -> Option<&dyn Drawable>;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -171,6 +171,17 @@ pub trait Drawable: DrawableClone + Debug {
     fn edit_info(&self) -> Option<(Vec2D, String, crate::style::Style)> {
         None
     }
+
+    /// Updates only the drawable color when supported. No-op for unsupported drawables.
+    fn set_color(&mut self, _color: crate::style::Color) {}
+
+    /// Returns whether the drawable is filled when supported. Returns false for unsupported drawables.
+    fn get_fill(&self) -> bool {
+        false
+    }
+
+    /// Updates only the drawable fill flag when supported. No-op for unsupported drawables.
+    fn set_fill(&mut self, _fill: bool) {}
 }
 
 #[derive(Debug)]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -150,11 +150,24 @@ pub trait Drawable: DrawableClone + Debug {
     -> Result<()>;
     fn handle_undo(&mut self) {}
     fn handle_redo(&mut self) {}
+    /// Returns the bounding box (top-left, bottom-right) in image coordinates, if supported.
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        None
+    }
+    /// Translates the drawable by the given delta (in image coordinates).
+    fn translate(&mut self, delta: Vec2D) {
+        let _ = delta;
+    }
+    /// Resizes the drawable to fit the new bounding box defined by top-left and bottom-right.
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        let _ = (tl, br);
+    }
 }
 
 #[derive(Debug)]
 pub enum ToolUpdateResult {
     Commit(Box<dyn Drawable>),
+    ReplaceDrawable(usize, Box<dyn Drawable>),
     Redraw,
     Unmodified,
     StopPropagation,
@@ -167,10 +180,11 @@ pub use crop::CropTool;
 pub use ellipse::EllipseTool;
 pub use highlight::{HighlightTool, Highlighters};
 pub use line::LineTool;
+pub use pointer::PointerTool;
 pub use rectangle::RectangleTool;
 pub use text::TextTool;
 
-use self::{brush::BrushTool, marker::MarkerTool, pointer::PointerTool};
+use self::{brush::BrushTool, marker::MarkerTool};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -228,16 +242,13 @@ impl Display for Tools {
 pub struct ToolsManager {
     tools: HashMap<Tools, Rc<RefCell<dyn Tool>>>,
     crop_tool: Rc<RefCell<CropTool>>,
+    pointer_tool: Rc<RefCell<PointerTool>>,
 }
 
 impl ToolsManager {
     pub fn new() -> Self {
         let mut tools: HashMap<Tools, Rc<RefCell<dyn Tool>>> = HashMap::new();
         //tools.insert(Tools::Crop, Rc::new(RefCell::new(CropTool::default())));
-        tools.insert(
-            Tools::Pointer,
-            Rc::new(RefCell::new(PointerTool::default())),
-        );
         tools.insert(Tools::Line, Rc::new(RefCell::new(LineTool::default())));
         tools.insert(Tools::Arrow, Rc::new(RefCell::new(ArrowTool::default())));
         tools.insert(
@@ -258,17 +269,23 @@ impl ToolsManager {
         tools.insert(Tools::Brush, Rc::new(RefCell::new(BrushTool::default())));
 
         let crop_tool = Rc::new(RefCell::new(CropTool::default()));
-        Self { tools, crop_tool }
+        let pointer_tool = Rc::new(RefCell::new(PointerTool::default()));
+        Self {
+            tools,
+            crop_tool,
+            pointer_tool,
+        }
     }
 
     pub fn get(&self, tool: &Tools) -> Rc<RefCell<dyn Tool>> {
         match tool {
             Tools::Crop => self.crop_tool.clone(),
+            Tools::Pointer => self.pointer_tool.clone(),
             _ => self
                 .tools
                 .get(tool)
                 .unwrap_or_else(|| {
-                    panic!("Did you add the requested too {tool:#?} to the tools HashMap?")
+                    panic!("Did you add the requested to {tool:#?} to the tools HashMap?")
                 })
                 .clone(),
         }
@@ -276,6 +293,10 @@ impl ToolsManager {
 
     pub fn get_crop_tool(&self) -> Rc<RefCell<CropTool>> {
         self.crop_tool.clone()
+    }
+
+    pub fn get_pointer_tool(&self) -> Rc<RefCell<PointerTool>> {
+        self.pointer_tool.clone()
     }
 }
 

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use femtovg::{Color, FontId, Paint, Path};
-use relm4::Sender;
+use relm4::{Sender, gtk::gdk::ModifierType};
 
 use crate::{
     math::Vec2D,
@@ -56,37 +56,94 @@ impl ResizeHandle {
     }
 
     /// Compute new (tl, br) after dragging this handle by `delta`.
-    pub fn apply_delta(&self, tl: Vec2D, br: Vec2D, delta: Vec2D) -> (Vec2D, Vec2D) {
+    pub fn resize(&self, event: MouseEventMsg, tl: Vec2D, br: Vec2D) -> (Vec2D, Vec2D) {
+        let mut delta = event.pos;
+
+        if event.modifier & ModifierType::SHIFT_MASK != ModifierType::empty() {
+            (delta.x, delta.y) = match self {
+                ResizeHandle::TopRight => {
+                    let x = delta.x.max(-delta.y);
+                    (x, -x)
+                }
+                ResizeHandle::BottomRight => {
+                    let x = delta.x.max(delta.y);
+                    (x, x)
+                }
+                ResizeHandle::BottomLeft => {
+                    let x = delta.x.min(-delta.y);
+                    (x, -x)
+                }
+                ResizeHandle::TopLeft => {
+                    let x = delta.x.min(delta.y);
+                    (x, x)
+                }
+                _ => (delta.x, delta.y),
+            };
+        }
+
+        let is_centered = event.modifier & ModifierType::ALT_MASK != ModifierType::empty();
+        if is_centered {
+            delta = delta / 2.0;
+        }
+
         let mut new_tl = tl;
         let mut new_br = br;
+
         match self {
-            ResizeHandle::TopLeft => {
-                new_tl += delta;
-            }
-            ResizeHandle::TopCenter => {
-                new_tl.y += delta.y;
-            }
             ResizeHandle::TopRight => {
                 new_tl.y += delta.y;
                 new_br.x += delta.x;
-            }
-            ResizeHandle::MiddleLeft => {
-                new_tl.x += delta.x;
+                if is_centered {
+                    new_tl.x -= delta.x;
+                    new_br.y -= delta.y;
+                }
             }
             ResizeHandle::MiddleRight => {
                 new_br.x += delta.x;
+                if is_centered {
+                    new_tl.x -= delta.x;
+                }
+            }
+            ResizeHandle::BottomRight => {
+                new_br += delta;
+                if is_centered {
+                    new_tl -= delta;
+                }
+            }
+            ResizeHandle::BottomCenter => {
+                new_br.y += delta.y;
+                if is_centered {
+                    new_tl.y -= delta.y;
+                }
             }
             ResizeHandle::BottomLeft => {
                 new_tl.x += delta.x;
                 new_br.y += delta.y;
+                if is_centered {
+                    new_tl.y -= delta.y;
+                    new_br.x -= delta.x;
+                }
             }
-            ResizeHandle::BottomCenter => {
-                new_br.y += delta.y;
+            ResizeHandle::MiddleLeft => {
+                new_tl.x += delta.x;
+                if is_centered {
+                    new_br.x -= delta.x;
+                }
             }
-            ResizeHandle::BottomRight => {
-                new_br += delta;
+            ResizeHandle::TopCenter => {
+                new_tl.y += delta.y;
+                if is_centered {
+                    new_br.y -= delta.y;
+                }
+            }
+            ResizeHandle::TopLeft => {
+                new_tl += delta;
+                if is_centered {
+                    new_br -= delta;
+                }
             }
         }
+
         (new_tl, new_br)
     }
 }
@@ -323,8 +380,7 @@ impl Tool for PointerTool {
                     orig_bounds,
                     ..
                 } => {
-                    let delta = event.pos;
-                    let (new_tl, new_br) = handle.apply_delta(orig_bounds.0, orig_bounds.1, delta);
+                    let (new_tl, new_br) = handle.resize(event, orig_bounds.0, orig_bounds.1);
                     let mut preview = original.clone_box();
                     preview.resize_bounds(new_tl, new_br);
                     self.selected_bounds = Some((new_tl, new_br));
@@ -382,7 +438,7 @@ impl Tool for PointerTool {
                             ToolUpdateResult::Redraw
                         } else {
                             let (new_tl, new_br) =
-                                handle.apply_delta(orig_bounds.0, orig_bounds.1, delta);
+                                handle.resize(event, orig_bounds.0, orig_bounds.1);
                             let mut final_drawable = original;
                             final_drawable.resize_bounds(new_tl, new_br);
                             self.selected_bounds = Some((new_tl, new_br));

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -1,20 +1,286 @@
-use super::{Tool, Tools};
-use crate::sketch_board::SketchBoardInput;
+use anyhow::Result;
+use femtovg::{Color, FontId, Paint, Path};
 use relm4::Sender;
 
-#[derive(Default)]
+use crate::{
+    math::Vec2D,
+    sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
+};
+
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
+
+/// Size of each resize handle in image-space pixels.
+const HANDLE_SIZE: f32 = 8.0;
+const HANDLE_HALF: f32 = HANDLE_SIZE / 2.0;
+const SELECTION_BORDER_OUTSET: f32 = 2.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ResizeHandle {
+    TopLeft,
+    TopCenter,
+    TopRight,
+    MiddleLeft,
+    MiddleRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+}
+
+impl ResizeHandle {
+    pub fn all() -> [ResizeHandle; 8] {
+        [
+            ResizeHandle::TopLeft,
+            ResizeHandle::TopCenter,
+            ResizeHandle::TopRight,
+            ResizeHandle::MiddleLeft,
+            ResizeHandle::MiddleRight,
+            ResizeHandle::BottomLeft,
+            ResizeHandle::BottomCenter,
+            ResizeHandle::BottomRight,
+        ]
+    }
+
+    pub fn center(&self, tl: Vec2D, br: Vec2D) -> Vec2D {
+        let mx = (tl.x + br.x) / 2.0;
+        let my = (tl.y + br.y) / 2.0;
+        match self {
+            ResizeHandle::TopLeft => tl,
+            ResizeHandle::TopCenter => Vec2D::new(mx, tl.y),
+            ResizeHandle::TopRight => Vec2D::new(br.x, tl.y),
+            ResizeHandle::MiddleLeft => Vec2D::new(tl.x, my),
+            ResizeHandle::MiddleRight => Vec2D::new(br.x, my),
+            ResizeHandle::BottomLeft => Vec2D::new(tl.x, br.y),
+            ResizeHandle::BottomCenter => Vec2D::new(mx, br.y),
+            ResizeHandle::BottomRight => br,
+        }
+    }
+
+    /// Compute new (tl, br) after dragging this handle by `delta`.
+    pub fn apply_delta(&self, tl: Vec2D, br: Vec2D, delta: Vec2D) -> (Vec2D, Vec2D) {
+        let mut new_tl = tl;
+        let mut new_br = br;
+        match self {
+            ResizeHandle::TopLeft => {
+                new_tl += delta;
+            }
+            ResizeHandle::TopCenter => {
+                new_tl.y += delta.y;
+            }
+            ResizeHandle::TopRight => {
+                new_tl.y += delta.y;
+                new_br.x += delta.x;
+            }
+            ResizeHandle::MiddleLeft => {
+                new_tl.x += delta.x;
+            }
+            ResizeHandle::MiddleRight => {
+                new_br.x += delta.x;
+            }
+            ResizeHandle::BottomLeft => {
+                new_tl.x += delta.x;
+                new_br.y += delta.y;
+            }
+            ResizeHandle::BottomCenter => {
+                new_br.y += delta.y;
+            }
+            ResizeHandle::BottomRight => {
+                new_br += delta;
+            }
+        }
+        (new_tl, new_br)
+    }
+}
+
+/// Returns the handle under `pos`, if any, given bounds `(tl, br)`.
+pub fn hit_handle(pos: Vec2D, tl: Vec2D, br: Vec2D) -> Option<ResizeHandle> {
+    for h in ResizeHandle::all() {
+        let c = h.center(tl, br);
+        if (pos.x - c.x).abs() <= HANDLE_HALF && (pos.y - c.y).abs() <= HANDLE_HALF {
+            return Some(h);
+        }
+    }
+    None
+}
+
+/// Draws a selection rectangle with 8 resize handles on top of the selected drawable.
+#[derive(Clone, Debug)]
+struct SelectionOverlay {
+    tl: Vec2D,
+    br: Vec2D,
+}
+
+impl Drawable for SelectionOverlay {
+    fn draw(
+        &self,
+        canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+        _font: FontId,
+        _bounds: (Vec2D, Vec2D),
+    ) -> Result<()> {
+        canvas.save();
+
+        let w = self.br.x - self.tl.x;
+        let h = self.br.y - self.tl.y;
+
+        // Selection rectangle
+        let border_tl = Vec2D::new(
+            self.tl.x - SELECTION_BORDER_OUTSET,
+            self.tl.y - SELECTION_BORDER_OUTSET,
+        );
+        let border_w = w + 2.0 * SELECTION_BORDER_OUTSET;
+        let border_h = h + 2.0 * SELECTION_BORDER_OUTSET;
+
+        let mut rect = Path::new();
+        rect.rect(border_tl.x, border_tl.y, border_w, border_h);
+        canvas.stroke_path(
+            &rect,
+            &Paint::color(Color::rgba(70, 130, 180, 220)).with_line_width(1.5),
+        );
+
+        // Resize handles
+        for handle in ResizeHandle::all() {
+            let c = handle.center(self.tl, self.br);
+            let mut hpath = Path::new();
+            hpath.rect(
+                c.x - HANDLE_HALF,
+                c.y - HANDLE_HALF,
+                HANDLE_SIZE,
+                HANDLE_SIZE,
+            );
+            canvas.fill_path(&hpath, &Paint::color(Color::rgba(255, 255, 255, 255)));
+            canvas.stroke_path(
+                &hpath,
+                &Paint::color(Color::rgba(70, 130, 180, 255)).with_line_width(1.5),
+            );
+        }
+
+        canvas.restore();
+        Ok(())
+    }
+}
+
+enum DragState {
+    None,
+    Moving {
+        index: usize,
+        original: Box<dyn Drawable>,
+        orig_bounds: (Vec2D, Vec2D),
+    },
+    Resizing {
+        index: usize,
+        original: Box<dyn Drawable>,
+        handle: ResizeHandle,
+        orig_bounds: (Vec2D, Vec2D),
+    },
+}
+
 pub struct PointerTool {
     input_enabled: bool,
     sender: Option<Sender<SketchBoardInput>>,
+    selected_index: Option<usize>,
+    selected_bounds: Option<(Vec2D, Vec2D)>,
+    drag_state: DragState,
+    /// Shown as the active-tool drawable: either a moved/resized preview, or a selection overlay.
+    preview: Option<Box<dyn Drawable>>,
+    selection_overlay: Option<SelectionOverlay>,
+}
+
+impl Default for PointerTool {
+    fn default() -> Self {
+        Self {
+            input_enabled: false,
+            sender: None,
+            selected_index: None,
+            selected_bounds: None,
+            drag_state: DragState::None,
+            preview: None,
+            selection_overlay: None,
+        }
+    }
+}
+
+impl PointerTool {
+    pub fn selected_index(&self) -> Option<usize> {
+        self.selected_index
+    }
+
+    /// Returns the handle under `pos` given the current selection bounds.
+    pub fn hit_test_handle(&self, pos: Vec2D) -> Option<ResizeHandle> {
+        self.selected_bounds
+            .and_then(|(tl, br)| hit_handle(pos, tl, br))
+    }
+
+    /// Called by SketchBoard before delivering a BeginDrag event: sets up a move drag.
+    pub fn begin_move(
+        &mut self,
+        index: usize,
+        drawable: Box<dyn Drawable>,
+        orig_bounds: (Vec2D, Vec2D),
+    ) {
+        self.selected_index = Some(index);
+        self.selected_bounds = Some(orig_bounds);
+        self.selection_overlay = None;
+        self.preview = Some(drawable.clone_box());
+        self.drag_state = DragState::Moving {
+            index,
+            original: drawable,
+            orig_bounds,
+        };
+    }
+
+    /// Called by SketchBoard before delivering a BeginDrag event: sets up a resize drag.
+    pub fn begin_resize(
+        &mut self,
+        index: usize,
+        drawable: Box<dyn Drawable>,
+        handle: ResizeHandle,
+        orig_bounds: (Vec2D, Vec2D),
+    ) {
+        self.selected_index = Some(index);
+        self.selected_bounds = Some(orig_bounds);
+        self.selection_overlay = None;
+        self.preview = Some(drawable.clone_box());
+        self.drag_state = DragState::Resizing {
+            index,
+            original: drawable,
+            handle,
+            orig_bounds,
+        };
+    }
+
+    /// Select a drawable without starting a drag (e.g. after a commit/replace).
+    pub fn set_selection(&mut self, index: usize, bounds: (Vec2D, Vec2D)) {
+        self.selected_index = Some(index);
+        self.selected_bounds = Some(bounds);
+        self.selection_overlay = Some(SelectionOverlay {
+            tl: bounds.0,
+            br: bounds.1,
+        });
+        self.drag_state = DragState::None;
+        self.preview = None;
+    }
+
+    pub fn deselect(&mut self) {
+        self.selected_index = None;
+        self.selected_bounds = None;
+        self.selection_overlay = None;
+        self.drag_state = DragState::None;
+        self.preview = None;
+    }
 }
 
 impl Tool for PointerTool {
-    fn get_tool_type(&self) -> super::Tools {
+    fn get_tool_type(&self) -> Tools {
         Tools::Pointer
     }
 
-    fn get_drawable(&self) -> Option<&dyn super::Drawable> {
-        None
+    fn get_drawable(&self) -> Option<&dyn Drawable> {
+        if let Some(p) = &self.preview {
+            Some(p.as_ref())
+        } else if let Some(s) = &self.selection_overlay {
+            Some(s)
+        } else {
+            None
+        }
     }
 
     fn input_enabled(&self) -> bool {
@@ -23,6 +289,117 @@ impl Tool for PointerTool {
 
     fn set_input_enabled(&mut self, value: bool) {
         self.input_enabled = value;
+    }
+
+    fn handle_deactivated(&mut self) -> ToolUpdateResult {
+        self.deselect();
+        ToolUpdateResult::Redraw
+    }
+
+    fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
+        if event.button == MouseButton::Middle {
+            return ToolUpdateResult::Unmodified;
+        }
+
+        // For EndDrag/UpdateDrag, event.pos is the cumulative delta since BeginDrag.
+        match event.type_ {
+            MouseEventType::UpdateDrag => match &self.drag_state {
+                DragState::Moving {
+                    original,
+                    orig_bounds,
+                    ..
+                } => {
+                    let delta = event.pos;
+                    let mut preview = original.clone_box();
+                    preview.translate(delta);
+                    let (tl, br) = *orig_bounds;
+                    self.selected_bounds = Some((tl + delta, br + delta));
+                    self.preview = Some(preview);
+                    ToolUpdateResult::Redraw
+                }
+                DragState::Resizing {
+                    original,
+                    handle,
+                    orig_bounds,
+                    ..
+                } => {
+                    let delta = event.pos;
+                    let (new_tl, new_br) = handle.apply_delta(orig_bounds.0, orig_bounds.1, delta);
+                    let mut preview = original.clone_box();
+                    preview.resize_bounds(new_tl, new_br);
+                    self.selected_bounds = Some((new_tl, new_br));
+                    self.preview = Some(preview);
+                    ToolUpdateResult::Redraw
+                }
+                DragState::None => ToolUpdateResult::Unmodified,
+            },
+
+            MouseEventType::EndDrag => {
+                match std::mem::replace(&mut self.drag_state, DragState::None) {
+                    DragState::Moving {
+                        index,
+                        original,
+                        orig_bounds,
+                    } => {
+                        let delta = event.pos;
+                        if delta.is_zero() {
+                            // Click with no movement: just show selection overlay
+                            self.selected_bounds = Some(orig_bounds);
+                            self.selection_overlay = Some(SelectionOverlay {
+                                tl: orig_bounds.0,
+                                br: orig_bounds.1,
+                            });
+                            self.preview = None;
+                            ToolUpdateResult::Redraw
+                        } else {
+                            let mut final_drawable = original;
+                            final_drawable.translate(delta);
+                            let (tl, br) = orig_bounds;
+                            let new_bounds = (tl + delta, br + delta);
+                            self.selected_bounds = Some(new_bounds);
+                            self.selection_overlay = Some(SelectionOverlay {
+                                tl: new_bounds.0,
+                                br: new_bounds.1,
+                            });
+                            self.preview = None;
+                            ToolUpdateResult::ReplaceDrawable(index, final_drawable)
+                        }
+                    }
+                    DragState::Resizing {
+                        index,
+                        original,
+                        handle,
+                        orig_bounds,
+                    } => {
+                        let delta = event.pos;
+                        if delta.is_zero() {
+                            self.selected_bounds = Some(orig_bounds);
+                            self.selection_overlay = Some(SelectionOverlay {
+                                tl: orig_bounds.0,
+                                br: orig_bounds.1,
+                            });
+                            self.preview = None;
+                            ToolUpdateResult::Redraw
+                        } else {
+                            let (new_tl, new_br) =
+                                handle.apply_delta(orig_bounds.0, orig_bounds.1, delta);
+                            let mut final_drawable = original;
+                            final_drawable.resize_bounds(new_tl, new_br);
+                            self.selected_bounds = Some((new_tl, new_br));
+                            self.selection_overlay = Some(SelectionOverlay {
+                                tl: new_tl,
+                                br: new_br,
+                            });
+                            self.preview = None;
+                            ToolUpdateResult::ReplaceDrawable(index, final_drawable)
+                        }
+                    }
+                    DragState::None => ToolUpdateResult::Unmodified,
+                }
+            }
+
+            _ => ToolUpdateResult::Unmodified,
+        }
     }
 
     fn set_sender(&mut self, sender: Sender<SketchBoardInput>) {

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -239,6 +239,12 @@ pub struct PointerTool {
     /// Shown as the active-tool drawable: either a moved/resized preview, or a selection overlay.
     preview: Option<Box<dyn Drawable>>,
     selection_overlay: Option<SelectionOverlay>,
+    /// For cycling through overlapping objects: last click position
+    last_click_pos: Option<Vec2D>,
+    /// For cycling through overlapping objects: all hit objects at last click position
+    hit_objects_at_pos: Vec<usize>,
+    /// For cycling through overlapping objects: current index in hit_objects list
+    current_cycle_index: usize,
 }
 
 impl Default for PointerTool {
@@ -251,6 +257,9 @@ impl Default for PointerTool {
             drag_state: DragState::None,
             preview: None,
             selection_overlay: None,
+            last_click_pos: None,
+            hit_objects_at_pos: Vec::new(),
+            current_cycle_index: 0,
         }
     }
 }
@@ -322,6 +331,43 @@ impl PointerTool {
         self.selection_overlay = None;
         self.drag_state = DragState::None;
         self.preview = None;
+        // Reset cycling state when deselecting
+        self.last_click_pos = None;
+        self.hit_objects_at_pos.clear();
+        self.current_cycle_index = 0;
+    }
+
+    /// Cycle through overlapping objects at the same position.
+    /// When Alt+Click is used, this method determines which object to select next.
+    /// Returns the next object index to cycle through, or None if no objects are at the position.
+    pub fn cycle_to_next_object(
+        &mut self,
+        click_pos: Vec2D,
+        hit_indices: Vec<usize>,
+    ) -> Option<usize> {
+        if hit_indices.is_empty() {
+            return None;
+        }
+
+        // Check if this is the same position as last click
+        if let Some(last_pos) = self.last_click_pos {
+            if (last_pos.x - click_pos.x).abs() < 0.1 && (last_pos.y - click_pos.y).abs() < 0.1 {
+                // Same position: advance to next object in cycle
+                self.current_cycle_index = (self.current_cycle_index + 1) % hit_indices.len();
+            } else {
+                // Different position: reset cycle
+                self.current_cycle_index = 0;
+            }
+        } else {
+            // First time: reset cycle
+            self.current_cycle_index = 0;
+        }
+
+        // Store position for next cycle check
+        self.last_click_pos = Some(click_pos);
+
+        // Return the object at current cycle index
+        hit_indices.get(self.current_cycle_index).copied()
     }
 }
 

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -56,6 +56,10 @@ impl Drawable for Rectangle {
         self.style.color = color;
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(self.style.color)
+    }
+
     fn get_fill(&self) -> bool {
         self.style.fill
     }

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -68,6 +68,14 @@ impl Drawable for Rectangle {
         self.style.fill = fill;
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        self.style.size = size;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -25,6 +25,33 @@ pub struct Rectangle {
 }
 
 impl Drawable for Rectangle {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let size = self.size?;
+        Some((
+            Vec2D::new(
+                self.top_left.x.min(self.top_left.x + size.x),
+                self.top_left.y.min(self.top_left.y + size.y),
+            ),
+            Vec2D::new(
+                self.top_left.x.max(self.top_left.x + size.x),
+                self.top_left.y.max(self.top_left.y + size.y),
+            ),
+        ))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.top_left += delta;
+        self.origin += delta;
+    }
+
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+        self.top_left = tl;
+        self.size = Some(br - tl);
+        self.origin = tl;
+        self.centered = false;
+        self.finishing = true;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -52,6 +52,18 @@ impl Drawable for Rectangle {
         self.finishing = true;
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        self.style.color = color;
+    }
+
+    fn get_fill(&self) -> bool {
+        self.style.fill
+    }
+
+    fn set_fill(&mut self, fill: bool) {
+        self.style.fill = fill;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -192,6 +192,10 @@ impl Drawable for Text {
         self.style.color = color;
     }
 
+    fn get_color(&self) -> Option<crate::style::Color> {
+        Some(self.style.color)
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use femtovg::{Color, FontId, Paint, Path};
+use relm4::gtk::glib::GString;
 use relm4::gtk::prelude::IMContextExt;
 use relm4::gtk::{
     TextBuffer,
@@ -141,6 +142,14 @@ impl Text {
             }
         }
     }
+
+    fn get_text(&self) -> GString {
+        self.text_buffer.text(
+            &self.text_buffer.start_iter(),
+            &self.text_buffer.end_iter(),
+            false,
+        )
+    }
 }
 
 impl Drawable for Text {
@@ -150,11 +159,7 @@ impl Drawable for Text {
         font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        let gtext = self.text_buffer.text(
-            &self.text_buffer.start_iter(),
-            &self.text_buffer.end_iter(),
-            false,
-        );
+        let gtext = self.get_text();
         let base_text = gtext.as_str();
         let display = self.display_text(base_text);
         let text = display.text.as_ref();
@@ -800,16 +805,25 @@ impl Tool for TextTool {
                         tool_update_result = ToolUpdateResult::RedrawAndStopPropagation;
                     }
                     _ => {
-                        t.preedit = None;
-                        t.editing = false;
-                        t.im_context = None;
-                        t.text_buffer
-                            .select_range(&t.text_buffer.start_iter(), &t.text_buffer.start_iter());
-                        *t.draw_rect.borrow_mut() = false;
-                        let result = t.clone_box();
-                        self.text = None;
-                        self.input_enabled = false;
-                        tool_update_result = ToolUpdateResult::Commit(result);
+                        let content = t.get_text();
+                        if content.is_empty() {
+                            self.text = None;
+                            self.input_enabled = false;
+                            tool_update_result = ToolUpdateResult::RedrawAndStopPropagation;
+                        } else {
+                            t.preedit = None;
+                            t.editing = false;
+                            t.im_context = None;
+                            t.text_buffer.select_range(
+                                &t.text_buffer.start_iter(),
+                                &t.text_buffer.start_iter(),
+                            );
+                            *t.draw_rect.borrow_mut() = false;
+                            let result = t.clone_box();
+                            self.text = None;
+                            self.input_enabled = false;
+                            tool_update_result = ToolUpdateResult::Commit(result);
+                        }
                     }
                 },
                 Key::Escape => {
@@ -1134,15 +1148,20 @@ impl Tool for TextTool {
                         // create commit message if necessary
                         let return_value = match &mut self.text {
                             Some(l) => {
-                                l.preedit = None;
-                                l.editing = false;
-                                l.im_context = None;
-                                l.text_buffer.select_range(
-                                    &l.text_buffer.start_iter(),
-                                    &l.text_buffer.start_iter(),
-                                );
-                                *l.draw_rect.borrow_mut() = false;
-                                ToolUpdateResult::Commit(l.clone_box())
+                                let content = l.get_text();
+                                if content.is_empty() {
+                                    ToolUpdateResult::Unmodified
+                                } else {
+                                    l.preedit = None;
+                                    l.editing = false;
+                                    l.im_context = None;
+                                    l.text_buffer.select_range(
+                                        &l.text_buffer.start_iter(),
+                                        &l.text_buffer.start_iter(),
+                                    );
+                                    *l.draw_rect.borrow_mut() = false;
+                                    ToolUpdateResult::Commit(l.clone_box())
+                                }
                             }
                             None => ToolUpdateResult::Redraw,
                         };
@@ -1274,16 +1293,23 @@ impl Tool for TextTool {
     fn handle_deactivated(&mut self) -> ToolUpdateResult {
         self.input_enabled = false;
         if let Some(t) = &mut self.text {
-            t.preedit = None;
-            t.editing = false;
-            t.im_context = None;
-            t.text_buffer
-                .select_range(&t.text_buffer.start_iter(), &t.text_buffer.start_iter());
-            *t.draw_rect.borrow_mut() = false;
-            let result = t.clone_box();
-            self.text = None;
-            self.input_enabled = false;
-            ToolUpdateResult::Commit(result)
+            let content = t.get_text();
+            if content.is_empty() {
+                // Don't create empty text objects
+                self.text = None;
+                ToolUpdateResult::Unmodified
+            } else {
+                t.preedit = None;
+                t.editing = false;
+                t.im_context = None;
+                t.text_buffer
+                    .select_range(&t.text_buffer.start_iter(), &t.text_buffer.start_iter());
+                *t.draw_rect.borrow_mut() = false;
+                let result = t.clone_box();
+                self.text = None;
+                self.input_enabled = false;
+                ToolUpdateResult::Commit(result)
+            }
         } else {
             ToolUpdateResult::Unmodified
         }
@@ -1431,11 +1457,7 @@ impl TextTool {
                         if has_selection {
                             cursor_itr = end_iter.unwrap();
                         } else {
-                            let content = &text.text_buffer.text(
-                                &text.text_buffer.start_iter(),
-                                &text.text_buffer.end_iter(),
-                                false,
-                            );
+                            let content = &text.get_text();
                             let current_offset = cursor_itr.offset();
 
                             let mut next_line = 0;
@@ -1488,11 +1510,7 @@ impl TextTool {
                         if has_selection {
                             cursor_itr = start_iter.unwrap();
                         } else {
-                            let content = &text.text_buffer.text(
-                                &text.text_buffer.start_iter(),
-                                &text.text_buffer.end_iter(),
-                                false,
-                            );
+                            let content = &text.get_text();
                             let current_offset = cursor_itr.offset();
 
                             let mut last_line = 0;
@@ -1591,11 +1609,7 @@ impl TextTool {
                         }
                     }
                     ActionScope::ForwardLineAndWord => {
-                        let content = &text.text_buffer.text(
-                            &text.text_buffer.start_iter(),
-                            &text.text_buffer.end_iter(),
-                            false,
-                        );
+                        let content = &text.get_text();
                         let current_offset = end_cursor_itr.offset();
 
                         let mut next_line = 0;
@@ -1638,11 +1652,7 @@ impl TextTool {
                         end_cursor_itr.set_offset(move_offset);
                     }
                     ActionScope::BackwardLineAndWord => {
-                        let content = &text.text_buffer.text(
-                            &text.text_buffer.start_iter(),
-                            &text.text_buffer.end_iter(),
-                            false,
-                        );
+                        let content = &text.get_text();
                         let current_offset = end_cursor_itr.offset();
 
                         let mut last_line = 0;

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -153,6 +153,32 @@ impl Text {
 }
 
 impl Drawable for Text {
+    fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
+        let rect = self.rect.borrow();
+        if rect.width() == 0 && rect.height() == 0 {
+            // Not yet drawn; use pos as a small point region
+            return Some((self.pos, self.pos + Vec2D::new(10.0, 10.0)));
+        }
+        Some((
+            Vec2D::new(rect.x() as f32, rect.y() as f32),
+            Vec2D::new(
+                (rect.x() + rect.width()) as f32,
+                (rect.y() + rect.height()) as f32,
+            ),
+        ))
+    }
+
+    fn translate(&mut self, delta: Vec2D) {
+        self.pos += delta;
+        let old = *self.rect.borrow();
+        *self.rect.borrow_mut() = Rectangle::new(
+            old.x() + delta.x as i32,
+            old.y() + delta.y as i32,
+            old.width(),
+            old.height(),
+        );
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -196,6 +196,40 @@ impl Drawable for Text {
         Some(self.style.color)
     }
 
+    fn get_size(&self) -> Option<crate::style::Size> {
+        Some(self.style.size)
+    }
+
+    fn set_size(&mut self, size: crate::style::Size) {
+        let old_font_size = self
+            .style
+            .size
+            .to_text_size(self.style.annotation_size_factor) as f32;
+        self.style.size = size;
+
+        let new_font_size = self
+            .style
+            .size
+            .to_text_size(self.style.annotation_size_factor) as f32;
+
+        if old_font_size > 0.0 {
+            let scale = new_font_size / old_font_size;
+            let old = *self.rect.borrow();
+
+            if old.width() != 0 || old.height() != 0 {
+                let dx = old.x() as f32 - self.pos.x;
+                let dy = old.y() as f32 - self.pos.y;
+
+                *self.rect.borrow_mut() = Rectangle::new(
+                    (self.pos.x + dx * scale).round() as i32,
+                    (self.pos.y + dy * scale).round() as i32,
+                    ((old.width() as f32) * scale).round().max(1.0) as i32,
+                    ((old.height() as f32) * scale).round().max(1.0) as i32,
+                );
+            }
+        }
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -188,6 +188,10 @@ impl Drawable for Text {
         Some((self.pos, content.to_string(), self.style))
     }
 
+    fn set_color(&mut self, color: crate::style::Color) {
+        self.style.color = color;
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -179,6 +179,15 @@ impl Drawable for Text {
         );
     }
 
+    fn edit_info(&self) -> Option<(Vec2D, String, crate::style::Style)> {
+        let content = self.text_buffer.text(
+            &self.text_buffer.start_iter(),
+            &self.text_buffer.end_iter(),
+            false,
+        );
+        Some((self.pos, content.to_string(), self.style))
+    }
+
     fn draw(
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
@@ -736,6 +745,7 @@ pub struct TextTool {
     sender: Option<Sender<SketchBoardInput>>,
     drag_start_pos: Vec2D,
     dragged: Rc<RefCell<bool>>,
+    editing_existing: bool,
 }
 
 impl Tool for TextTool {
@@ -1171,6 +1181,8 @@ impl Tool for TextTool {
                             }
                         }
 
+                        let editing_existing = self.editing_existing;
+
                         // create commit message if necessary
                         let return_value = match &mut self.text {
                             Some(l) => {
@@ -1192,10 +1204,17 @@ impl Tool for TextTool {
                             None => ToolUpdateResult::Redraw,
                         };
 
-                        // create a new Text
-                        self.text = Some(Text::new(event.pos, self.style, self.im_context.clone()));
-
-                        self.set_input_enabled(true);
+                        if editing_existing {
+                            // Pointer-initiated edit: finish editing and let SketchBoard switch tool.
+                            self.text = None;
+                            self.set_input_enabled(false);
+                            self.editing_existing = false;
+                        } else {
+                            // Native text-tool behavior: commit current text and start a new one.
+                            self.text =
+                                Some(Text::new(event.pos, self.style, self.im_context.clone()));
+                            self.set_input_enabled(true);
+                        }
 
                         return_value
                     }
@@ -1318,6 +1337,7 @@ impl Tool for TextTool {
 
     fn handle_deactivated(&mut self) -> ToolUpdateResult {
         self.input_enabled = false;
+        self.editing_existing = false;
         if let Some(t) = &mut self.text {
             let content = t.get_text();
             if content.is_empty() {
@@ -1757,5 +1777,18 @@ impl TextTool {
                 }
             }
         }
+    }
+
+    /// Pre-populate the tool with an existing text drawable so the user can edit it.
+    /// Call this before switching to the Text tool.
+    pub fn load_for_editing(&mut self, pos: Vec2D, content: &str, style: Style) {
+        let t = Text::new(pos, style, self.im_context.clone());
+        t.text_buffer.insert_at_cursor(content);
+        // Move cursor to end
+        t.text_buffer.place_cursor(&t.text_buffer.end_iter());
+        self.text = Some(t);
+        self.style = style;
+        self.set_input_enabled(true);
+        self.editing_existing = true;
     }
 }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -30,6 +30,7 @@ pub struct StyleToolbar {
     custom_color_pixbuf: Pixbuf,
     color_action: SimpleAction,
     visible: bool,
+    fill_enabled: bool,
     annotation_size: f32,
     annotation_size_formatted: String,
     annotation_dialog_controller: Option<Controller<AnnotationSizeDialog>>,
@@ -71,6 +72,7 @@ pub enum StyleToolbarInput {
     ColorDialogFinished(Option<Color>),
     SetVisibility(bool),
     ToggleVisibility,
+    SetFill(bool),
     ShowAnnotationDialog,
     AnnotationDialogFinished(Option<f32>),
     DimensionsChanged((i32, i32)),
@@ -572,20 +574,15 @@ impl Component for StyleToolbar {
                 set_focusable: false,
                 set_hexpand: false,
 
-                set_icon_name: if APP_CONFIG.read().default_fill_shapes() {
+                #[watch]
+                set_icon_name: if model.fill_enabled {
                     "paint-bucket-filled"
                 } else {
                     "paint-bucket-regular"
                 },
-                set_tooltip: "Fill shape",
-                connect_clicked[sender] => move |button| {
+                set_tooltip: "Fill shape (f)",
+                connect_clicked[sender] => move |_| {
                     sender.output_sender().emit(ToolbarEvent::ToggleFill);
-                    let new_icon = if button.icon_name() == Some("paint-bucket-regular".into()) {
-                        "paint-bucket-filled"
-                    } else {
-                        "paint-bucket-regular"
-                    };
-                    button.set_icon_name(new_icon);
                 },
             },
         },
@@ -637,6 +634,9 @@ impl Component for StyleToolbar {
             StyleToolbarInput::SetVisibility(visible) => self.visible = visible,
             StyleToolbarInput::ToggleVisibility => {
                 self.visible = !self.visible;
+            }
+            StyleToolbarInput::SetFill(fill_enabled) => {
+                self.fill_enabled = fill_enabled;
             }
             StyleToolbarInput::DimensionsChanged((width, height)) => {
                 self.output_dimensions = format!("{}x{}", width, height);
@@ -702,6 +702,7 @@ impl Component for StyleToolbar {
             custom_color_pixbuf,
             color_action: SimpleAction::from(color_action.clone()),
             visible: !APP_CONFIG.read().default_hide_toolbars(),
+            fill_enabled: APP_CONFIG.read().default_fill_shapes(),
             annotation_size: APP_CONFIG.read().annotation_size_factor(),
             annotation_size_formatted: format!(
                 "{0:.2}",

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -73,6 +73,7 @@ pub enum StyleToolbarInput {
     SizeButtonSelected(Size),
     CycleSize,
     SetColor(Color),
+    SetSize(Size),
     ShowColorDialog,
     ColorDialogFinished(Option<Color>),
     SetVisibility(bool),
@@ -637,6 +638,10 @@ impl Component for StyleToolbar {
                 }
 
                 self.color_action.change_state(&palette_match.to_variant());
+            }
+            StyleToolbarInput::SetSize(size) => {
+                self.current_size = size;
+                self.size_action.change_state(&size.to_variant());
             }
 
             StyleToolbarInput::SizeButtonSelected(size) => {

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -30,6 +30,8 @@ pub struct StyleToolbar {
     custom_color_pixbuf: Pixbuf,
     color_action: SimpleAction,
     visible: bool,
+    current_size: Size,
+    size_action: SimpleAction,
     annotation_size: f32,
     annotation_size_formatted: String,
     annotation_dialog_controller: Option<Controller<AnnotationSizeDialog>>,
@@ -67,6 +69,8 @@ pub enum ToolsToolbarInput {
 #[derive(Debug, Copy, Clone)]
 pub enum StyleToolbarInput {
     ColorButtonSelected(ColorButtons),
+    SizeButtonSelected(Size),
+    CycleSize,
     ShowColorDialog,
     ColorDialogFinished(Option<Color>),
     SetVisibility(bool),
@@ -619,6 +623,26 @@ impl Component for StyleToolbar {
                     .emit(ToolbarEvent::ColorSelected(color));
             }
 
+            StyleToolbarInput::SizeButtonSelected(size) => {
+                self.current_size = size;
+                sender
+                    .output_sender()
+                    .emit(ToolbarEvent::SizeSelected(size));
+            }
+
+            StyleToolbarInput::CycleSize => {
+                self.current_size = match self.current_size {
+                    Size::Small => Size::Large,
+                    Size::Medium => Size::Small,
+                    Size::Large => Size::Medium,
+                };
+                self.size_action
+                    .change_state(&self.current_size.to_variant());
+                sender
+                    .output_sender()
+                    .emit(ToolbarEvent::SizeSelected(self.current_size));
+            }
+
             StyleToolbarInput::ShowAnnotationDialog => {
                 self.show_annotation_dialog(sender, root.toplevel_window());
             }
@@ -682,9 +706,7 @@ impl Component for StyleToolbar {
         let size_action: RelmAction<SizeAction> =
             RelmAction::new_stateful_with_target_value(&Size::Medium, move |_, state, value| {
                 *state = value;
-                sender_tmp
-                    .output_sender()
-                    .emit(ToolbarEvent::SizeSelected(*state));
+                sender_tmp.input(StyleToolbarInput::SizeButtonSelected(*state));
             });
 
         let custom_color = APP_CONFIG
@@ -701,6 +723,8 @@ impl Component for StyleToolbar {
             custom_color,
             custom_color_pixbuf,
             color_action: SimpleAction::from(color_action.clone()),
+            current_size: Size::Medium,
+            size_action: SimpleAction::from(size_action.clone()),
             visible: !APP_CONFIG.read().default_hide_toolbars(),
             annotation_size: APP_CONFIG.read().annotation_size_factor(),
             annotation_size_formatted: format!(

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -72,6 +72,7 @@ pub enum StyleToolbarInput {
     ColorButtonSelected(ColorButtons),
     SizeButtonSelected(Size),
     CycleSize,
+    SetColor(Color),
     ShowColorDialog,
     ColorDialogFinished(Option<Color>),
     SetVisibility(bool),
@@ -618,6 +619,24 @@ impl Component for StyleToolbar {
                 sender
                     .output_sender()
                     .emit(ToolbarEvent::ColorSelected(color));
+            }
+            StyleToolbarInput::SetColor(color) => {
+                let palette_match = APP_CONFIG
+                    .read()
+                    .color_palette()
+                    .palette()
+                    .iter()
+                    .position(|&p| p == color)
+                    .map(|index| ColorButtons::Palette(index as u64))
+                    .unwrap_or(ColorButtons::Custom);
+
+                // Only update custom_color if this is not a palette color
+                if matches!(palette_match, ColorButtons::Custom) {
+                    self.custom_color = color;
+                    self.custom_color_pixbuf = create_icon_pixbuf(color);
+                }
+
+                self.color_action.change_state(&palette_match.to_variant());
             }
 
             StyleToolbarInput::SizeButtonSelected(size) => {

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -138,7 +138,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "recycling-bin",
-                set_tooltip: "Reset",
+                set_tooltip: "Reset (Shift+Delete)",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::Reset);},
             },
             gtk::Separator {},


### PR DESCRIPTION
This PR introduces the ability to edit existing annotations in Satty.

It builds on the other PRs I have submitted, even includes them and some other not really related changes which would be in conflict when moved - I am not sure if I should split it up into several PRs or how to proceed ... so this draft PR is for discussion.

I am not deeply into Rust so Copilot was a big help.

Have been using it for a while now without issues.

https://github.com/user-attachments/assets/bb70cdb2-5cda-4bd0-8d3a-f08b9de02cd6

