### PR TITLE
fix: manpage needs target directory in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ install: target/release/satty
 	install -Dm644 completions/satty.elv $(ELVDIR)/satty.elv
 	install -Dm644 completions/satty.nu $(NUDIR)/satty.nu
 	install -Dm644 completions/satty.ts $(FIGDIR)/satty.ts
-	install -Dm644 man/satty.1 ${PREFIX}/share/man/man1
+	install -Dm644 man/satty.1 -t ${PREFIX}/share/man/man1
 
 uninstall:
 	rm ${BINDIR}/satty


### PR DESCRIPTION
Without the `-t` the last element is not treated as directory. And if `${PREFIX}/share/man/man1` doesn't already exist, `satty.1` is copied to a file named `man1`. This was a copy+paste mistake, the PR fixes this by adding the missing  `-t` argument.