### PR TITLE
fix: broken icon in scale dialog

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,7 @@ fn main() -> Result<(), io::Error> {
             "paint-bucket-regular",
             "page-fit-regular",
             "resize-large-regular",
+            "arrow-counterclockwise-regular",
         ],
     );
 

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -842,7 +842,7 @@ impl Component for AnnotationSizeDialog {
                     set_hexpand: false,
 
                     set_tooltip: "Reset Annotation Size Factor",
-                    set_icon_name: "edit-reset-symbolic",
+                    set_icon_name: "arrow-counterclockwise-regular",
                     connect_clicked[sender] => move |_| {
                         sender.input(AnnotationSizeDialogInput::Reset);
                     },


### PR DESCRIPTION
Was somewere lost ... or maybe not provided by my Arch system/setup with Hyprland.

<img width="381" height="139" alt="image" src="https://github.com/user-attachments/assets/f090d780-b005-4117-9c60-7fbc488f11f8" />
