### PR TITLE
fix: release.nu to also replace satty_cli dependency

### DIFF
--- a/release.nu
+++ b/release.nu
@@ -80,6 +80,9 @@ def patch_cargo_toml [version: list<int>] {
     let version_str = $version | str join '.'
     # Update workspace.package.version
     sed -i $"/\\[workspace.package\\]/,/^version =/s/^version = .*/version = \"($version_str)\"/" Cargo.toml
+    open --raw Cargo.toml
+    | str replace --regex '(satty_cli = \{ path = "cli", version = ")[^"]*"' $'${1}($version_str)"'
+    | save -f Cargo.toml
 }
 
 def update_cargo_lock [] {


### PR DESCRIPTION
with working towards #395 (cargo publish), we needed to explicitly add satty_cli's version to main Cargo.toml or cargo publish throws a warning. But we forgot that now this needs to be replaced by release.nu.