### PR TITLE
Add documentation for icon_names module

### DIFF
--- a/src/icons/mod.rs
+++ b/src/icons/mod.rs
@@ -1,3 +1,4 @@
+/// Module containing generated icon name constants for use in the application.
 pub mod icon_names {
     #![allow(dead_code)]
     #![allow(unused_imports)]


### PR DESCRIPTION
## Problem Background
The public module `icon_names` in `src/icons/mod.rs` lacked documentation, making it harder for users to understand its purpose and usage within the Satty application. This could lead to confusion for contributors and users trying to utilize icon name constants.

## Changes Made
- Added a docstring to the `icon_names` module to clearly describe its purpose: "Module containing generated icon name constants for use in the application."

## Verification
- Reviewed the code change to ensure the docstring accurately reflects the module's functionality.
- Built the project to verify no compilation errors were introduced, and the documentation is correctly integrated.