### PR TITLE
feat: span fullscreen="all" across all monitors on Wayland (layer-shell)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
@@ -141,7 +141,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -333,7 +333,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b96028ce3ff03972312fd8243281858e80fc0f9838b1f035676b6c199214d9e"
 dependencies = [
- "gl_generator",
+ "gl_generator 0.9.0",
  "libc",
  "pkg-config",
  "shared_library",
@@ -356,11 +356,11 @@ dependencies = [
 
 [[package]]
 name = "femtovg"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ffe2b7481ac709026ea4c5f7168ff5f64fe75bcbf114f5d60eb7dbe21a5e08"
+checksum = "f43d05da42e81724c16d34a150fb7fda53d3f786e5a94673ee526ff8602f0f6a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "fnv",
  "glow",
@@ -564,6 +564,7 @@ dependencies = [
  "gdk-pixbuf",
  "gdk4-sys",
  "gio",
+ "gl",
  "glib",
  "libc",
  "pango",
@@ -642,14 +643,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94edab108827d67608095e269cf862e60d920f144a5026d3dbcfd8b877fb404"
+dependencies = [
+ "gl_generator 0.14.0",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 dependencies = [
- "khronos_api",
+ "khronos_api 2.2.0",
  "log",
- "xml-rs",
+ "xml-rs 0.7.0",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api 3.1.0",
+ "log",
+ "xml-rs 0.8.28",
 ]
 
 [[package]]
@@ -658,7 +679,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -795,6 +816,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtk4-layer-shell"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2186c5662dc74e378dd85402418776b1a88e1ba2a6fcb4020437e15b18f02c80"
+dependencies = [
+ "bitflags 2.13.0",
+ "gdk4",
+ "glib",
+ "glib-sys",
+ "gtk4",
+ "gtk4-layer-shell-sys",
+ "libc",
+]
+
+[[package]]
+name = "gtk4-layer-shell-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e386481f3d83ab32e4ee457d9706d4ebbafa29ea013f9ae5066070713d2efacc"
+dependencies = [
+ "gdk4-sys",
+ "glib-sys",
+ "gtk4-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gtk4-macros"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -938,13 +987,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -956,7 +1004,7 @@ checksum = "29541831d33940ea1c68a1b8980382c1a507c95a528a98c0e335b361b9726975"
 dependencies = [
  "arraydeque",
  "arrayvec",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "keycode_macro",
 ]
 
@@ -977,6 +1025,12 @@ name = "khronos_api"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -1070,9 +1124,9 @@ checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -1358,7 +1412,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -1394,6 +1448,7 @@ dependencies = [
  "femtovg",
  "fontconfig",
  "glow",
+ "gtk4-layer-shell",
  "hex_color",
  "keycode",
  "libloading 0.9.0",
@@ -1521,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spin"
@@ -1768,18 +1823,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1790,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1800,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1813,18 +1868,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1938,6 +1993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
 name = "yeslogic-fontconfig-sys"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,18 +2011,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ satty_cli.workspace = true
 relm4 = { version = "0.10.1", features = ["macros", "libadwaita", "gnome_42"] }
 tokio = { version = "1.52.3", features = ["time"] }
 
+# wayland layer-shell: used to span fullscreen="all" across all monitors
+# 0.7.x targets gtk4-rs 0.10, matching the relm4 0.10 gtk4 dependency
+gtk4-layer-shell = "0.7.0"
+
 # error handling
 anyhow = "1.0"
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Default single-key shortcuts:
 fullscreen = false
 # fullscreen = true
 # since 0.20.1, this can be written like below. Current is just the current screen, all is all screens. This may depend on the compositor.
+# On Wayland, "all" spans every monitor using one layer-shell surface per output (requires a
+# compositor with wlr-layer-shell, e.g. Hyprland/Sway/river); it falls back to a single screen
+# otherwise. On X11 it uses GDK's native all-monitor fullscreen.
 #fullscreen = "all"
 #fullscreen = "current-screen"
 # resize initially (0.20.1)

--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,9 @@
 fullscreen = false
 # fullscreen = true
 # since 0.20.1, this can be written like below. Current is just the current screen, all is all screens. This may depend on the compositor.
+# On Wayland, "all" spans every monitor using one layer-shell surface per output (requires a
+# compositor with wlr-layer-shell, e.g. Hyprland/Sway/river); it falls back to a single screen
+# otherwise. On X11 it uses GDK's native all-monitor fullscreen.
 #fullscreen = "all"
 #fullscreen = "current-screen"
 # resize initially (0.20.1)

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -58,6 +58,12 @@ pub struct FemtoVgAreaMut {
     drag_offset: Vec2D,
     is_drag: bool,
     is_reset: bool,
+    // When set, the area renders a fixed slice of the image at native scale instead of
+    // fitting/centering it. Used for fullscreen="all" on Wayland, where each monitor gets a
+    // layer-shell surface showing its own portion of the screenshot.
+    // `(image_origin, image_per_device_px)`: the image coordinate shown at the top-left of the
+    // canvas, and the image-pixels-per-canvas-device-pixel ratio.
+    layout_view: Option<(Vec2D, f32)>,
 }
 
 #[glib::object_subclass]
@@ -180,6 +186,7 @@ impl FemtoVGArea {
             last_scale: initial_scale,
             is_drag: false,
             is_reset: false,
+            layout_view: None,
         });
         self.sender.borrow_mut().replace(sender);
     }
@@ -631,10 +638,22 @@ impl FemtoVgAreaMut {
         }
     }
 
+    pub fn set_layout_view(&mut self, view: Option<(Vec2D, f32)>) {
+        self.layout_view = view;
+    }
+
     pub fn update_transformation(
         &mut self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
     ) {
+        // Fixed per-monitor slice (fullscreen="all" on Wayland): render the image at native scale,
+        // with the monitor's image-space origin pinned to the canvas top-left. No fit/center/zoom.
+        if let Some((origin, image_per_device_px)) = self.layout_view {
+            self.scale_factor = 1.0 / image_per_device_px;
+            self.offset = Vec2D::new(-origin.x * self.scale_factor, -origin.y * self.scale_factor);
+            return;
+        }
+
         let image_width = self.background_image.width() as f32;
         let image_height = self.background_image.height() as f32;
         let aspect_ratio = image_width / image_height;

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -177,4 +177,22 @@ impl FemtoVGArea {
     pub fn resize(&self, width: i32, height: i32) {
         self.imp().resize(width, height);
     }
+
+    /// Pin this area to a fixed slice of the image at native scale (fullscreen="all" on Wayland).
+    /// `view` is `(image_origin, image_per_device_px)`; pass `None` to restore fit/center behaviour.
+    pub fn set_layout_view(&self, view: Option<(Vec2D, f32)>) {
+        self.prime_layout_view(view);
+        // recompute transform for the new view (area must already be realized)
+        self.imp().resize(0, 0);
+    }
+
+    /// Set the layout view without forcing a render. Use before the area is realized; the natural
+    /// resize when the surface is mapped will apply the transform.
+    pub fn prime_layout_view(&self, view: Option<(Vec2D, f32)>) {
+        self.imp()
+            .inner()
+            .as_mut()
+            .expect("Did you call init before using FemtoVgArea?")
+            .set_layout_view(view);
+    }
 }

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -108,6 +108,10 @@ impl FemtoVGArea {
     }
 
     pub fn set_zoom_scale(&self, factor: f32) {
+        // fullscreen="all" pins every surface to a fixed per-monitor slice; zoom is disabled.
+        if crate::layershell_all_active() {
+            return;
+        }
         self.imp()
             .inner()
             .as_mut()
@@ -134,6 +138,10 @@ impl FemtoVGArea {
     }
 
     pub fn set_drag_offset(&self, offset: Vec2D) {
+        // fullscreen="all" pins every surface to a fixed per-monitor slice; panning is disabled.
+        if crate::layershell_all_active() {
+            return;
+        }
         self.imp()
             .inner()
             .as_mut()
@@ -160,6 +168,10 @@ impl FemtoVGArea {
     }
 
     pub fn reset_size(&self, factor: f32) {
+        // fullscreen="all" pins every surface to a fixed per-monitor slice; 1:1/fit are disabled.
+        if crate::layershell_all_active() {
+            return;
+        }
         self.imp()
             .inner()
             .as_mut()

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use relm4::{
     gtk::{self, CssProvider, Window, gdk::DisplayManager, gdk::FullscreenMode, gdk::Toplevel},
 };
 
+use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
+
 use anyhow::{Context, Result, anyhow};
 use satty_cli::command_line::{Fullscreen, Resize};
 
@@ -35,7 +37,8 @@ mod style;
 mod tools;
 mod ui;
 
-use crate::sketch_board::{SketchBoard, SketchBoardInput};
+use crate::math::Vec2D;
+use crate::sketch_board::{MonitorViewSpec, SketchBoard, SketchBoardInput};
 use crate::tools::Tools;
 
 pub static START_TIME: LazyLock<chrono::DateTime<chrono::Local>> =
@@ -104,6 +107,12 @@ impl App {
             "Fullscreen {:?} | Resize {:?} | Floatinghack {:?}",
             fullscreen, resize, floating_hack
         );
+
+        // On Wayland fullscreen="all" is realized via per-monitor layer-shell surfaces (set up in
+        // init), which size themselves to each output. Skip the native sizing/fullscreen path.
+        if layershell_all_active() {
+            return;
+        }
 
         if fullscreen == Some(Fullscreen::All)
             && let Some(surface) = root.surface()
@@ -417,6 +426,13 @@ impl Component for App {
             }
         });
 
+        // fullscreen="all" on Wayland: span all monitors via per-monitor layer-shell surfaces.
+        if layershell_all_active() {
+            setup_layershell_all(&root, model.sketch_board.sender(), image_dimensions);
+            // toolbars overlay the canvas (layer-shell surfaces don't emit "fullscreened")
+            sender.input(AppInput::FullscreenChanged(true));
+        }
+
         generate_profile_output!("app init end");
 
         relm4::gtk::glib::idle_add_local_once(move || {
@@ -425,6 +441,122 @@ impl Component for App {
 
         ComponentParts { model, widgets }
     }
+}
+
+fn is_wayland() -> bool {
+    DisplayManager::get()
+        .default_display()
+        .map(|d| d.type_().name() == "GdkWaylandDisplay")
+        .unwrap_or(false)
+}
+
+/// True when fullscreen="all" should be realized by spanning all monitors with per-monitor
+/// layer-shell surfaces (Wayland only; X11 keeps GDK's native all-monitor fullscreen).
+fn layershell_all_active() -> bool {
+    APP_CONFIG.read().fullscreen() == Some(Fullscreen::All)
+        && is_wayland()
+        && gtk4_layer_shell::is_supported()
+}
+
+/// Span fullscreen="all" across every monitor on Wayland. The App root window becomes the primary
+/// layer-shell surface; SketchBoard creates one more layer-shell surface per remaining monitor.
+/// Each surface shows its own slice of the screenshot at native scale.
+fn setup_layershell_all(
+    root: &Window,
+    sketch_board_sender: &relm4::Sender<SketchBoardInput>,
+    image_dimensions: (i32, i32),
+) {
+    let Some(display) = DisplayManager::get().default_display() else {
+        eprintln!("fullscreen=all: no default display");
+        return;
+    };
+    let monitor_model = display.monitors();
+
+    // (monitor, connector, geometry, scale_factor) for each connected monitor
+    let mut monitors: Vec<(gtk::gdk::Monitor, String, Rectangle, i32)> = Vec::new();
+    for i in 0..monitor_model.n_items() {
+        if let Some(mon) = monitor_model
+            .item(i)
+            .and_then(|obj| obj.downcast::<gtk::gdk::Monitor>().ok())
+        {
+            let Some(connector) = mon.connector().map(|c| c.to_string()) else {
+                continue;
+            };
+            let geometry = mon.geometry();
+            let scale = mon.scale_factor();
+            monitors.push((mon, connector, geometry, scale));
+        }
+    }
+    if monitors.is_empty() {
+        eprintln!("fullscreen=all: no monitors found");
+        return;
+    }
+
+    // bounding box of the whole layout, in logical coordinates
+    let min_x = monitors.iter().map(|m| m.2.x()).min().unwrap_or(0);
+    let min_y = monitors.iter().map(|m| m.2.y()).min().unwrap_or(0);
+    let max_right = monitors
+        .iter()
+        .map(|m| m.2.x() + m.2.width())
+        .max()
+        .unwrap_or(0);
+    let max_bottom = monitors
+        .iter()
+        .map(|m| m.2.y() + m.2.height())
+        .max()
+        .unwrap_or(0);
+    let layout_w = (max_right - min_x).max(1) as f32;
+    let layout_h = (max_bottom - min_y).max(1) as f32;
+
+    // how the screenshot maps onto the layout (≈ 1.0 for an unscaled grim capture of all outputs)
+    let sx = image_dimensions.0 as f32 / layout_w;
+    let sy = image_dimensions.1 as f32 / layout_h;
+
+    // the toolbars live on the primary monitor: prefer the one containing the layout origin (0,0)
+    let primary_idx = monitors
+        .iter()
+        .position(|m| {
+            let g = m.2;
+            g.x() <= 0 && 0 < g.x() + g.width() && g.y() <= 0 && 0 < g.y() + g.height()
+        })
+        .unwrap_or(0);
+
+    // configure the App root window as the primary layer-shell surface
+    let primary_monitor = &monitors[primary_idx].0;
+    root.init_layer_shell();
+    root.set_namespace(Some("satty"));
+    root.set_layer(Layer::Overlay);
+    root.set_monitor(Some(primary_monitor));
+    for edge in [Edge::Left, Edge::Right, Edge::Top, Edge::Bottom] {
+        root.set_anchor(edge, true);
+    }
+    root.set_exclusive_zone(-1);
+    root.set_keyboard_mode(KeyboardMode::OnDemand);
+
+    let specs: Vec<MonitorViewSpec> = monitors
+        .iter()
+        .enumerate()
+        .map(|(i, (_, connector, geometry, scale))| MonitorViewSpec {
+            connector: connector.clone(),
+            image_origin: Vec2D::new(
+                (geometry.x() - min_x) as f32 * sx,
+                (geometry.y() - min_y) as f32 * sy,
+            ),
+            image_per_device_px: sx / (*scale).max(1) as f32,
+            is_primary: i == primary_idx,
+        })
+        .collect();
+
+    eprintln!(
+        "fullscreen=all: spanning {} monitors (layout {}x{}, image {}x{})",
+        specs.len(),
+        layout_w as i32,
+        layout_h as i32,
+        image_dimensions.0,
+        image_dimensions.1
+    );
+
+    sketch_board_sender.emit(SketchBoardInput::SetupAllMonitors(specs));
 }
 
 fn read_css_overrides() -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,12 @@ struct App {
     style_toolbar: Controller<StyleToolbar>,
     outer_box: gtk::Box,
     overlay: gtk::Overlay,
+    // Whether the toolbars currently live in the overlay (fullscreen) rather than the outer box.
+    // Tracked so FullscreenChanged stays idempotent: it can fire more than once for the same state
+    // (e.g. our explicit call for layer-shell fullscreen="all" plus the window's "fullscreened"
+    // notify), and re-running the move would hit a gtk_box_remove assertion on an already-moved
+    // widget.
+    toolbars_overlaid: bool,
 }
 
 #[derive(Debug)]
@@ -292,18 +298,24 @@ impl Component for App {
                     .emit(SketchBoardInput::ScaleFactorChanged);
             }
             AppInput::FullscreenChanged(fullscreen) => {
-                let tools = self.tools_toolbar.widget();
-                let style = self.style_toolbar.widget();
-                if fullscreen {
-                    self.outer_box.remove(tools);
-                    self.outer_box.remove(style);
-                    self.overlay.add_overlay(tools);
-                    self.overlay.add_overlay(style);
-                } else {
-                    self.overlay.remove_overlay(tools);
-                    self.overlay.remove_overlay(style);
-                    self.outer_box.prepend(tools);
-                    self.outer_box.append(style);
+                // Idempotent: skip when the toolbars are already in the requested place. Without
+                // this guard a repeated FullscreenChanged(true) re-runs the move and trips a
+                // gtk_box_remove assertion on the (already moved) toolbar widgets.
+                if fullscreen != self.toolbars_overlaid {
+                    let tools = self.tools_toolbar.widget();
+                    let style = self.style_toolbar.widget();
+                    if fullscreen {
+                        self.outer_box.remove(tools);
+                        self.outer_box.remove(style);
+                        self.overlay.add_overlay(tools);
+                        self.overlay.add_overlay(style);
+                    } else {
+                        self.overlay.remove_overlay(tools);
+                        self.overlay.remove_overlay(style);
+                        self.outer_box.prepend(tools);
+                        self.outer_box.append(style);
+                    }
+                    self.toolbars_overlaid = fullscreen;
                 }
             }
             AppInput::DimensionsUpdate(dimensions) => {
@@ -381,6 +393,7 @@ impl Component for App {
             image_dimensions,
             outer_box,
             overlay,
+            toolbars_overlaid: false,
         };
 
         // Initialize style toolbar with full image dimensions

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,7 +465,7 @@ fn is_wayland() -> bool {
 
 /// True when fullscreen="all" should be realized by spanning all monitors with per-monitor
 /// layer-shell surfaces (Wayland only; X11 keeps GDK's native all-monitor fullscreen).
-fn layershell_all_active() -> bool {
+pub(crate) fn layershell_all_active() -> bool {
     APP_CONFIG.read().fullscreen() == Some(Fullscreen::All)
         && is_wayland()
         && gtk4_layer_shell::is_supported()

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -18,13 +18,15 @@ use gtk::prelude::*;
 use relm4::gtk::gdk::{DisplayManager, Key, ModifierType, Texture};
 use relm4::{Component, ComponentParts, ComponentSender, RelmWidgetExt, gtk};
 
+use gtk4_layer_shell::{Edge, Layer, LayerShell};
+
 use crate::configuration::{APP_CONFIG, Action};
 use crate::femtovg_area::FemtoVGArea;
 use crate::ime::pango_adapter::spans_from_pango_attrs;
 use crate::math::Vec2D;
 use crate::notification::log_result;
 use crate::style::Style;
-use crate::tools::{Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
+use crate::tools::{Drawable, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
 use crate::ui::toolbars::ToolbarEvent;
 use xdg::BaseDirectories;
 
@@ -45,7 +47,21 @@ pub enum SketchBoardInput {
     Refresh,
     Exit,
     ScaleFactorChanged,
+    SetupAllMonitors(Vec<MonitorViewSpec>),
     Output(SketchBoardOutput),
+}
+
+/// Describes how one monitor maps onto the screenshot for fullscreen="all" on Wayland.
+#[derive(Debug, Clone)]
+pub struct MonitorViewSpec {
+    /// gdk monitor connector (e.g. "HDMI-A-1"); used to find the matching monitor for layer-shell.
+    pub connector: String,
+    /// Image-space coordinate shown at this monitor's top-left.
+    pub image_origin: Vec2D,
+    /// Image pixels per canvas device pixel (≈ 1.0 for an unscaled grim capture).
+    pub image_per_device_px: f32,
+    /// The primary monitor reuses the App root window; others get their own layer-shell window.
+    pub is_primary: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -113,6 +129,10 @@ pub struct MouseEventMsg {
     pub pos: Vec2D,
     pub n_pressed: i32,
     pub release: bool,
+    // True when `pos` is already in image coordinates (events forwarded from a secondary
+    // fullscreen="all" monitor area, which converts using its own transform). The primary area
+    // sends canvas coordinates that SketchBoard converts via its renderer.
+    pub image_space: bool,
 }
 
 impl SketchBoardInput {
@@ -133,6 +153,30 @@ impl SketchBoardInput {
             pos,
             is_touchpad: false,
             release,
+            image_space: false,
+        }))
+    }
+
+    /// Mouse event from a secondary fullscreen="all" monitor area: `pos` is already in image
+    /// coordinates, so SketchBoard must not convert it again.
+    pub fn new_image_space_mouse_event(
+        event_type: MouseEventType,
+        button: u32,
+        n_pressed: i32,
+        modifier: ModifierType,
+        pos: Vec2D,
+        release: bool,
+    ) -> SketchBoardInput {
+        SketchBoardInput::InputEvent(InputEvent::Mouse(MouseEventMsg {
+            type_: event_type,
+            button: button.into(),
+            n_pressed,
+            modifier,
+            screen_pos: pos,
+            pos,
+            is_touchpad: false,
+            release,
+            image_space: true,
         }))
     }
     pub fn new_key_event(event: KeyEventMsg) -> SketchBoardInput {
@@ -166,6 +210,7 @@ impl SketchBoardInput {
             pos: Vec2D::new(delta_x as f32, delta_y as f32),
             is_touchpad,
             release: false,
+            image_space: false,
         }))
     }
 }
@@ -277,11 +322,244 @@ pub struct SketchBoard {
     style: Style,
     im_context: gtk::IMMulticontext,
     last_saved_filepath: RefCell<Option<String>>,
+    // fullscreen="all" on Wayland: the background image and the secondary per-monitor layer-shell
+    // surfaces that mirror the scene. Empty for the normal single-window case.
+    image: Pixbuf,
+    mirrors: Vec<FemtoVGArea>,
+    mirror_windows: Vec<gtk::Window>,
 }
 
 impl SketchBoard {
     fn refresh_screen(&mut self) {
         self.renderer.queue_render();
+        for m in &self.mirrors {
+            m.queue_render();
+        }
+    }
+
+    /// Commit a drawable to every area. The primary keeps the original; each mirror gets its own
+    /// clone so that per-canvas state (e.g. the blur tool's cached image) stays independent.
+    fn commit_drawable(&mut self, drawable: Box<dyn Drawable>) {
+        for m in &mut self.mirrors {
+            m.commit(drawable.clone_box());
+        }
+        self.renderer.commit(drawable);
+    }
+
+    fn undo_all(&mut self) -> bool {
+        let undone = self.renderer.undo();
+        for m in &mut self.mirrors {
+            m.undo();
+        }
+        undone
+    }
+
+    fn redo_all(&mut self) -> bool {
+        let redone = self.renderer.redo();
+        for m in &mut self.mirrors {
+            m.redo();
+        }
+        redone
+    }
+
+    fn reset_all(&mut self) -> bool {
+        let reset = self.renderer.reset();
+        for m in &mut self.mirrors {
+            m.reset();
+        }
+        reset
+    }
+
+    /// Request a render on the primary (this is where save/copy renders the full image) and
+    /// redraw every mirror so the on-screen result stays in sync.
+    fn request_render_all(&self, actions: &[Action]) {
+        self.renderer.request_render(actions);
+        for m in &self.mirrors {
+            m.queue_render();
+        }
+    }
+
+    fn set_active_tool_all(&mut self, tool: Rc<RefCell<dyn Tool>>) {
+        self.renderer.set_active_tool(tool.clone());
+        for m in &mut self.mirrors {
+            m.set_active_tool(tool.clone());
+        }
+    }
+
+    /// fullscreen="all" on Wayland: pin the primary area to its monitor's slice and create a
+    /// layer-shell mirror window for every other monitor, each showing its own slice of the image.
+    fn setup_all_monitors(&mut self, specs: Vec<MonitorViewSpec>, sender: &ComponentSender<Self>) {
+        let Some(display) = DisplayManager::get().default_display() else {
+            eprintln!("fullscreen=all: no default display");
+            return;
+        };
+        let monitors = display.monitors();
+
+        let find_monitor = |connector: &str| -> Option<gtk::gdk::Monitor> {
+            for i in 0..monitors.n_items() {
+                if let Some(mon) = monitors
+                    .item(i)
+                    .and_then(|obj| obj.downcast::<gtk::gdk::Monitor>().ok())
+                    && mon.connector().as_deref() == Some(connector)
+                {
+                    return Some(mon);
+                }
+            }
+            None
+        };
+
+        for spec in specs {
+            let view = Some((spec.image_origin, spec.image_per_device_px));
+
+            if spec.is_primary {
+                // primary reuses the App root window / its already-realized area
+                self.renderer.set_layout_view(view);
+                continue;
+            }
+
+            let Some(monitor) = find_monitor(&spec.connector) else {
+                eprintln!(
+                    "fullscreen=all: monitor '{}' not found, skipping",
+                    spec.connector
+                );
+                continue;
+            };
+
+            let mut area = FemtoVGArea::default();
+            area.init(
+                sender.input_sender().clone(),
+                self.tools.get_crop_tool(),
+                self.active_tool.clone(),
+                self.image.clone(),
+            );
+            area.set_vexpand(true);
+            area.set_hexpand(true);
+            area.prime_layout_view(view);
+            Self::add_mirror_input_controllers(&area, sender.input_sender().clone());
+
+            let window = gtk::Window::new();
+            window.add_css_class("root");
+            window.set_child(Some(&area));
+            window.init_layer_shell();
+            window.set_namespace(Some("satty"));
+            window.set_layer(Layer::Overlay);
+            window.set_monitor(Some(&monitor));
+            for edge in [Edge::Left, Edge::Right, Edge::Top, Edge::Bottom] {
+                window.set_anchor(edge, true);
+            }
+            window.set_exclusive_zone(-1);
+            window.present();
+
+            self.mirrors.push(area);
+            self.mirror_windows.push(window);
+        }
+
+        self.refresh_screen();
+    }
+
+    /// Input controllers for a secondary monitor's mirror area. Pointer coordinates are converted
+    /// to image space using the mirror's own transform and forwarded as image-space events.
+    fn add_mirror_input_controllers(area: &FemtoVGArea, sender: relm4::Sender<SketchBoardInput>) {
+        let drag = gtk::GestureDrag::new();
+        drag.set_button(0);
+        {
+            let sender = sender.clone();
+            let area = area.clone();
+            drag.connect_drag_begin(move |controller, x, y| {
+                let pos = area.abs_canvas_to_image_coordinates(Vec2D::new(x as f32, y as f32));
+                sender.emit(SketchBoardInput::new_image_space_mouse_event(
+                    MouseEventType::BeginDrag,
+                    controller.current_button(),
+                    1,
+                    controller.current_event_state(),
+                    pos,
+                    false,
+                ));
+            });
+        }
+        {
+            let sender = sender.clone();
+            let area = area.clone();
+            drag.connect_drag_update(move |controller, x, y| {
+                let pos = area.rel_canvas_to_image_coordinates(Vec2D::new(x as f32, y as f32));
+                sender.emit(SketchBoardInput::new_image_space_mouse_event(
+                    MouseEventType::UpdateDrag,
+                    controller.current_button(),
+                    1,
+                    controller.current_event_state(),
+                    pos,
+                    false,
+                ));
+            });
+        }
+        {
+            let sender = sender.clone();
+            let area = area.clone();
+            drag.connect_drag_end(move |controller, x, y| {
+                let pos = area.rel_canvas_to_image_coordinates(Vec2D::new(x as f32, y as f32));
+                sender.emit(SketchBoardInput::new_image_space_mouse_event(
+                    MouseEventType::EndDrag,
+                    controller.current_button(),
+                    1,
+                    controller.current_event_state(),
+                    pos,
+                    false,
+                ));
+            });
+        }
+        area.add_controller(drag);
+
+        let click = gtk::GestureClick::new();
+        click.set_button(0);
+        {
+            let sender = sender.clone();
+            let area = area.clone();
+            click.connect_pressed(move |controller, n_pressed, x, y| {
+                let pos = area.abs_canvas_to_image_coordinates(Vec2D::new(x as f32, y as f32));
+                sender.emit(SketchBoardInput::new_image_space_mouse_event(
+                    MouseEventType::Click,
+                    controller.current_button(),
+                    n_pressed,
+                    controller.current_event_state(),
+                    pos,
+                    false,
+                ));
+            });
+        }
+        {
+            let sender = sender.clone();
+            let area = area.clone();
+            click.connect_released(move |controller, n_released, x, y| {
+                let pos = area.abs_canvas_to_image_coordinates(Vec2D::new(x as f32, y as f32));
+                sender.emit(SketchBoardInput::new_image_space_mouse_event(
+                    MouseEventType::Release,
+                    controller.current_button(),
+                    n_released,
+                    controller.current_event_state(),
+                    pos,
+                    true,
+                ));
+            });
+        }
+        area.add_controller(click);
+
+        let motion = gtk::EventControllerMotion::new();
+        {
+            let sender = sender.clone();
+            let area = area.clone();
+            motion.connect_motion(move |controller, x, y| {
+                let pos = area.abs_canvas_to_image_coordinates(Vec2D::new(x as f32, y as f32));
+                sender.emit(SketchBoardInput::new_image_space_mouse_event(
+                    MouseEventType::PointerPos,
+                    0,
+                    0,
+                    controller.current_event_state(),
+                    pos,
+                    false,
+                ));
+            });
+        }
+        area.add_controller(motion);
     }
 
     fn image_to_pixbuf(image: RenderedImage) -> Pixbuf {
@@ -299,11 +577,13 @@ impl SketchBoard {
     }
 
     fn deactivate_active_tool(&mut self) -> bool {
-        if self.active_tool.borrow().active()
-            && let ToolUpdateResult::Commit(result) =
-                self.active_tool.borrow_mut().handle_deactivated()
-        {
-            self.renderer.commit(result);
+        if !self.active_tool.borrow().active() {
+            return false;
+        }
+        // drop the tool borrow before commit_drawable, which needs &mut self
+        let result = self.active_tool.borrow_mut().handle_deactivated();
+        if let ToolUpdateResult::Commit(drawable) = result {
+            self.commit_drawable(drawable);
             return true;
         }
         false
@@ -315,7 +595,7 @@ impl SketchBoard {
         } else {
             ToolUpdateResult::Unmodified
         };
-        self.renderer.request_render(actions);
+        self.request_render_all(actions);
         rv
     }
 
@@ -740,7 +1020,7 @@ impl SketchBoard {
     fn handle_undo(&mut self) -> ToolUpdateResult {
         if self.active_tool.borrow().active() {
             self.active_tool.borrow_mut().handle_undo()
-        } else if self.renderer.undo() {
+        } else if self.undo_all() {
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
@@ -750,7 +1030,7 @@ impl SketchBoard {
     fn handle_redo(&mut self) -> ToolUpdateResult {
         if self.active_tool.borrow().active() {
             self.active_tool.borrow_mut().handle_redo()
-        } else if self.renderer.redo() {
+        } else if self.redo_all() {
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
@@ -759,7 +1039,7 @@ impl SketchBoard {
 
     fn handle_reset(&mut self) -> ToolUpdateResult {
         // can't use lazy || here
-        if self.deactivate_active_tool() | self.renderer.reset() {
+        if self.deactivate_active_tool() | self.reset_all() {
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
@@ -768,13 +1048,13 @@ impl SketchBoard {
 
     fn handle_resize(&mut self) -> ToolUpdateResult {
         self.renderer.reset_size(0.);
-        self.renderer.request_render(&[]);
+        self.request_render_all(&[]);
         ToolUpdateResult::Unmodified
     }
 
     fn handle_original_scale(&mut self) -> ToolUpdateResult {
         self.renderer.reset_size(1.);
-        self.renderer.request_render(&[]);
+        self.request_render_all(&[]);
         ToolUpdateResult::Unmodified
     }
 
@@ -804,9 +1084,9 @@ impl SketchBoard {
                 old_tool.borrow_mut().set_im_context(None);
 
                 if let ToolUpdateResult::Commit(d) = deactivate_result {
-                    self.renderer.commit(d);
+                    self.commit_drawable(d);
                     if APP_CONFIG.read().auto_copy() {
-                        self.renderer.request_render(&[Action::SaveToClipboard]);
+                        self.request_render_all(&[Action::SaveToClipboard]);
                     }
                     // we handle commit directly and "downgrade" to a simple redraw result
                     deactivate_result = ToolUpdateResult::Redraw;
@@ -814,7 +1094,7 @@ impl SketchBoard {
 
                 // change active tool
                 self.active_tool = self.tools.get(&tool);
-                self.renderer.set_active_tool(self.active_tool.clone());
+                self.set_active_tool_all(self.active_tool.clone());
                 let widget_ref: gtk::Widget = self.renderer.clone().upcast();
                 self.active_tool
                     .borrow_mut()
@@ -1147,25 +1427,24 @@ impl Component for SketchBoard {
                             } else if ke.is_one_of(Key::s, KeyMappingId::UsS)
                                 && ke.modifier == ModifierType::CONTROL_MASK
                             {
-                                self.renderer.request_render(&[Action::SaveToFile]);
+                                self.request_render_all(&[Action::SaveToFile]);
                                 ToolUpdateResult::Unmodified
                             } else if ke.is_one_of(Key::s, KeyMappingId::UsS)
                                 && ke.modifier
                                     == (ModifierType::CONTROL_MASK | ModifierType::SHIFT_MASK)
                             {
-                                self.renderer.request_render(&[Action::SaveToFileAs]);
+                                self.request_render_all(&[Action::SaveToFileAs]);
                                 ToolUpdateResult::Unmodified
                             } else if ke.is_one_of(Key::c, KeyMappingId::UsC)
                                 && ke.modifier == ModifierType::CONTROL_MASK
                             {
-                                self.renderer.request_render(&[Action::SaveToClipboard]);
+                                self.request_render_all(&[Action::SaveToClipboard]);
                                 ToolUpdateResult::Unmodified
                             } else if ke.is_one_of(Key::c, KeyMappingId::UsC)
                                 && ke.modifier
                                     == (ModifierType::CONTROL_MASK | ModifierType::ALT_MASK)
                             {
-                                self.renderer
-                                    .request_render(&[Action::CopyFilepathToClipboard]);
+                                self.request_render_all(&[Action::CopyFilepathToClipboard]);
                                 ToolUpdateResult::Unmodified
                             } else if (ke.is_one_of(Key::d, KeyMappingId::UsD)
                                 || ke.is_one_of(Key::i, KeyMappingId::UsI))
@@ -1206,7 +1485,7 @@ impl Component for SketchBoard {
                                 }
 
                                 self.renderer.store_last_offset();
-                                self.renderer.request_render(&[]);
+                                self.request_render_all(&[]);
                                 ToolUpdateResult::Unmodified
                             } else if ke.modifier.is_empty() && ke.key == Key::Delete {
                                 self.handle_reset()
@@ -1223,7 +1502,7 @@ impl Component for SketchBoard {
                                     } else {
                                         APP_CONFIG.read().actions_on_enter()
                                     };
-                                    self.renderer.request_render(&actions);
+                                    self.request_render_all(&actions);
                                 };
                                 active_tool_result
                             } else {
@@ -1232,7 +1511,13 @@ impl Component for SketchBoard {
                         }
                     }
                 } else {
-                    ie.handle_event_mouse_input(&self.renderer);
+                    // Events forwarded from a secondary fullscreen="all" monitor are already in
+                    // image coordinates and must not be converted again, nor drive pan/zoom (the
+                    // mirror surfaces use a fixed view).
+                    let from_mirror = matches!(&ie, InputEvent::Mouse(me) if me.image_space);
+                    if !from_mirror {
+                        ie.handle_event_mouse_input(&self.renderer);
+                    }
                     let active_tool_result = self
                         .active_tool
                         .borrow_mut()
@@ -1244,7 +1529,9 @@ impl Component for SketchBoard {
                         ToolUpdateResult::StopPropagation
                         | ToolUpdateResult::RedrawAndStopPropagation => active_tool_result,
                         _ => {
-                            if let Some(result) = ie.handle_mouse_event(&self.renderer) {
+                            if from_mirror {
+                                active_tool_result
+                            } else if let Some(result) = ie.handle_mouse_event(&self.renderer) {
                                 result
                             } else {
                                 active_tool_result
@@ -1263,7 +1550,7 @@ impl Component for SketchBoard {
                     if factor.is_finite() && factor > 0.0 {
                         self.renderer.set_pointer_offset_center();
                         self.renderer.set_zoom_scale(factor);
-                        self.renderer.request_render(&[]);
+                        self.request_render_all(&[]);
                     }
                     self.pinch_last_scale = scale;
                 }
@@ -1300,6 +1587,10 @@ impl Component for SketchBoard {
                 self.renderer.resize(0, 0);
                 ToolUpdateResult::Redraw
             }
+            SketchBoardInput::SetupAllMonitors(specs) => {
+                self.setup_all_monitors(specs, &sender);
+                ToolUpdateResult::Redraw
+            }
             SketchBoardInput::Output(output) => {
                 sender.output_sender().emit(output);
                 ToolUpdateResult::Unmodified
@@ -1316,9 +1607,9 @@ impl Component for SketchBoard {
 
         match result {
             ToolUpdateResult::Commit(drawable) => {
-                self.renderer.commit(drawable);
+                self.commit_drawable(drawable);
                 if APP_CONFIG.read().auto_copy() {
-                    self.renderer.request_render(&[Action::SaveToClipboard]);
+                    self.request_render_all(&[Action::SaveToClipboard]);
                 }
                 self.refresh_screen();
             }
@@ -1348,6 +1639,9 @@ impl Component for SketchBoard {
             tools,
             im_context,
             last_saved_filepath: RefCell::new(None),
+            image: image.clone(),
+            mirrors: Vec::new(),
+            mirror_windows: Vec::new(),
         };
 
         let area = &mut model.renderer;

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -24,32 +24,44 @@ pub struct Blur {
 }
 
 impl Blur {
+    /// Sample the current render target under the blur rect and produce a blurred image of it.
+    ///
+    /// Returns `Ok(None)` when the rect doesn't overlap what this render target currently shows.
+    /// With fullscreen="all" each monitor's canvas only renders its own slice of the image, so a
+    /// blur belonging to another monitor maps entirely off this target; there is nothing to sample
+    /// and nothing visible to draw. Crucially we do NOT cache in that case (see `draw`), so the
+    /// full-image render used for saving/copying still recomputes the blur from real pixels.
     fn blur(
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         pos: Vec2D,
         size: Vec2D,
         sigma: f32,
-    ) -> Result<ImageId> {
-        let img = canvas.screenshot()?;
-
+    ) -> Result<Option<ImageId>> {
         let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
         let transformed_size = size * canvas.transform().average_scale();
 
-        // Clamp the sampled region to the actual framebuffer. With fullscreen="all" each monitor's
-        // canvas only shows a slice of the image, so a blur belonging to another monitor maps to
-        // out-of-bounds (even negative) coordinates here; sub_image would otherwise panic.
-        let img_w = img.width() as f32;
-        let img_h = img.height() as f32;
-        let left = transformed_pos.0.clamp(0.0, img_w);
-        let top = transformed_pos.1.clamp(0.0, img_h);
-        let right = (transformed_pos.0 + transformed_size.x).clamp(0.0, img_w);
-        let bottom = (transformed_pos.1 + transformed_size.y).clamp(0.0, img_h);
-        let width = ((right - left) as usize).max(1);
-        let height = ((bottom - top) as usize).max(1);
+        // Clamp the sampled region to the current render target. `width()`/`height()` report the
+        // active target (the on-screen slice while drawing, the full image while exporting), which
+        // is exactly what `screenshot()` below reads back. Flooring each edge independently keeps
+        // `left + width <= width()` (likewise for height), which is what sub_image asserts — note a
+        // forced minimum size would break this when the rect sits past the right/bottom edge.
+        let target_w = canvas.width() as usize;
+        let target_h = canvas.height() as usize;
+        let left = (transformed_pos.0.max(0.0) as usize).min(target_w);
+        let top = (transformed_pos.1.max(0.0) as usize).min(target_h);
+        let right = ((transformed_pos.0 + transformed_size.x).max(0.0) as usize).min(target_w);
+        let bottom = ((transformed_pos.1 + transformed_size.y).max(0.0) as usize).min(target_h);
+        let width = right.saturating_sub(left);
+        let height = bottom.saturating_sub(top);
 
-        let (buf, width, height) = img
-            .sub_image(left as usize, top as usize, width, height)
-            .to_contiguous_buf();
+        // No overlap: bail before the (expensive) screenshot read-back and without caching.
+        if width == 0 || height == 0 {
+            return Ok(None);
+        }
+
+        let img = canvas.screenshot()?;
+
+        let (buf, width, height) = img.sub_image(left, top, width, height).to_contiguous_buf();
         let sub = Img::new(buf.into_owned(), width, height);
 
         let src_image_id = canvas.create_image(sub.as_ref(), ImageFlags::empty())?;
@@ -67,7 +79,7 @@ impl Blur {
         );
         //canvas.delete_image(src_image_id);
 
-        Ok(dst_image_id)
+        Ok(Some(dst_image_id))
     }
 }
 
@@ -112,39 +124,38 @@ impl Drawable for Blur {
             canvas.save();
             canvas.flush();
 
-            // create new cached image
+            // Create the cached image lazily. `blur` returns None when the rect isn't visible on
+            // this render target; we leave the cache empty in that case so a later render that does
+            // contain it (e.g. the full-image export) can still compute it.
             if self.cached_image.borrow().is_none() {
-                self.cached_image.borrow_mut().replace(Self::blur(
+                let blurred = Self::blur(
                     canvas,
                     pos,
                     size,
                     self.style
                         .size
                         .to_blur_factor(self.style.annotation_size_factor),
-                )?);
+                )?;
+                if let Some(id) = blurred {
+                    self.cached_image.borrow_mut().replace(id);
+                }
             }
 
-            let mut path = Path::new();
-            path.rounded_rect(
-                pos.x,
-                pos.y,
-                size.x,
-                size.y,
-                APP_CONFIG.read().corner_roundness(),
-            );
-
-            canvas.fill_path(
-                &path,
-                &Paint::image(
-                    self.cached_image.borrow().unwrap(), // this unwrap is safe because we placed it above
+            if let Some(image_id) = *self.cached_image.borrow() {
+                let mut path = Path::new();
+                path.rounded_rect(
                     pos.x,
                     pos.y,
                     size.x,
                     size.y,
-                    0f32,
-                    1f32,
-                ),
-            );
+                    APP_CONFIG.read().corner_roundness(),
+                );
+
+                canvas.fill_path(
+                    &path,
+                    &Paint::image(image_id, pos.x, pos.y, size.x, size.y, 0f32, 1f32),
+                );
+            }
             canvas.restore();
         }
         Ok(())

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -35,13 +35,20 @@ impl Blur {
         let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
         let transformed_size = size * canvas.transform().average_scale();
 
+        // Clamp the sampled region to the actual framebuffer. With fullscreen="all" each monitor's
+        // canvas only shows a slice of the image, so a blur belonging to another monitor maps to
+        // out-of-bounds (even negative) coordinates here; sub_image would otherwise panic.
+        let img_w = img.width() as f32;
+        let img_h = img.height() as f32;
+        let left = transformed_pos.0.clamp(0.0, img_w);
+        let top = transformed_pos.1.clamp(0.0, img_h);
+        let right = (transformed_pos.0 + transformed_size.x).clamp(0.0, img_w);
+        let bottom = (transformed_pos.1 + transformed_size.y).clamp(0.0, img_h);
+        let width = ((right - left) as usize).max(1);
+        let height = ((bottom - top) as usize).max(1);
+
         let (buf, width, height) = img
-            .sub_image(
-                transformed_pos.0 as usize,
-                transformed_pos.1 as usize,
-                (transformed_size.x as usize).max(1),
-                (transformed_size.y as usize).max(1),
-            )
+            .sub_image(left as usize, top as usize, width, height)
             .to_contiguous_buf();
         let sub = Img::new(buf.into_owned(), width, height);
 

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -111,19 +111,21 @@ impl Drawable for Crop {
         &self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         _font: femtovg::FontId,
-        _bounds: (Vec2D, Vec2D),
+        bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
         let size = self.size;
         let scale = canvas.transform().average_scale();
-        let dimensions = Vec2D::new(
-            canvas.width() as f32 / scale,
-            canvas.height() as f32 / scale,
-        );
+
+        // Dim the whole image (in image coordinates) and punch a hole at the crop selection.
+        // Using the image bounds rather than this canvas's dimensions keeps the overlay aligned
+        // for fullscreen="all" on Wayland, where each monitor's area only shows a fixed slice of
+        // the image at a non-zero origin.
+        let (origin, far) = bounds;
 
         let shadow_paint = Paint::color(Color::rgbaf(0.0, 0.0, 0.0, 0.5))
             .with_fill_rule(femtovg::FillRule::EvenOdd);
         let mut shadow_path = Path::new();
-        shadow_path.rect(0.0, 0.0, dimensions.x, dimensions.y);
+        shadow_path.rect(origin.x, origin.y, far.x - origin.x, far.y - origin.y);
         shadow_path.rect(self.pos.x, self.pos.y, size.x, size.y);
 
         let border_paint = Paint::color(Color::rgbf(0.1, 0.1, 0.1)).with_line_width(2.0);

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -427,13 +427,27 @@ impl StyleToolbar {
                 .hide_on_close(true)
                 .rgba(&current_color);
 
-            if let Some(w) = root {
+            // In fullscreen="all" the annotation surfaces sit on the Overlay layer and a normal
+            // dialog toplevel would open behind them (invisible). transient_for a layer-shell
+            // surface is meaningless anyway, so skip it there and promote the dialog itself to an
+            // Overlay layer-shell surface below.
+            let layershell = crate::layershell_all_active();
+            if !layershell && let Some(w) = root {
                 builder = builder.transient_for(&w);
             }
 
             // build dialog and configure further
             let dialog = builder.build();
             dialog.set_use_alpha(true);
+
+            if layershell {
+                use gtk4_layer_shell::{KeyboardMode, Layer, LayerShell};
+                dialog.init_layer_shell();
+                dialog.set_namespace(Some("satty"));
+                dialog.set_layer(Layer::Overlay);
+                // grab the keyboard so hex/values can be typed into the dialog
+                dialog.set_keyboard_mode(KeyboardMode::Exclusive);
+            }
 
             let custom_colors = APP_CONFIG
                 .read()
@@ -904,6 +918,17 @@ impl Component for AnnotationSizeDialog {
         header_bar.pack_end(&ok_button);
 
         let widgets = view_output!();
+
+        // In fullscreen="all" the annotation surfaces are on the Overlay layer and would hide this
+        // dialog (a normal toplevel). Promote it to its own Overlay layer-shell surface, grabbing
+        // the keyboard so the spin button and Enter/Escape work.
+        if crate::layershell_all_active() {
+            use gtk4_layer_shell::{KeyboardMode, Layer, LayerShell};
+            root.init_layer_shell();
+            root.set_namespace(Some("satty"));
+            root.set_layer(Layer::Overlay);
+            root.set_keyboard_mode(KeyboardMode::Exclusive);
+        }
 
         let key_controller = gtk::EventControllerKey::builder()
             // not sure if this is the correct phase, but anything higher and Enter to close doesn't work consistently

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -101,6 +101,101 @@ fn create_icon(color: Color) -> gtk::Image {
     gtk::Image::from_pixbuf(Some(&create_icon_pixbuf(color)))
 }
 
+/// Color picker for fullscreen="all". `GtkColorChooserDialog` puts its Select/Cancel in a header bar
+/// (not rendered on a layer-shell surface) and wraps the chooser in a scrolled window (scrollbar on
+/// the taller custom editor). Build it ourselves instead: a bare `GtkColorChooserWidget` — which
+/// sizes to its content, so no scrollbar — in an Overlay layer-shell window with in-content
+/// Cancel/Select buttons. Confirms on Select or a double-clicked swatch; cancels on Cancel or Esc.
+fn show_color_picker_overlay(
+    sender: ComponentSender<StyleToolbar>,
+    current_color: RGBA,
+    custom_colors: Vec<RGBA>,
+) {
+    use gtk4_layer_shell::{KeyboardMode, Layer, LayerShell};
+
+    let chooser = gtk::ColorChooserWidget::new();
+    chooser.set_use_alpha(true);
+    chooser.set_rgba(&current_color);
+    chooser.set_vexpand(true);
+    if !custom_colors.is_empty() {
+        chooser.add_palette(gtk::Orientation::Horizontal, 8, &custom_colors);
+    }
+
+    let cancel = gtk::Button::with_label("Cancel");
+    let select = gtk::Button::with_label("Select");
+    select.add_css_class("suggested-action");
+
+    let buttons = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(8)
+        .halign(Align::End)
+        .margin_top(12)
+        .margin_bottom(8)
+        .margin_start(8)
+        .margin_end(8)
+        .build();
+    buttons.append(&cancel);
+    buttons.append(&select);
+
+    let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    content.set_margin_top(8);
+    content.set_margin_bottom(8);
+    content.set_margin_start(8);
+    content.set_margin_end(8);
+    content.append(&chooser);
+    content.append(&buttons);
+
+    let window = gtk::Window::builder()
+        .title("Choose Color")
+        .modal(true)
+        .child(&content)
+        .build();
+    window.init_layer_shell();
+    window.set_namespace(Some("satty"));
+    window.set_layer(Layer::Overlay);
+    window.set_keyboard_mode(KeyboardMode::Exclusive);
+
+    let confirm = {
+        let window = window.clone();
+        let sender = sender.clone();
+        move |color: Color| {
+            sender.input(StyleToolbarInput::ColorDialogFinished(Some(color)));
+            window.close();
+        }
+    };
+
+    {
+        let confirm = confirm.clone();
+        let chooser = chooser.clone();
+        select.connect_clicked(move |_| confirm(Color::from_gdk(chooser.rgba())));
+    }
+    {
+        // double-clicking a swatch also confirms, matching the stock dialog
+        let confirm = confirm.clone();
+        chooser.connect_color_activated(move |_, rgba| confirm(Color::from_gdk(*rgba)));
+    }
+    {
+        let window = window.clone();
+        cancel.connect_clicked(move |_| window.close());
+    }
+
+    let key = gtk::EventControllerKey::new();
+    {
+        let window = window.clone();
+        key.connect_key_pressed(move |_, keyval, _, _| {
+            if keyval == gtk::gdk::Key::Escape {
+                window.close();
+                relm4::gtk::glib::Propagation::Stop
+            } else {
+                relm4::gtk::glib::Propagation::Proceed
+            }
+        });
+    }
+    window.add_controller(key);
+
+    window.present();
+}
+
 #[relm4::component(pub)]
 impl SimpleComponent for ToolsToolbar {
     type Init = ();
@@ -420,6 +515,23 @@ impl StyleToolbar {
 
     fn show_color_dialog(&self, sender: ComponentSender<StyleToolbar>, root: Option<Window>) {
         let current_color: RGBA = self.custom_color.into();
+        let custom_colors = APP_CONFIG
+            .read()
+            .color_palette()
+            .custom()
+            .iter()
+            .copied()
+            .map(RGBA::from)
+            .collect::<Vec<_>>();
+
+        // In fullscreen="all" a normal dialog toplevel opens behind the Overlay annotation surfaces
+        // (invisible), and a layer-shell surface doesn't render the dialog's header-bar buttons. Use
+        // a bespoke overlay window with the chooser widget and in-content Cancel/Select buttons.
+        if crate::layershell_all_active() {
+            show_color_picker_overlay(sender, current_color, custom_colors);
+            return;
+        }
+
         relm4::spawn_local(async move {
             let mut builder = ColorChooserDialog::builder()
                 .modal(true)
@@ -427,36 +539,13 @@ impl StyleToolbar {
                 .hide_on_close(true)
                 .rgba(&current_color);
 
-            // In fullscreen="all" the annotation surfaces sit on the Overlay layer and a normal
-            // dialog toplevel would open behind them (invisible). transient_for a layer-shell
-            // surface is meaningless anyway, so skip it there and promote the dialog itself to an
-            // Overlay layer-shell surface below.
-            let layershell = crate::layershell_all_active();
-            if !layershell && let Some(w) = root {
+            if let Some(w) = root {
                 builder = builder.transient_for(&w);
             }
 
             // build dialog and configure further
             let dialog = builder.build();
             dialog.set_use_alpha(true);
-
-            if layershell {
-                use gtk4_layer_shell::{KeyboardMode, Layer, LayerShell};
-                dialog.init_layer_shell();
-                dialog.set_namespace(Some("satty"));
-                dialog.set_layer(Layer::Overlay);
-                // grab the keyboard so hex/values can be typed into the dialog
-                dialog.set_keyboard_mode(KeyboardMode::Exclusive);
-            }
-
-            let custom_colors = APP_CONFIG
-                .read()
-                .color_palette()
-                .custom()
-                .iter()
-                .copied()
-                .map(RGBA::from)
-                .collect::<Vec<_>>();
 
             if !custom_colors.is_empty() {
                 dialog.add_palette(

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -32,12 +32,7 @@ pub struct StyleToolbar {
     visible: bool,
     annotation_size: f32,
     annotation_size_formatted: String,
-    annotation_dialog_controller: Option<Controller<AnnotationSizeDialog>>,
     output_dimensions: String,
-}
-
-pub struct AnnotationSizeDialog {
-    annotation_size: f32,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -72,24 +67,9 @@ pub enum StyleToolbarInput {
     ColorDialogFinished(Option<Color>),
     SetVisibility(bool),
     ToggleVisibility,
-    ShowAnnotationDialog,
     AdjustAnnotationSize(f32),
-    AnnotationDialogFinished(Option<f32>),
+    ResetAnnotationSize,
     DimensionsChanged((i32, i32)),
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum AnnotationSizeDialogInput {
-    ValueChanged(f32),
-    Reset,
-    Show(f32),
-    Submit,
-    Cancel,
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum AnnotationSizeDialogOutput {
-    AnnotationSizeSubmitted(f32),
 }
 
 fn create_icon_pixbuf(color: Color) -> Pixbuf {
@@ -578,33 +558,6 @@ impl StyleToolbar {
             ColorButtons::Custom => self.custom_color,
         }
     }
-
-    fn show_annotation_dialog(
-        &mut self,
-        sender: ComponentSender<StyleToolbar>,
-        root: Option<Window>,
-    ) {
-        if self.annotation_dialog_controller.is_none() {
-            let mut builder = AnnotationSizeDialog::builder();
-            if let Some(w) = root {
-                builder = builder.transient_for(&w);
-            }
-
-            let connector = builder.launch(self.annotation_size);
-
-            let mut controller = connector.forward(sender.input_sender(), |output| match output {
-                AnnotationSizeDialogOutput::AnnotationSizeSubmitted(value) => {
-                    StyleToolbarInput::AnnotationDialogFinished(Some(value))
-                }
-            });
-
-            controller.detach_runtime();
-            self.annotation_dialog_controller = Some(controller);
-        }
-
-        let ctrl = self.annotation_dialog_controller.as_mut().unwrap();
-        ctrl.emit(AnnotationSizeDialogInput::Show(self.annotation_size));
-    }
 }
 
 #[relm4::component(pub)]
@@ -682,13 +635,27 @@ impl Component for StyleToolbar {
                 set_focusable: false,
                 set_hexpand: false,
 
+                set_label: "\u{2212}", // minus sign
+                set_tooltip: "Decrease annotation size factor",
+                connect_clicked => StyleToolbarInput::AdjustAnnotationSize(-0.1),
+            },
+            // value readout; not clickable, but scrolling over it fine-tunes the factor
+            gtk::Button {
+                set_focusable: false,
+                set_hexpand: false,
+                set_can_focus: false,
+                add_css_class: "flat",
+
                 #[watch]
                 set_label: &model.annotation_size_formatted,
-                set_tooltip: "Edit Annotation Size Factor",
+                set_tooltip: "Annotation size factor (scroll to fine-tune)",
 
-                connect_clicked => StyleToolbarInput::ShowAnnotationDialog,
                 add_controller = gtk::EventControllerScroll {
-                    set_flags: gtk::EventControllerScrollFlags::VERTICAL,
+                    // DISCRETE collapses smooth/high-resolution scrolling into one ±1 step per
+                    // wheel notch; without it a single tick fires many fractional events and the
+                    // value jumps erratically (faster scroll = bigger jump).
+                    set_flags: gtk::EventControllerScrollFlags::VERTICAL
+                        | gtk::EventControllerScrollFlags::DISCRETE,
                     connect_scroll[sender] => move |_, _, dy| {
                         if dy != 0.0 {
                             sender.input(StyleToolbarInput::AdjustAnnotationSize(
@@ -698,6 +665,22 @@ impl Component for StyleToolbar {
                         relm4::gtk::glib::Propagation::Stop
                     },
                 },
+            },
+            gtk::Button {
+                set_focusable: false,
+                set_hexpand: false,
+
+                set_label: "+",
+                set_tooltip: "Increase annotation size factor",
+                connect_clicked => StyleToolbarInput::AdjustAnnotationSize(0.1),
+            },
+            gtk::Button {
+                set_focusable: false,
+                set_hexpand: false,
+
+                set_icon_name: "arrow-counterclockwise-regular",
+                set_tooltip: "Reset annotation size factor",
+                connect_clicked => StyleToolbarInput::ResetAnnotationSize,
             },
             gtk::Separator {},
             gtk::Label {
@@ -762,10 +745,6 @@ impl Component for StyleToolbar {
                     .emit(ToolbarEvent::ColorSelected(color));
             }
 
-            StyleToolbarInput::ShowAnnotationDialog => {
-                self.show_annotation_dialog(sender, root.toplevel_window());
-            }
-
             StyleToolbarInput::AdjustAnnotationSize(delta) => {
                 let value = self.annotation_size + delta;
                 if self.set_annotation_size(value) {
@@ -775,10 +754,9 @@ impl Component for StyleToolbar {
                 }
             }
 
-            StyleToolbarInput::AnnotationDialogFinished(value) => {
-                if let Some(value) = value
-                    && self.set_annotation_size(value)
-                {
+            StyleToolbarInput::ResetAnnotationSize => {
+                let value = APP_CONFIG.read().annotation_size_factor();
+                if self.set_annotation_size(value) {
                     sender
                         .output_sender()
                         .emit(ToolbarEvent::AnnotationSizeChanged(value));
@@ -858,7 +836,6 @@ impl Component for StyleToolbar {
                 "{0:.2}",
                 APP_CONFIG.read().annotation_size_factor()
             ),
-            annotation_dialog_controller: None,
             output_dimensions: String::new(),
         };
 
@@ -915,162 +892,5 @@ impl FromVariant for ColorButtons {
             std::u64::MAX => Self::Custom,
             _ => Self::Palette(v),
         })
-    }
-}
-
-#[relm4::component(pub)]
-impl Component for AnnotationSizeDialog {
-    type Init = f32;
-    type Input = AnnotationSizeDialogInput;
-    type Output = AnnotationSizeDialogOutput;
-    type CommandOutput = ();
-
-    view! {
-        gtk::Window {
-            set_modal: true,
-            set_title: Some("Choose Annotation Size"),
-            set_titlebar: Some(&header_bar),
-
-            #[wrap(Some)]
-            set_child = &gtk::Box {
-                set_spacing: 10,
-                set_margin_all: 12,
-                set_orientation: gtk::Orientation::Horizontal,
-
-                #[name = "spin"]
-                gtk::SpinButton {
-                    set_editable: true,
-                    set_can_focus: true,
-                    set_hexpand: false,
-
-                    set_tooltip: "Annotation Size Factor",
-                    set_numeric: true,
-                    set_adjustment: &gtk::Adjustment::new(0.0, 0.0, 100.0, 0.01, 0.1, 0.0),
-                    set_climb_rate: 0.1,
-                    set_digits: 2,
-                    #[watch]
-                    #[block_signal(value_changed)]
-                    set_value: model.annotation_size.into(),
-
-                    connect_value_changed[sender] => move |button| {
-                        sender.input(AnnotationSizeDialogInput::ValueChanged(button.value() as f32));
-                        } @value_changed,
-                },
-                #[name = "spin_reset"]
-                gtk::Button {
-                    set_focusable: false,
-                    set_hexpand: false,
-
-                    set_tooltip: "Reset Annotation Size Factor",
-                    set_icon_name: "arrow-counterclockwise-regular",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AnnotationSizeDialogInput::Reset);
-                    },
-                },
-
-            },
-        }
-    }
-
-    fn init(
-        init_value: f32,
-        root: Self::Root,
-        sender: ComponentSender<Self>,
-    ) -> ComponentParts<Self> {
-        let model = AnnotationSizeDialog {
-            annotation_size: init_value,
-        };
-
-        // the title bar didn't really work within the view! macro.
-        let title_label = gtk::Label::builder()
-            .label("Choose Annotation Size")
-            .margin_start(6)
-            .build();
-
-        let cancel_button = gtk::Button::builder().label("Cancel").build();
-        let sender_clone = sender.clone();
-        cancel_button.connect_clicked(move |_| {
-            sender_clone.input(AnnotationSizeDialogInput::Cancel);
-        });
-
-        let ok_button = gtk::Button::builder().label("OK").build();
-
-        let sender_clone = sender.clone();
-        ok_button.connect_clicked(move |_| {
-            sender_clone.input(AnnotationSizeDialogInput::Submit);
-        });
-
-        let header_bar = gtk::HeaderBar::builder().show_title_buttons(false).build();
-
-        header_bar.set_title_widget(Some(&title_label));
-        header_bar.pack_start(&cancel_button);
-        header_bar.pack_end(&ok_button);
-
-        let widgets = view_output!();
-
-        // In fullscreen="all" the annotation surfaces are on the Overlay layer and would hide this
-        // dialog (a normal toplevel). Promote it to its own Overlay layer-shell surface, grabbing
-        // the keyboard so the spin button and Enter/Escape work.
-        if crate::layershell_all_active() {
-            use gtk4_layer_shell::{KeyboardMode, Layer, LayerShell};
-            root.init_layer_shell();
-            root.set_namespace(Some("satty"));
-            root.set_layer(Layer::Overlay);
-            root.set_keyboard_mode(KeyboardMode::Exclusive);
-        }
-
-        let key_controller = gtk::EventControllerKey::builder()
-            // not sure if this is the correct phase, but anything higher and Enter to close doesn't work consistently
-            .propagation_phase(gtk::PropagationPhase::Capture)
-            .build();
-
-        key_controller.connect_key_pressed(move |_, keyval, _, _| {
-            use gtk::gdk::Key;
-            match keyval {
-                Key::Return => {
-                    sender.input(AnnotationSizeDialogInput::Submit);
-                    relm4::gtk::glib::Propagation::Stop
-                }
-                Key::Escape => {
-                    sender.input(AnnotationSizeDialogInput::Cancel);
-                    relm4::gtk::glib::Propagation::Stop
-                }
-                _ => relm4::gtk::glib::Propagation::Proceed,
-            }
-        });
-        root.add_controller(key_controller);
-
-        ComponentParts { model, widgets }
-    }
-
-    fn update(
-        &mut self,
-        message: AnnotationSizeDialogInput,
-        sender: ComponentSender<Self>,
-        root: &Self::Root,
-    ) {
-        match message {
-            AnnotationSizeDialogInput::ValueChanged(value) => self.annotation_size = value,
-            AnnotationSizeDialogInput::Reset => {
-                let a = APP_CONFIG.read().annotation_size_factor();
-                self.annotation_size = a;
-            }
-            AnnotationSizeDialogInput::Show(value) => {
-                self.annotation_size = value;
-                root.show();
-            }
-            AnnotationSizeDialogInput::Cancel => {
-                root.hide();
-            }
-            AnnotationSizeDialogInput::Submit => {
-                // yeah, not sure if this can even happen.
-                if let Err(e) = sender.output(AnnotationSizeDialogOutput::AnnotationSizeSubmitted(
-                    self.annotation_size,
-                )) {
-                    eprintln!("Error submitting annotation size factor: {e:?}");
-                }
-                root.hide();
-            }
-        }
     }
 }


### PR DESCRIPTION
## Disclaimer

**The whole PR was vibe-coded with Opus 4.8**

## Summary

`fullscreen = "all"` previously only ever covered a single monitor on Wayland. The implementation relied on GDK's `FullscreenMode::AllMonitors`, which is a no-op on the Wayland backend — and a single Wayland surface cannot span multiple outputs by design.

This PR makes `fullscreen = "all"` actually span every monitor on Wayland by using the `wlr-layer-shell` protocol: the app's root window becomes the primary layer-shell surface, and one additional layer-shell surface is created per remaining output. Each surface renders its **own native-scale slice** of the screenshot, so together they cover the whole layout 1:1.

Behaviour is unchanged on X11 (still uses GDK's native all-monitor fullscreen) and it falls back gracefully to a single screen on compositors without layer-shell and for single-monitor setups.

Related to #118 — this introduces `wlr-layer-shell` support to the codebase, a prerequisite for the layer-shell / live-annotation ideas discussed there.

## How it works

- A new per-area "layout view" transform pins each `FemtoVGArea` to a fixed image slice at native scale (`image_origin` + image-pixels-per-device-pixel) instead of the usual fit/center.
- The App root window is configured as the primary layer-shell overlay (anchored to all edges of its monitor); `SketchBoard` creates one more layer-shell window per other monitor.
- Each monitor's area renders the shared scene on its own GL context. Committed drawables are broadcast (cloned) to every area; undo/redo/reset/refresh are broadcast too. This keeps per-canvas state independent (e.g. the blur tool's cached image), so each output renders correctly.
- Secondary monitor areas convert pointer events to image coordinates locally and forward them as image-space events, so drawing works on every monitor.
- Save/copy continues to render the full image on the primary area, so the exported result contains annotations from all monitors.
- The blur tool screenshots the canvas, so it now clamps the sampled region to the framebuffer to avoid out-of-bounds sampling on surfaces that only show a slice.

## New dependency

- `gtk4-layer-shell` (Rust crate `0.7`, targeting gtk4-rs 0.10). Requires the `gtk4-layer-shell` C library at build and runtime.

## Testing

Verified on Hyprland with a 3-monitor layout (1920×1080 @ -1920,0 · 2560×1440 @ 0,0 · 2560×1440 @ 2560,0):

- All three monitors covered, each showing its correct, seamlessly-aligned slice; toolbars overlaid on the primary monitor.
- Drawing verified on every monitor (primary and both secondaries), correctly positioned.
- Save/copy produces the full 7040×1440 image containing annotations drawn on all three monitors.
- Blur verified on a secondary monitor with real content — renders correctly, no crash.
- Single-window mode unchanged (normal toplevel, no layer-shell); `cargo test` passes, `cargo clippy` clean.

## Known limitations (initial version)

- Keyboard / text-tool input is routed to the primary monitor.
- A blur dragged across a monitor seam may look slightly off.
- Mixed-DPI monitors are not fully handled yet (uniform scale — the common case — is correct).
