### PR TITLE
fix: improve use of adwaita vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ app-id = "org.satty.satty"
 # experimental feature (0.22.0): show thumbnail as notifcation icon
 # notification-thumbnail = "app-icon"
 notification-thumbnail = "screenshot"
+# experimental feature (NEXTRELEASE): skip adwaita them variables in the default css.
+skip-adwaita-vars = false
 
 # Tool selection keyboard shortcuts (since 0.20.0)
 [keybinds]
@@ -361,6 +363,8 @@ Options:
           Experimental feature (0.21.0): Set toplevel app_id. Note that this has to match D-Bus well known name format, otherwise GTK does not accept it
       --notification-thumbnail <NOTIFICATION_THUMBNAIL>
           Experimental feature (0.22.0): use preview thumbnail in notifications where available [possible values: screenshot, app-icon]
+      --skip-adwaita-vars
+          Experimental feature (NEXTRELEASE): do not use Adwaita CSS variables
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -163,6 +163,10 @@ pub struct CommandLine {
     #[arg(long)]
     pub notification_thumbnail: Option<NotificationThumbnail>,
 
+    /// Experimental feature (NEXTRELEASE): do not use Adwaita CSS variables
+    #[arg(long)]
+    pub skip_adwaita_vars: bool,
+
     // --- deprecated options ---
     /// Right click to copy.
     /// Preferably use the `action_on_right_click` option instead.

--- a/config.toml
+++ b/config.toml
@@ -81,6 +81,8 @@ app-id = "org.satty.satty"
 # experimental feature (0.22.0): show thumbnail as notifcation icon
 # notification-thumbnail = "app-icon"
 notification-thumbnail = "screenshot"
+# experimental feature (NEXTRELEASE): skip adwaita them variables in the default css.
+skip-adwaita-vars = false
 
 # Tool selection keyboard shortcuts (since 0.20.0)
 [keybinds]

--- a/src/assets/default-adw.css
+++ b/src/assets/default-adw.css
@@ -1,0 +1,12 @@
+.outer_box {
+    background-color: @headerbar_bg_color;
+}
+
+.toolbar {
+    color: @headerbar_fg_color;
+    background-color: @headerbar_bg_color;
+}
+
+button.editing {
+    color: @accent_color;
+}

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -3,18 +3,10 @@
     min-height: 10rem;
 }
 
-.outer_box {
-    background-color: @headerbar_bg_color;
-}
-
 .inner_box {
     background-color: #000000;
 }
 
-.toolbar {
-    color: @headerbar_fg_color;
-    background-color: @headerbar_bg_color;
-}
 .toast {
     color: #f9f9f9;
     background-color: #00000099;
@@ -29,7 +21,3 @@
 
 .overlay .toolbar-bottom { border-radius: 6px 6px 0px 0px; }
 .overlay .toolbar-top { border-radius: 0px 0px 6px 6px; }
-
-button.editing {
-    color: @accent_color;
-}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -75,6 +75,7 @@ pub struct Configuration {
     title: Option<String>,
     app_id: Option<String>,
     notification_thumbnail: NotificationThumbnail,
+    skip_adwaita_vars: bool,
 }
 
 pub struct Keybinds {
@@ -432,6 +433,9 @@ impl Configuration {
         if let Some(v) = general.notification_thumbnail {
             self.notification_thumbnail = v;
         }
+        if let Some(v) = general.skip_adwaita_vars {
+            self.skip_adwaita_vars = v;
+        }
 
         // --- deprecated options ---
         if let Some(v) = general.right_click_copy
@@ -567,6 +571,9 @@ impl Configuration {
         }
         if let Some(v) = command_line.notification_thumbnail {
             self.notification_thumbnail = v;
+        }
+        if command_line.skip_adwaita_vars {
+            self.skip_adwaita_vars = true
         }
 
         // --- deprecated options ---
@@ -738,6 +745,9 @@ impl Configuration {
     pub fn notification_thumbnail(&self) -> NotificationThumbnail {
         self.notification_thumbnail
     }
+    pub fn skip_adwaita_vars(&self) -> bool {
+        self.skip_adwaita_vars
+    }
 }
 
 impl Default for Configuration {
@@ -779,6 +789,7 @@ impl Default for Configuration {
             title: None,
             app_id: None,
             notification_thumbnail: NotificationThumbnail::default(),
+            skip_adwaita_vars: false,
         }
     }
 }
@@ -865,6 +876,7 @@ struct ConfigurationFileGeneral {
     title: Option<String>,
     app_id: Option<String>,
     notification_thumbnail: Option<NotificationThumbnail>,
+    skip_adwaita_vars: Option<bool>,
 
     // --- deprecated options ---
     right_click_copy: Option<bool>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,8 +184,16 @@ impl App {
     }
 
     fn apply_style() {
+        let default_css = include_str!("assets/default.css");
+        let default_css_adw = include_str!("assets/default-adw.css");
+        let default_css_with_adw = format!("{default_css}{default_css_adw}");
+
         let css_provider = CssProvider::new();
-        css_provider.load_from_data(include_str!("assets/default.css"));
+        css_provider.load_from_data(if APP_CONFIG.read().skip_adwaita_vars() {
+            default_css
+        } else {
+            &default_css_with_adw
+        });
 
         let css_provider_override = if let Some(overrides) = read_css_overrides() {
             let css_provider2 = CssProvider::new();


### PR DESCRIPTION
Closes: #551

This improves use of adwaita vars by explicitly setting headerbar variables for buttons.

Also adds skip-adwaita-vars config to use a slimmer default css.