### PR TITLE
feat: annotation-size-factor with Ctrl mod and climb rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Minimum is 0.1 and maximum to 99.99.
 The bindings are:
 - Mouse <kbd>left-button</kbd>, <kbd>wheel</kbd> and key <kbd>up</kbd>/<kbd>down</kbd> step size is 0.1
 - Holding <kbd>Shift</kbd> will switch to 0.01 step size
+- Holding <kbd>Ctrl</kbd> will switch to 1.0 step size
 - Mouse <kbd>middle-button</kbd> and <kbd>page up</kbd>/<kbd>page down</kbd> step size is 1.0
 - Mouse <kbd>right-button</kbd> jumps to minimum/maximum
 

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -527,6 +527,7 @@ impl Component for StyleToolbar {
                     0.1, 99.99, // min, max
                     0.1, 1.0, // step sizes
                     0.0),
+                set_climb_rate: 0.1,
                 set_numeric: true,
                 set_digits: 2,
                 set_width_chars: 4,
@@ -547,13 +548,15 @@ impl Component for StyleToolbar {
 
                         if matches!(keyval, Key::Shift_L | Key::Shift_R) {
                             size_spin_button.adjustment().set_step_increment(0.01);
+                        } else if matches!(keyval, Key::Control_L | Key::Control_R) {
+                            size_spin_button.adjustment().set_step_increment(1.0);
                         }
 
                         relm4::gtk::glib::Propagation::Proceed
                     },
 
                     connect_key_released[size_spin_button] => move |_, keyval, _, _| {
-                        if matches!(keyval, Key::Shift_L | Key::Shift_R) {
+                        if matches!(keyval, Key::Shift_L | Key::Shift_R| Key::Control_L | Key::Control_R) {
                             size_spin_button.adjustment().set_step_increment(0.1);
                         }
                     },


### PR DESCRIPTION
- Holding <kbd>Ctrl</kbd> now changes the step size to 1.0.
- Restore set_climb_rate to 0.1 (previously lost in PR #549).

Thanks to PR #284 for the inspiration, but a climb rate of 1.0 is IMHO a bit too much.