### PR TITLE
feat!: generic key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 
 ### Shortcuts
 
+#### General
 - <kbd>Enter</kbd>: as configured (see below), default: copy-to-clipboard (may be masked by active tool)
 - <kbd>Esc</kbd>: as configured (see below), default: exit (may be masked by active tool)
-- <kbd>Delete</kbd> reset (clear) <sup>experimental</sup> <sup>0.20.1</sup>
+- <kbd>Shift+Delete</kbd> reset (clear) <sup>experimental</sup> <sup>NEXTRELEASE</sup>
 - <kbd>Ctrl+C</kbd>: Save to clipboard (may be masked by active tool)
 - <kbd>Ctrl+Shift+D</kbd> or <kbd>Ctrl+Shift+I</kbd>: Open GTK inspector if not already opened
 - <kbd>Ctrl+S</kbd>: Save to specified output file
@@ -82,6 +83,7 @@ The bindings are:
 - Holding <kbd>Ctrl</kbd> will switch to 1.0 step size
 - Mouse <kbd>middle-button</kbd> and <kbd>page up</kbd>/<kbd>page down</kbd> step size is 1.0
 - Mouse <kbd>right-button</kbd> jumps to minimum/maximum
+- <kbd>s</kbd> focuses the annotation size factor input field
 
 #### Tool Selection Shortcuts (configurable) <sup>0.20.0</sup>
 Default single-key shortcuts:
@@ -133,6 +135,22 @@ Marker:
 Highlight: 
 - Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below).
 - Hold <kbd>Shift</kbd> in freehand mode for a straight 15° aligned line. Stop at some position and release and hold <kbd>Shift</kbd> again to achieve perfectly aligned turns.
+
+#### Overwriting Keybindings (since NEXTRELEASE)
+
+Shortcuts can be overwritten in the config by 
+```toml
+[keybinds]
+"BINDING" = "TOOL-OR-COMMAND"
+```
+
+Where `BINDING` follows the GTK syntax. This means modifiers are enclosed in angle brackets (e.g., `<mod>`) and keys are specified by name (for example, `-` must be written as `minus`). 
+
+Pressing any unbound key will print its name to the console.
+
+Setting a binding to `"none"` will unbind it.
+
+The defaults are listed in the `config.toml`.
 
 ### Configuration File
 
@@ -222,19 +240,60 @@ app-id = "org.satty.satty"
 # notification-thumbnail = "app-icon"
 notification-thumbnail = "screenshot"
 
-# Tool selection keyboard shortcuts (since 0.20.0)
+# Generic keyboard shortcuts (NEXTRELEASE)
 [keybinds]
-pointer = "p"
-crop = "c"
-brush = "b"
-line = "i"
-arrow = "z"
-rectangle = "r"
-ellipse = "e"
-text = "t"
-marker = "m"
-blur = "u"
-highlight = "g"
+# "<Control>q" = "run-actions-on-escape" # additionally to Escape
+# "i" = "none" # unbind "i" default for line
+# "l" = "line"
+
+# Global
+"<Shift><Control>d" = "open-gtk-inspector"
+"<Shift><Control>i" = "open-gtk-inspector"
+"<Alt>Left" = "pan-left"
+"<Alt>Right" = "pan-right"
+"<Alt>Up" = "pan-up"
+"<Alt>Down" = "pan-down"
+"Delete" = "delete-selection"
+"Escape" = "run-actions-on-escape"
+"Return" = "run-actions-on-enter"
+"<Control>t" = "toggle-toolbars"
+
+# top toolbar
+"<Control>1" = "original-scale"
+"<Control>2" = "fit-to-window"
+"<Shift>Delete" = "clear-all"
+"<Control>z" = "undo"
+"<Control>y" = "redo"
+"p" = "pointer"
+"c" = "crop"
+"b" = "brush"
+"i" = "line"
+"z" = "arrow"
+"r" = "rectangle"
+"e" = "ellipse"
+"t" = "text"
+"m" = "marker"
+"u" = "blur"
+"g" = "highlight"
+"<Control>s" = "save-to-file"
+"<Shift><Control>s" = "save-to-file-as"
+"<Control>c" = "save-to-clipboard"
+"<Shift><Control>c" = "copy-filepath-to-clipboard"
+
+# bottom toolbar
+"1" = "select-color-index:1"
+"2" = "select-color-index:2"
+"3" = "select-color-index:3"
+"4" = "select-color-index:4"
+"5" = "select-color-index:5"
+"6" = "select-color-index:6"
+"7" = "select-color-index:7"
+"8" = "select-color-index:8"
+"9" = "select-color-index:9"
+"minus" = "cycle-size"
+#"..." = "select-size:(small|medium|large)"
+"s" = "focus-annotation-size-factor"
+"f" = "toggle-fill"
 
 # Font to use for text annotations
 [font]
@@ -281,6 +340,7 @@ custom = [
     # add or remove as needed
 ]
 ```
+
 
 ### Command Line
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ notification-thumbnail = "screenshot"
 #"..." = "select-size:(small|medium|large)"
 "s" = "focus-annotation-size-factor"
 "f" = "toggle-fill"
+"k" = "toggle-round-caps"
 
 # Font to use for text annotations
 [font]

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Highlight:
 - Hold <kbd>Ctrl</kbd> to switch between block and freehand mode (default configurable, see below).
 - Hold <kbd>Shift</kbd> in freehand mode for a straight 15° aligned line. Stop at some position and release and hold <kbd>Shift</kbd> again to achieve perfectly aligned turns.
 
-#### Overwriting Keybindings (since NEXTRELEASE)
+#### Overwriting Keybindings <sup>NEXTRELEASE</sup>
 
 Shortcuts can be overwritten in the config by 
 ```toml
@@ -260,7 +260,7 @@ notification-thumbnail = "screenshot"
 
 # top toolbar
 "<Control>1" = "original-scale"
-"<Control>2" = "fit-to-window"
+"<Control>2" = "fit-to-window" # experimental binding - may change in the future, see #338
 "<Shift>Delete" = "clear-all"
 "<Control>z" = "undo"
 "<Control>y" = "redo"

--- a/config.toml
+++ b/config.toml
@@ -82,19 +82,60 @@ app-id = "org.satty.satty"
 # notification-thumbnail = "app-icon"
 notification-thumbnail = "screenshot"
 
-# Tool selection keyboard shortcuts (since 0.20.0)
+# Generic keyboard shortcuts (NEXTRELEASE)
 [keybinds]
-pointer = "p"
-crop = "c"
-brush = "b"
-line = "i"
-arrow = "z"
-rectangle = "r"
-ellipse = "e"
-text = "t"
-marker = "m"
-blur = "u"
-highlight = "g"
+# "<Control>q" = "run-actions-on-escape" # additionally to Escape
+# "i" = "none" # unbind "i" default for line
+# "l" = "line"
+
+# Global
+"<Shift><Control>d" = "open-gtk-inspector"
+"<Shift><Control>i" = "open-gtk-inspector"
+"<Alt>Left" = "pan-left"
+"<Alt>Right" = "pan-right"
+"<Alt>Up" = "pan-up"
+"<Alt>Down" = "pan-down"
+"Delete" = "delete-selection"
+"Escape" = "run-actions-on-escape"
+"Return" = "run-actions-on-enter"
+"<Control>t" = "toggle-toolbars"
+
+# top toolbar
+"<Control>1" = "original-scale"
+"<Control>2" = "fit-to-window"
+"<Shift>Delete" = "clear-all"
+"<Control>z" = "undo"
+"<Control>y" = "redo"
+"p" = "pointer"
+"c" = "crop"
+"b" = "brush"
+"i" = "line"
+"z" = "arrow"
+"r" = "rectangle"
+"e" = "ellipse"
+"t" = "text"
+"m" = "marker"
+"u" = "blur"
+"g" = "highlight"
+"<Control>s" = "save-to-file"
+"<Shift><Control>s" = "save-to-file-as"
+"<Control>c" = "save-to-clipboard"
+"<Shift><Control>c" = "copy-filepath-to-clipboard"
+
+# bottom toolbar
+"1" = "select-color-index:1"
+"2" = "select-color-index:2"
+"3" = "select-color-index:3"
+"4" = "select-color-index:4"
+"5" = "select-color-index:5"
+"6" = "select-color-index:6"
+"7" = "select-color-index:7"
+"8" = "select-color-index:8"
+"9" = "select-color-index:9"
+"minus" = "cycle-size"
+#"..." = "select-size:(small|medium|large)"
+"s" = "focus-annotation-size-factor"
+"f" = "toggle-fill"
 
 # Font to use for text annotations
 [font]

--- a/config.toml
+++ b/config.toml
@@ -102,7 +102,7 @@ notification-thumbnail = "screenshot"
 
 # top toolbar
 "<Control>1" = "original-scale"
-"<Control>2" = "fit-to-window"
+"<Control>2" = "fit-to-window" # experimental binding - may change in the future, see #338
 "<Shift>Delete" = "clear-all"
 "<Control>z" = "undo"
 "<Control>y" = "redo"

--- a/config.toml
+++ b/config.toml
@@ -136,6 +136,7 @@ notification-thumbnail = "screenshot"
 #"..." = "select-size:(small|medium|large)"
 "s" = "focus-annotation-size-factor"
 "f" = "toggle-fill"
+"k" = "toggle-round-caps"
 
 # Font to use for text annotations
 [font]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -67,7 +67,7 @@ pub struct Configuration {
     profile_startup: bool,
     no_window_decoration: bool,
     brush_smooth_history_size: usize,
-    keybinds: Keybinds,
+    keybinds: HashMap<String, String>, // key_binding -> tool_or_command
     zoom_factor: f32,
     pan_step_size: f32,
     text_move_length: f32,
@@ -75,80 +75,6 @@ pub struct Configuration {
     title: Option<String>,
     app_id: Option<String>,
     notification_thumbnail: NotificationThumbnail,
-}
-
-pub struct Keybinds {
-    shortcuts: HashMap<char, Tools>,
-}
-
-impl Keybinds {
-    pub fn get_tool(&self, key: char) -> Option<Tools> {
-        self.shortcuts.get(&key).copied()
-    }
-
-    pub fn shortcuts(&self) -> &HashMap<char, Tools> {
-        &self.shortcuts
-    }
-
-    /// Update a single keybind, only if it is valid
-    fn update_keybind(&mut self, key: Option<String>, tool: Tools) {
-        if let Some(key_str) = key
-            && let Some(validated_key) = Self::validate_keybind(&key_str, tool)
-        {
-            self.shortcuts.retain(|_, v| *v != tool);
-            self.shortcuts.insert(validated_key, tool);
-        }
-    }
-
-    /// A shortcut keybinding is only valid if it is one char
-    fn validate_keybind(key: &str, tool: Tools) -> Option<char> {
-        let mut chars = key.chars();
-        match (chars.next(), chars.next()) {
-            (Some(c), None) => Some(c),
-            _ => {
-                eprintln!(
-                    "Warning: Invalid keybind: '{} = {}'. Keybinds must be single characters. Using default keybind instead.",
-                    tool, key
-                );
-                None
-            }
-        }
-    }
-
-    /// Merge keybindings with default
-    /// Only replaces defaults if they are set
-    fn merge(&mut self, file_keybinds: KeybindsFile) {
-        self.update_keybind(file_keybinds.pointer, Tools::Pointer);
-        self.update_keybind(file_keybinds.crop, Tools::Crop);
-        self.update_keybind(file_keybinds.brush, Tools::Brush);
-        self.update_keybind(file_keybinds.line, Tools::Line);
-        self.update_keybind(file_keybinds.arrow, Tools::Arrow);
-        self.update_keybind(file_keybinds.rectangle, Tools::Rectangle);
-        self.update_keybind(file_keybinds.ellipse, Tools::Ellipse);
-        self.update_keybind(file_keybinds.text, Tools::Text);
-        self.update_keybind(file_keybinds.marker, Tools::Marker);
-        self.update_keybind(file_keybinds.blur, Tools::Blur);
-        self.update_keybind(file_keybinds.highlight, Tools::Highlight);
-    }
-}
-
-impl Default for Keybinds {
-    fn default() -> Self {
-        let mut shortcuts = HashMap::new();
-        shortcuts.insert('p', Tools::Pointer);
-        shortcuts.insert('c', Tools::Crop);
-        shortcuts.insert('b', Tools::Brush);
-        shortcuts.insert('i', Tools::Line);
-        shortcuts.insert('z', Tools::Arrow);
-        shortcuts.insert('r', Tools::Rectangle);
-        shortcuts.insert('e', Tools::Ellipse);
-        shortcuts.insert('t', Tools::Text);
-        shortcuts.insert('m', Tools::Marker);
-        shortcuts.insert('u', Tools::Blur);
-        shortcuts.insert('g', Tools::Highlight);
-
-        Self { shortcuts }
-    }
 }
 
 #[derive(Default)]
@@ -293,7 +219,7 @@ impl From<Vec<EarlyExitTriggers>> for EarlyExit {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Action {
     SaveToClipboard,
@@ -344,6 +270,7 @@ impl Configuration {
 
         APP_CONFIG.write().merge(file, command_line);
     }
+
     fn merge_general(&mut self, general: ConfigurationFileGeneral) {
         if let Some(v) = general.fullscreen {
             self.fullscreen = Some(v);
@@ -448,6 +375,7 @@ impl Configuration {
         }
         // ---
     }
+
     fn merge(&mut self, file: Option<ConfigurationFile>, command_line: CommandLine) {
         // input_filename is required and needs to be overwritten
         self.input_filename = command_line.filename;
@@ -463,9 +391,7 @@ impl Configuration {
             if let Some(v) = file.font {
                 self.font.merge(v);
             }
-            if let Some(v) = file.keybinds {
-                self.keybinds.merge(v);
-            }
+            self.keybinds = file.keybinds.unwrap_or_default();
         }
 
         // overwrite with all specified values from command line
@@ -707,7 +633,7 @@ impl Configuration {
         self.brush_smooth_history_size
     }
 
-    pub fn keybinds(&self) -> &Keybinds {
+    pub fn keybinds(&self) -> &HashMap<String, String> {
         &self.keybinds
     }
 
@@ -771,7 +697,7 @@ impl Default for Configuration {
             profile_startup: false,
             no_window_decoration: false,
             brush_smooth_history_size: 0, // default to 0, no history
-            keybinds: Keybinds::default(),
+            keybinds: HashMap::new(),
             zoom_factor: 1.1,
             pan_step_size: 50.,
             text_move_length: 50.0,
@@ -804,23 +730,7 @@ struct ConfigurationFile {
     general: Option<ConfigurationFileGeneral>,
     color_palette: Option<ColorPaletteFile>,
     font: Option<FontFile>,
-    keybinds: Option<KeybindsFile>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-struct KeybindsFile {
-    pointer: Option<String>,
-    crop: Option<String>,
-    brush: Option<String>,
-    line: Option<String>,
-    arrow: Option<String>,
-    rectangle: Option<String>,
-    ellipse: Option<String>,
-    text: Option<String>,
-    marker: Option<String>,
-    blur: Option<String>,
-    highlight: Option<String>,
+    keybinds: Option<HashMap<String, String>>,
 }
 
 #[derive(Deserialize)]

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -45,6 +45,7 @@ pub enum ShortcutCommand {
     SelectSize(Size),
     FocusAnnotationSizeFactor,
     ToggleFill,
+    ToggleRoundCaps,
 }
 
 impl fmt::Display for ShortcutCommand {
@@ -96,6 +97,7 @@ impl fmt::Display for ShortcutCommand {
             },
             ShortcutCommand::FocusAnnotationSizeFactor => "focus-annotation-size-factor",
             ShortcutCommand::ToggleFill => "toggle-fill",
+            ShortcutCommand::ToggleRoundCaps => "toggle-round-caps",
         };
         write!(f, "{}", name)
     }
@@ -161,7 +163,7 @@ impl FromStr for ShortcutCommand {
             "select-size:large" => Ok(ShortcutCommand::SelectSize(Size::Large)),
             "focus-annotation-size-factor" => Ok(ShortcutCommand::FocusAnnotationSizeFactor),
             "toggle-fill" => Ok(ShortcutCommand::ToggleFill),
-
+            "toggle-round-caps" => Ok(ShortcutCommand::ToggleRoundCaps),
             _ => Err(ParseCommandError),
         }
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1,0 +1,355 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+use std::sync::OnceLock;
+
+use relm4::gtk;
+use relm4::gtk::gdk::{Key, ModifierType};
+
+use crate::configuration::{APP_CONFIG, Action};
+use crate::sketch_board::KeyEventMsg;
+use crate::style::Size;
+use crate::tools::Tools;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionTrigger {
+    Escape,
+    Enter,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShortcutCommand {
+    // generic
+    ToggleToolbars,
+    OpenGtkInspector,
+    PanLeft,
+    PanRight,
+    PanUp,
+    PanDown,
+    Zoom(i16),
+    DeleteSelection,
+    RunConfiguredActions(ActionTrigger),
+
+    // top toolbar
+    OriginalScale,
+    FitToWindow,
+    ClearAll,
+    SelectTool(Tools),
+    Undo,
+    Redo,
+    RunAction(Action),
+
+    // bottom toolbar
+    SelectColorIndex(u64),
+    CycleSize,
+    SelectSize(Size),
+    FocusAnnotationSizeFactor,
+    ToggleFill,
+}
+
+impl fmt::Display for ShortcutCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            // generic
+            ShortcutCommand::OpenGtkInspector => "open-gtk-inspector",
+            ShortcutCommand::PanLeft => "pan-left",
+            ShortcutCommand::PanRight => "pan-right",
+            ShortcutCommand::PanUp => "pan-up",
+            ShortcutCommand::PanDown => "pan-down",
+            ShortcutCommand::Zoom(factor) => {
+                write!(f, "zoom:{}", factor)?;
+                return Ok(());
+            }
+            ShortcutCommand::DeleteSelection => "delete-selection",
+            ShortcutCommand::RunConfiguredActions(ActionTrigger::Escape) => "run-actions-on-escape",
+            ShortcutCommand::RunConfiguredActions(ActionTrigger::Enter) => "run-actions-on-enter",
+            ShortcutCommand::ToggleToolbars => "toggle-toolbars",
+
+            // top toolbar
+            ShortcutCommand::OriginalScale => "original-scale",
+            ShortcutCommand::FitToWindow => "fit-to-window",
+            ShortcutCommand::ClearAll => "clear-all",
+            ShortcutCommand::Undo => "undo",
+            ShortcutCommand::Redo => "redo",
+            ShortcutCommand::SelectTool(tool) => {
+                write!(f, "{}", tool.to_string().to_lowercase())?;
+                return Ok(());
+            }
+            ShortcutCommand::RunAction(action) => match action {
+                Action::SaveToClipboard => "save-to-clipboard",
+                Action::SaveToFile => "save-to-file",
+                Action::SaveToFileAs => "save-to-file-as",
+                Action::CopyFilepathToClipboard => "copy-filepath-to-clipboard",
+                Action::Exit => "exit",
+            },
+
+            // bottom toolbar
+            ShortcutCommand::SelectColorIndex(index) => {
+                write!(f, "select-color-index:{}", index + 1)?;
+                return Ok(());
+            }
+            ShortcutCommand::CycleSize => "cycle-size",
+            ShortcutCommand::SelectSize(size) => match size {
+                Size::Small => "select-size:small",
+                Size::Medium => "select-size:medium",
+                Size::Large => "select-size:large",
+            },
+            ShortcutCommand::FocusAnnotationSizeFactor => "focus-annotation-size-factor",
+            ShortcutCommand::ToggleFill => "toggle-fill",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseCommandError;
+
+impl FromStr for ShortcutCommand {
+    type Err = ParseCommandError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            // generic
+            "open-gtk-inspector" => Ok(ShortcutCommand::OpenGtkInspector),
+            "toggle-toolbars" => Ok(ShortcutCommand::ToggleToolbars),
+            "pan-left" => Ok(ShortcutCommand::PanLeft),
+            "pan-right" => Ok(ShortcutCommand::PanRight),
+            "pan-up" => Ok(ShortcutCommand::PanUp),
+            "pan-down" => Ok(ShortcutCommand::PanDown),
+            text if text.starts_with("zoom:") => {
+                let num_str = text.strip_prefix("zoom:").unwrap();
+                if let Ok(num) = num_str.parse::<i16>() {
+                    return Ok(ShortcutCommand::Zoom(num));
+                }
+                Err(ParseCommandError)
+            }
+            "delete-selection" => Ok(ShortcutCommand::DeleteSelection),
+            "run-actions-on-escape" => {
+                Ok(ShortcutCommand::RunConfiguredActions(ActionTrigger::Escape))
+            }
+            "run-actions-on-enter" => {
+                Ok(ShortcutCommand::RunConfiguredActions(ActionTrigger::Enter))
+            }
+
+            // top toolbar
+            "original-scale" => Ok(ShortcutCommand::OriginalScale),
+            "fit-to-window" => Ok(ShortcutCommand::FitToWindow),
+            "clear-all" => Ok(ShortcutCommand::ClearAll),
+            "undo" => Ok(ShortcutCommand::Undo),
+            "redo" => Ok(ShortcutCommand::Redo),
+            "select-tool" => Ok(ShortcutCommand::SelectTool(Tools::Rectangle)),
+            "save-to-file" => Ok(ShortcutCommand::RunAction(Action::SaveToFile)),
+            "save-to-file-as" => Ok(ShortcutCommand::RunAction(Action::SaveToFileAs)),
+            "save-to-clipboard" => Ok(ShortcutCommand::RunAction(Action::SaveToClipboard)),
+            "copy-filepath-to-clipboard" => {
+                Ok(ShortcutCommand::RunAction(Action::CopyFilepathToClipboard))
+            }
+            "exit" => Ok(ShortcutCommand::RunAction(Action::Exit)),
+
+            // bottom toolbar
+            text if text.starts_with("select-color-index:") => {
+                let num_str = text.strip_prefix("select-color-index:").unwrap();
+
+                if let Some(num) = num_str.parse::<u64>().ok().filter(|n| *n > 0) {
+                    return Ok(ShortcutCommand::SelectColorIndex(num - 1));
+                }
+                Err(ParseCommandError)
+            }
+            "cycle-size" => Ok(ShortcutCommand::CycleSize),
+            "select-size:small" => Ok(ShortcutCommand::SelectSize(Size::Small)),
+            "select-size:medium" => Ok(ShortcutCommand::SelectSize(Size::Medium)),
+            "select-size:large" => Ok(ShortcutCommand::SelectSize(Size::Large)),
+            "focus-annotation-size-factor" => Ok(ShortcutCommand::FocusAnnotationSizeFactor),
+            "toggle-fill" => Ok(ShortcutCommand::ToggleFill),
+
+            _ => Err(ParseCommandError),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct KeyBinding {
+    modifiers: ModifierType,
+    key: Key,
+}
+
+impl KeyBinding {
+    fn from_binding_str(key_binding: &str) -> Result<Self, String> {
+        if let Some((key, modifiers)) = gtk::accelerator_parse(key_binding) {
+            if gtk::accelerator_valid(key, modifiers) {
+                Ok(KeyBinding { modifiers, key })
+            } else {
+                Err(format!(
+                    "Keybinding '{}' parsed successfully but not a valid hardware shortcut context.",
+                    key_binding
+                ))
+            }
+        } else {
+            Err(format!(
+                "Syntax Error: '{}' is not a recognized GTK accelerator string name.",
+                key_binding
+            ))
+        }
+    }
+}
+
+impl fmt::Display for KeyBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", gtk::accelerator_name(self.key, self.modifiers))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ShortcutRegistry {
+    key_bindings: HashMap<KeyBinding, ShortcutCommand>,
+}
+
+impl ShortcutRegistry {
+    fn add_key_binding(&mut self, key_binding_str: &str, command: ShortcutCommand) {
+        match KeyBinding::from_binding_str(key_binding_str) {
+            Ok(key_binding) => {
+                self.key_bindings.insert(key_binding, command);
+            }
+            Err(err) => {
+                eprintln!(
+                    "Invalid key binding '{}' for command {:?}: {}",
+                    key_binding_str, command, err
+                );
+            }
+        }
+    }
+
+    pub fn from_config() -> Self {
+        static REGISTRY: OnceLock<ShortcutRegistry> = OnceLock::new();
+        REGISTRY.get_or_init(Self::build_from_config).clone()
+    }
+
+    fn build_from_config() -> Self {
+        let mut registry = Self::default();
+
+        // generic
+        registry.add_key_binding("<Shift><Control>d", ShortcutCommand::OpenGtkInspector);
+        registry.add_key_binding("<Shift><Control>i", ShortcutCommand::OpenGtkInspector);
+        registry.add_key_binding("<Control>t", ShortcutCommand::ToggleToolbars);
+        registry.add_key_binding("<Alt>Left", ShortcutCommand::PanLeft);
+        registry.add_key_binding("<Alt>Right", ShortcutCommand::PanRight);
+        registry.add_key_binding("<Alt>Up", ShortcutCommand::PanUp);
+        registry.add_key_binding("<Alt>Down", ShortcutCommand::PanDown);
+        registry.add_key_binding("<Control>plus", ShortcutCommand::Zoom(1));
+        registry.add_key_binding("<Control>minus", ShortcutCommand::Zoom(-1));
+        registry.add_key_binding("Delete", ShortcutCommand::DeleteSelection);
+        registry.add_key_binding("<Shift>Delete", ShortcutCommand::ClearAll);
+        registry.add_key_binding(
+            "Escape",
+            ShortcutCommand::RunConfiguredActions(ActionTrigger::Escape),
+        );
+        registry.add_key_binding(
+            "Return",
+            ShortcutCommand::RunConfiguredActions(ActionTrigger::Enter),
+        );
+        registry.add_key_binding(
+            "KP_Enter",
+            ShortcutCommand::RunConfiguredActions(ActionTrigger::Enter),
+        );
+
+        // top toolbar
+        type SC = ShortcutCommand;
+        type A = Action;
+        registry.add_key_binding("<Control>1", SC::OriginalScale);
+        registry.add_key_binding("<Control>2", SC::FitToWindow);
+        registry.add_key_binding("<Control>z", SC::Undo);
+        registry.add_key_binding("<Control>y", SC::Redo);
+        registry.add_key_binding("p", SC::SelectTool(Tools::Pointer));
+        registry.add_key_binding("c", SC::SelectTool(Tools::Crop));
+        registry.add_key_binding("b", SC::SelectTool(Tools::Brush));
+        registry.add_key_binding("i", SC::SelectTool(Tools::Line));
+        registry.add_key_binding("z", SC::SelectTool(Tools::Arrow));
+        registry.add_key_binding("r", SC::SelectTool(Tools::Rectangle));
+        registry.add_key_binding("e", SC::SelectTool(Tools::Ellipse));
+        registry.add_key_binding("t", SC::SelectTool(Tools::Text));
+        registry.add_key_binding("m", SC::SelectTool(Tools::Marker));
+        registry.add_key_binding("u", SC::SelectTool(Tools::Blur));
+        registry.add_key_binding("g", SC::SelectTool(Tools::Highlight));
+        registry.add_key_binding("<Control>c", SC::RunAction(A::SaveToClipboard));
+        registry.add_key_binding("<Control><Alt>c", SC::RunAction(A::CopyFilepathToClipboard));
+        registry.add_key_binding("<Control>s", SC::RunAction(A::SaveToFile));
+        registry.add_key_binding("<Shift><Control>s", SC::RunAction(A::SaveToFileAs));
+
+        // bottom toolbar
+        for i in 1..11 {
+            let key = (i % 10).to_string();
+            registry.add_key_binding(&key, SC::SelectColorIndex(i - 1));
+        }
+
+        registry.add_key_binding("minus", SC::CycleSize);
+        registry.add_key_binding("s", SC::FocusAnnotationSizeFactor);
+        registry.add_key_binding("f", SC::ToggleFill);
+
+        // merge with config keybinds, allowing config to override defaults
+        for (kb_str, tool_or_cmd) in APP_CONFIG.read().keybinds() {
+            if let Ok(tool) = Tools::from_str(tool_or_cmd.as_str()) {
+                registry.add_key_binding(kb_str, SC::SelectTool(tool));
+            } else if let Ok(tool) = Tools::from_str(kb_str.as_str()) {
+                registry.add_key_binding(tool_or_cmd, SC::SelectTool(tool));
+                eprintln!("Deprecated syntax for key binding: {kb_str} = \"{tool_or_cmd}\"");
+                eprintln!("    Please update the config to: \"{tool_or_cmd}\" = \"{kb_str}\"");
+            } else if let Ok(command) = SC::from_str(tool_or_cmd.as_str()) {
+                registry.add_key_binding(kb_str, command);
+            } else if tool_or_cmd == "none" {
+                match KeyBinding::from_binding_str(kb_str) {
+                    Ok(key_binding) => {
+                        registry.key_bindings.remove(&key_binding);
+                    }
+                    Err(err) => {
+                        eprintln!(
+                            "Invalid key binding '{}' for command 'none': {}",
+                            kb_str, err
+                        );
+                    }
+                }
+            } else {
+                eprintln!("Unknown tool or command in config for key '{kb_str}': '{tool_or_cmd}'");
+            }
+        }
+
+        registry
+    }
+
+    pub fn get_command_for_key_event(&self, event: &KeyEventMsg) -> Option<ShortcutCommand> {
+        let modifier_only = matches!(
+            event.key,
+            Key::Control_L
+                | Key::Control_R
+                | Key::Shift_L
+                | Key::Shift_R
+                | Key::Alt_L
+                | Key::Alt_R
+                | Key::Meta_L
+                | Key::Meta_R
+                | Key::Super_L
+                | Key::Super_R
+        );
+        let key_binding = KeyBinding {
+            key: event.key,
+            modifiers: event.modifier,
+        };
+        if let Some(command) = self.key_bindings.get(&key_binding) {
+            Some(*command)
+        } else if !modifier_only {
+            eprintln!("\"{}\" is not bound to a command or tool", key_binding);
+            None
+        } else {
+            None
+        }
+    }
+
+    pub fn get_binding_for_command(&self, command: ShortcutCommand) -> Option<String> {
+        self.key_bindings.iter().find_map(|(binding, cmd)| {
+            if *cmd == command {
+                Some(gtk::accelerator_get_label(binding.key, binding.modifiers).to_string())
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ enum AppInput {
     ColorSwitchShortcut(u64),
     SetColor(Color),
     SetFill(bool),
+    SetRoundCaps(bool),
     SetSize(Size),
     FocusAnnotationSizeFactorShortcut,
     ScaleFactorChanged,
@@ -302,6 +303,11 @@ impl Component for App {
                     .sender()
                     .emit(StyleToolbarInput::SetFill(fill_enabled));
             }
+            AppInput::SetRoundCaps(round_caps_enabled) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetRoundCaps(round_caps_enabled));
+            }
             AppInput::SetSize(size) => {
                 self.style_toolbar
                     .sender()
@@ -382,6 +388,9 @@ impl Component for App {
                     }
                     SketchBoardOutput::SetColor(color) => AppInput::SetColor(color),
                     SketchBoardOutput::SetFill(fill_enabled) => AppInput::SetFill(fill_enabled),
+                    SketchBoardOutput::SetRoundCaps(round_caps_enabled) => {
+                        AppInput::SetRoundCaps(round_caps_enabled)
+                    }
                     SketchBoardOutput::SetSize(size) => AppInput::SetSize(size),
                     SketchBoardOutput::FocusAnnotationSizeFactorShortcut => {
                         AppInput::FocusAnnotationSizeFactorShortcut

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod configuration;
 mod femtovg_area;
 mod icons;
 mod ime;
+mod keybindings;
 mod math;
 mod notification;
 mod sketch_board;
@@ -36,6 +37,7 @@ mod tools;
 mod ui;
 
 use crate::sketch_board::{SketchBoard, SketchBoardInput};
+use crate::style::{Color, Size};
 use crate::tools::Tools;
 
 pub static START_TIME: LazyLock<chrono::DateTime<chrono::Local>> =
@@ -78,6 +80,10 @@ enum AppInput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    SetColor(Color),
+    SetFill(bool),
+    SetSize(Size),
+    FocusAnnotationSizeFactorShortcut,
     ScaleFactorChanged,
     FullscreenChanged(bool),
     DimensionsUpdate(Option<(i32, i32)>),
@@ -286,6 +292,26 @@ impl Component for App {
                     .sender()
                     .emit(StyleToolbarInput::ColorButtonSelected(color_button));
             }
+            AppInput::SetColor(color) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetColor(color));
+            }
+            AppInput::SetFill(fill_enabled) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetFill(fill_enabled));
+            }
+            AppInput::SetSize(size) => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetSize(size));
+            }
+            AppInput::FocusAnnotationSizeFactorShortcut => {
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::FocusAnnotationSizeFactor);
+            }
             AppInput::ScaleFactorChanged => {
                 self.sketch_board
                     .sender()
@@ -353,6 +379,12 @@ impl Component for App {
                     }
                     SketchBoardOutput::ColorSwitchShortcut(index) => {
                         AppInput::ColorSwitchShortcut(index)
+                    }
+                    SketchBoardOutput::SetColor(color) => AppInput::SetColor(color),
+                    SketchBoardOutput::SetFill(fill_enabled) => AppInput::SetFill(fill_enabled),
+                    SketchBoardOutput::SetSize(size) => AppInput::SetSize(size),
+                    SketchBoardOutput::FocusAnnotationSizeFactorShortcut => {
+                        AppInput::FocusAnnotationSizeFactorShortcut
                     }
                     SketchBoardOutput::DimensionsUpdate(dimensions) => {
                         AppInput::DimensionsUpdate(dimensions)

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -2,10 +2,9 @@ use anyhow::anyhow;
 
 use femtovg::imgref::Img;
 use femtovg::rgb::{ComponentBytes, RGBA};
-use keycode::{KeyMap, KeyMappingId};
 use relm4::gtk::gdk_pixbuf::Pixbuf;
 use relm4::gtk::gdk_pixbuf::glib::Bytes;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::io::Write;
 use std::panic;
 use std::path::{Path, PathBuf};
@@ -21,9 +20,10 @@ use relm4::{Component, ComponentParts, ComponentSender, RelmWidgetExt, gtk};
 use crate::configuration::{APP_CONFIG, Action};
 use crate::femtovg_area::FemtoVGArea;
 use crate::ime::pango_adapter::spans_from_pango_attrs;
+use crate::keybindings::{ActionTrigger, ShortcutCommand, ShortcutRegistry};
 use crate::math::Vec2D;
 use crate::notification::{log_result, log_result_with_pixbuf};
-use crate::style::Style;
+use crate::style::{Color, Size, Style};
 use crate::tools::{Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
 use crate::ui::toolbars::ToolbarEvent;
 use xdg::BaseDirectories;
@@ -53,6 +53,10 @@ pub enum SketchBoardOutput {
     ToggleToolbarsDisplay,
     ToolSwitchShortcut(Tools),
     ColorSwitchShortcut(u64),
+    SetColor(Color),
+    SetSize(Size),
+    FocusAnnotationSizeFactorShortcut,
+    SetFill(bool),
     DimensionsUpdate(Option<(i32, i32)>),
     ToolEditingChanged(bool),
 }
@@ -270,6 +274,8 @@ impl InputEvent {
 
 pub struct SketchBoard {
     renderer: FemtoVGArea,
+    ime_enabled: Rc<Cell<bool>>,
+    shortcut_registry: ShortcutRegistry,
     active_tool: Rc<RefCell<dyn Tool>>,
     tool_edit_mode: bool,
     tools: ToolsManager,
@@ -838,6 +844,9 @@ impl SketchBoard {
             }
             ToolbarEvent::SizeSelected(size) => {
                 self.style.size = size;
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::SetSize(self.style.size));
                 self.active_tool
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))
@@ -849,6 +858,9 @@ impl SketchBoard {
             ToolbarEvent::ClearAll => self.handle_clear_all(),
             ToolbarEvent::ToggleFill => {
                 self.style.fill = !self.style.fill;
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::SetFill(self.style.fill));
                 self.active_tool
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))
@@ -864,6 +876,13 @@ impl SketchBoard {
                 self.active_tool
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))
+            }
+            ToolbarEvent::SetFill(fill_enabled) => {
+                self.style.fill = fill_enabled;
+                self.active_tool
+                    .borrow_mut()
+                    .handle_event(ToolEvent::StyleChanged(self.style));
+                ToolUpdateResult::Redraw
             }
             ToolbarEvent::SaveFileAs => self.handle_action(&[Action::SaveToFileAs]),
             ToolbarEvent::Resize => self.handle_resize(),
@@ -894,28 +913,6 @@ impl SketchBoard {
                     sender.input(SketchBoardInput::new_text_event(TextEventMsg::Commit(
                         txt.to_string(),
                     )));
-                } else if let Some(tool) = txt
-                    .chars()
-                    .next()
-                    .and_then(|char| APP_CONFIG.read().keybinds().get_tool(char))
-                {
-                    sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::ToolSelected(
-                        tool,
-                    )));
-                    sender
-                        .output_sender()
-                        .emit(SketchBoardOutput::ToolSwitchShortcut(tool));
-                } else if let Some(hotkey_digit) =
-                    txt.chars().next().and_then(|char| char.to_digit(10))
-                {
-                    let index_digit = if hotkey_digit == 0 {
-                        9
-                    } else {
-                        hotkey_digit - 1
-                    };
-                    sender
-                        .output_sender()
-                        .emit(SketchBoardOutput::ColorSwitchShortcut(index_digit as u64));
                 }
             }
             TextEventMsg::Preedit {
@@ -946,6 +943,117 @@ impl SketchBoard {
 
     pub fn active_tool_type(&self) -> Tools {
         self.active_tool.borrow().get_tool_type()
+    }
+
+    fn dispatch_key_shortcut_command(
+        &mut self,
+        command: ShortcutCommand,
+        sender: ComponentSender<Self>,
+        active_tool_result: ToolUpdateResult,
+    ) -> ToolUpdateResult {
+        match command {
+            ShortcutCommand::SelectTool(tool) => {
+                sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::ToolSelected(
+                    tool,
+                )));
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::ToolSwitchShortcut(tool));
+                ToolUpdateResult::RedrawAndStopPropagation
+            }
+            ShortcutCommand::SelectColorIndex(index) => {
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::ColorSwitchShortcut(index));
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::SelectSize(size) => {
+                sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::SizeSelected(
+                    size,
+                )));
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::CycleSize => {
+                self.style.size = match self.style.size {
+                    Size::Small => Size::Large,
+                    Size::Medium => Size::Small,
+                    Size::Large => Size::Medium,
+                };
+                sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::SizeSelected(
+                    self.style.size,
+                )));
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::FocusAnnotationSizeFactor => {
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::FocusAnnotationSizeFactorShortcut);
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::ToggleFill => {
+                sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::ToggleFill));
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::Undo => self.handle_undo(),
+            ShortcutCommand::Redo => self.handle_redo(),
+            ShortcutCommand::ToggleToolbars => self.handle_toggle_toolbars_display(sender),
+            ShortcutCommand::RunAction(action) => {
+                self.renderer.request_render(&[action]);
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::OpenGtkInspector => {
+                gtk::Window::set_interactive_debugging(true);
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::PanLeft
+            | ShortcutCommand::PanRight
+            | ShortcutCommand::PanUp
+            | ShortcutCommand::PanDown => {
+                let pan_step_size = APP_CONFIG.read().pan_step_size();
+                let (x, y) = match command {
+                    ShortcutCommand::PanLeft => (-pan_step_size, 0.),
+                    ShortcutCommand::PanRight => (pan_step_size, 0.),
+                    ShortcutCommand::PanUp => (0., -pan_step_size),
+                    ShortcutCommand::PanDown => (0., pan_step_size),
+                    _ => (0., 0.),
+                };
+                self.renderer.set_drag_offset(Vec2D::new(x, y));
+                self.renderer.store_last_offset();
+                self.renderer.request_render(&[]);
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::Zoom(step_count) => {
+                if step_count != 0 {
+                    let zoom_factor = APP_CONFIG.read().zoom_factor();
+                    let scale = if step_count > 0 {
+                        zoom_factor.powi(step_count as i32)
+                    } else {
+                        (1.0 / zoom_factor).powi((-step_count) as i32)
+                    };
+                    self.renderer.set_pointer_offset_center();
+                    self.renderer.set_zoom_scale(scale);
+                    self.renderer.request_render(&[]);
+                }
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::OriginalScale => self.handle_original_scale(),
+            ShortcutCommand::FitToWindow => self.handle_resize(),
+            ShortcutCommand::DeleteSelection => {
+                // Placeholder for future delete selection implementation
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::ClearAll => self.handle_clear_all(),
+            ShortcutCommand::RunConfiguredActions(trigger) => {
+                if let ToolUpdateResult::Unmodified = active_tool_result {
+                    let actions = match trigger {
+                        ActionTrigger::Escape => APP_CONFIG.read().actions_on_escape(),
+                        ActionTrigger::Enter => APP_CONFIG.read().actions_on_enter(),
+                    };
+                    self.renderer.request_render(&actions);
+                }
+                active_tool_result
+            }
+        }
     }
 }
 
@@ -1060,8 +1168,12 @@ impl Component for SketchBoard {
                 },
 
                 add_controller = gtk::EventControllerKey {
-                    connect_key_pressed[sender] => move |controller, key, code, modifier | {
-                        if let Some(im_context) = controller.im_context() {
+                    connect_key_pressed[
+                        sender,
+                        im_context = model.im_context.clone(),
+                        ime_enabled = model.ime_enabled.clone()] => move |controller, key, code, modifier | {
+                        // for text tool we propagate to IME
+                        if ime_enabled.get() {
                             im_context.focus_in();
                             if !im_context.filter_keypress(controller.current_event().unwrap()) {
                                 sender.input(SketchBoardInput::new_key_event(KeyEventMsg::new(key, code, modifier)));
@@ -1082,7 +1194,6 @@ impl Component for SketchBoard {
                             sender.input(SketchBoardInput::new_key_release_event(KeyEventMsg::new(key, code, modifier)));
                         }
                     },
-                    set_im_context: Some(&model.im_context),
                 },
 
                 add_controller = gtk::EventControllerMotion {
@@ -1102,6 +1213,16 @@ impl Component for SketchBoard {
     }
 
     fn update(&mut self, msg: SketchBoardInput, sender: ComponentSender<Self>, _root: &Self::Root) {
+        let ime_should_be_enabled =
+            self.active_tool_type() == Tools::Text && self.active_tool.borrow().input_enabled();
+
+        if !self.ime_enabled.get() && ime_should_be_enabled {
+            self.ime_enabled.set(true);
+        } else if self.ime_enabled.get() && !ime_should_be_enabled {
+            self.ime_enabled.set(false);
+            self.im_context.focus_out();
+        }
+
         // handle resize ourselves, pass everything else to tool
         let sender_clone = sender.clone();
         let result = match msg {
@@ -1112,112 +1233,23 @@ impl Component for SketchBoard {
                         .borrow_mut()
                         .handle_event(ToolEvent::Input(ie.clone()));
 
-                    // eprintln!("active_tool_result={:?}", active_tool_result);
-
                     match active_tool_result {
                         ToolUpdateResult::StopPropagation
                         | ToolUpdateResult::RedrawAndStopPropagation => active_tool_result,
-                        _ => {
-                            if ke.key == Key::y && ke.modifier == ModifierType::CONTROL_MASK {
-                                self.handle_redo()
-                            } else if ke.is_one_of(Key::z, KeyMappingId::UsZ)
-                                && ke.modifier == ModifierType::CONTROL_MASK
+                        ToolUpdateResult::Unmodified => {
+                            if let Some(command) =
+                                self.shortcut_registry.get_command_for_key_event(&ke)
                             {
-                                self.handle_undo()
-                            } else if ke.is_one_of(Key::y, KeyMappingId::UsY)
-                                && ke.modifier == ModifierType::CONTROL_MASK
-                            {
-                                self.handle_redo()
-                            } else if ke.is_one_of(Key::t, KeyMappingId::UsT)
-                                && ke.modifier == ModifierType::CONTROL_MASK
-                            {
-                                self.handle_toggle_toolbars_display(sender)
-                            } else if ke.is_one_of(Key::s, KeyMappingId::UsS)
-                                && ke.modifier == ModifierType::CONTROL_MASK
-                            {
-                                self.renderer.request_render(&[Action::SaveToFile]);
-                                ToolUpdateResult::Unmodified
-                            } else if ke.is_one_of(Key::s, KeyMappingId::UsS)
-                                && ke.modifier
-                                    == (ModifierType::CONTROL_MASK | ModifierType::SHIFT_MASK)
-                            {
-                                self.renderer.request_render(&[Action::SaveToFileAs]);
-                                ToolUpdateResult::Unmodified
-                            } else if ke.is_one_of(Key::c, KeyMappingId::UsC)
-                                && ke.modifier == ModifierType::CONTROL_MASK
-                            {
-                                self.renderer.request_render(&[Action::SaveToClipboard]);
-                                ToolUpdateResult::Unmodified
-                            } else if ke.is_one_of(Key::c, KeyMappingId::UsC)
-                                && ke.modifier
-                                    == (ModifierType::CONTROL_MASK | ModifierType::ALT_MASK)
-                            {
-                                self.renderer
-                                    .request_render(&[Action::CopyFilepathToClipboard]);
-                                ToolUpdateResult::Unmodified
-                            } else if (ke.is_one_of(Key::d, KeyMappingId::UsD)
-                                || ke.is_one_of(Key::i, KeyMappingId::UsI))
-                                && ke.modifier
-                                    == (ModifierType::CONTROL_MASK | ModifierType::SHIFT_MASK)
-                            {
-                                /* GTK does not appear to offer any tracking for this, so
-                                we'd have to track the state ourselves. But since the user may
-                                just choose to close the inspector window, doing so adds little
-                                benefit.
-
-                                Just enable it everytime, and let the user close the window if they
-                                so wish.
-                                 */
-                                gtk::Window::set_interactive_debugging(true);
-                                ToolUpdateResult::Unmodified
-                            } else if (ke.is_one_of(Key::leftarrow, KeyMappingId::ArrowLeft)
-                                || ke.is_one_of(Key::rightarrow, KeyMappingId::ArrowRight)
-                                || ke.is_one_of(Key::uparrow, KeyMappingId::ArrowUp)
-                                || ke.is_one_of(Key::downarrow, KeyMappingId::ArrowDown))
-                                && ke.modifier == ModifierType::ALT_MASK
-                            {
-                                let pan_step_size = APP_CONFIG.read().pan_step_size();
-                                match ke.key {
-                                    Key::Left => self
-                                        .renderer
-                                        .set_drag_offset(Vec2D::new(-pan_step_size, 0.)),
-                                    Key::Right => {
-                                        self.renderer.set_drag_offset(Vec2D::new(pan_step_size, 0.))
-                                    }
-                                    Key::Up => self
-                                        .renderer
-                                        .set_drag_offset(Vec2D::new(0., -pan_step_size)),
-                                    Key::Down => {
-                                        self.renderer.set_drag_offset(Vec2D::new(0., pan_step_size))
-                                    }
-                                    _ => { /* unreachable */ }
-                                }
-
-                                self.renderer.store_last_offset();
-                                self.renderer.request_render(&[]);
-                                ToolUpdateResult::Unmodified
-                            } else if ke.modifier.is_empty() && ke.key == Key::Delete {
-                                self.handle_clear_all()
-                            } else if ke.modifier.is_empty()
-                                && (ke.key == Key::Escape
-                                    || ke.key == Key::Return
-                                    || ke.key == Key::KP_Enter)
-                            {
-                                // First, let the tool handle the event. If the tool does nothing, we can do our thing (otherwise require a second keyboard press)
-                                // Relying on ToolUpdateResult::Unmodified is probably not a good idea, but it's the only way at the moment. See discussion in #144
-                                if let ToolUpdateResult::Unmodified = active_tool_result {
-                                    let actions = if ke.key == Key::Escape {
-                                        APP_CONFIG.read().actions_on_escape()
-                                    } else {
-                                        APP_CONFIG.read().actions_on_enter()
-                                    };
-                                    self.renderer.request_render(&actions);
-                                };
-                                active_tool_result
+                                self.dispatch_key_shortcut_command(
+                                    command,
+                                    sender,
+                                    active_tool_result,
+                                )
                             } else {
                                 active_tool_result
                             }
                         }
+                        _ => active_tool_result,
                     }
                 } else {
                     if let InputEvent::Mouse(me) = &ie
@@ -1333,8 +1365,15 @@ impl Component for SketchBoard {
 
         let im_context = gtk::IMMulticontext::new();
 
+        let text_tool = tools.get_text_tool();
+
+        let initial_ime_enabled =
+            config.initial_tool() == Tools::Text && text_tool.borrow().input_enabled();
+
         let mut model = Self {
             renderer: FemtoVGArea::default(),
+            ime_enabled: Rc::new(Cell::new(initial_ime_enabled)),
+            shortcut_registry: ShortcutRegistry::from_config(),
             active_tool: tools.get(&config.initial_tool()),
             tool_edit_mode: false,
             style: Style::default(),
@@ -1432,17 +1471,6 @@ impl KeyEventMsg {
             code,
             modifier,
         }
-    }
-
-    /// Matches one of providen keys. The modifier is not considered.
-    /// And the key has more priority over keycode.
-    fn is_one_of(&self, key: Key, code: KeyMappingId) -> bool {
-        // INFO: on linux the keycode from gtk4 is evdev keycode, so need to match by him if need
-        // to use layout-independent shortcuts. And notice that there is subtraction by 8, it's
-        // because of x11 compatibility in which the keycodes are in range [8,255]. So need shift
-        // them to get correct evdev keycode.
-        let keymap = KeyMap::from(code);
-        self.key == key || self.code as u16 - 8 == keymap.evdev
     }
 }
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -57,6 +57,7 @@ pub enum SketchBoardOutput {
     SetSize(Size),
     FocusAnnotationSizeFactorShortcut,
     SetFill(bool),
+    SetRoundCaps(bool),
     DimensionsUpdate(Option<(i32, i32)>),
     ToolEditingChanged(bool),
 }
@@ -867,6 +868,9 @@ impl SketchBoard {
             }
             ToolbarEvent::ToggleRoundCaps => {
                 self.style.round_caps = !self.style.round_caps;
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::SetRoundCaps(self.style.round_caps));
                 self.active_tool
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))
@@ -992,6 +996,12 @@ impl SketchBoard {
             }
             ShortcutCommand::ToggleFill => {
                 sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::ToggleFill));
+                ToolUpdateResult::Unmodified
+            }
+            ShortcutCommand::ToggleRoundCaps => {
+                sender.input(SketchBoardInput::ToolbarEvent(
+                    ToolbarEvent::ToggleRoundCaps,
+                ));
                 ToolUpdateResult::Unmodified
             }
             ShortcutCommand::Undo => self.handle_undo(),

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,10 +1,6 @@
-use std::{
-    borrow::Cow,
-    cell::RefCell,
-    collections::HashMap,
-    fmt::{Debug, Display},
-    rc::Rc,
-};
+use std::fmt;
+use std::str::FromStr;
+use std::{borrow::Cow, cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc};
 
 use anyhow::Result;
 use femtovg::{Canvas, FontId, renderer::OpenGl};
@@ -195,9 +191,9 @@ pub enum Tools {
     Brush = 10,
 }
 
-impl Tools {
-    pub fn display_name(&self) -> &'static str {
-        match self {
+impl fmt::Display for Tools {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
             Tools::Pointer => "Pointer",
             Tools::Crop => "Crop",
             Tools::Brush => "Brush",
@@ -206,28 +202,35 @@ impl Tools {
             Tools::Rectangle => "Rectangle",
             Tools::Ellipse => "Ellipse",
             Tools::Text => "Text",
-            Tools::Marker => "Numbered Marker",
+            Tools::Marker => "Marker",
             Tools::Blur => "Blur",
             Tools::Highlight => "Highlight",
-        }
+        };
+        write!(f, "{}", name)
     }
 }
 
-// used for printing
-impl Display for Tools {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Pointer => write!(f, "pointer"),
-            Self::Crop => write!(f, "crop"),
-            Self::Line => write!(f, "line"),
-            Self::Arrow => write!(f, "arrow"),
-            Self::Rectangle => write!(f, "rectangle"),
-            Self::Ellipse => write!(f, "ellipse"),
-            Self::Text => write!(f, "text"),
-            Self::Marker => write!(f, "marker"),
-            Self::Blur => write!(f, "blur"),
-            Self::Highlight => write!(f, "highlight"),
-            Self::Brush => write!(f, "brush"),
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseCommandError;
+
+impl FromStr for Tools {
+    type Err = ParseCommandError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower_name = s.to_lowercase();
+        match lower_name.as_str() {
+            "pointer" => Ok(Self::Pointer),
+            "crop" => Ok(Self::Crop),
+            "line" => Ok(Self::Line),
+            "arrow" => Ok(Self::Arrow),
+            "rectangle" => Ok(Self::Rectangle),
+            "ellipse" => Ok(Self::Ellipse),
+            "text" => Ok(Self::Text),
+            "marker" => Ok(Self::Marker),
+            "blur" => Ok(Self::Blur),
+            "highlight" => Ok(Self::Highlight),
+            "brush" => Ok(Self::Brush),
+            _ => Err(ParseCommandError),
         }
     }
 }
@@ -235,6 +238,7 @@ impl Display for Tools {
 pub struct ToolsManager {
     tools: HashMap<Tools, Rc<RefCell<dyn Tool>>>,
     crop_tool: Rc<RefCell<CropTool>>,
+    text_tool: Rc<RefCell<TextTool>>,
 }
 
 impl ToolsManager {
@@ -265,12 +269,18 @@ impl ToolsManager {
         tools.insert(Tools::Brush, Rc::new(RefCell::new(BrushTool::default())));
 
         let crop_tool = Rc::new(RefCell::new(CropTool::default()));
-        Self { tools, crop_tool }
+        let text_tool = Rc::new(RefCell::new(TextTool::default()));
+        Self {
+            tools,
+            crop_tool,
+            text_tool,
+        }
     }
 
     pub fn get(&self, tool: &Tools) -> Rc<RefCell<dyn Tool>> {
         match tool {
             Tools::Crop => self.crop_tool.clone(),
+            Tools::Text => self.text_tool.clone(),
             _ => self
                 .tools
                 .get(tool)
@@ -283,6 +293,10 @@ impl ToolsManager {
 
     pub fn get_crop_tool(&self) -> Rc<RefCell<CropTool>> {
         self.crop_tool.clone()
+    }
+
+    pub fn get_text_tool(&self) -> Rc<RefCell<TextTool>> {
+        self.text_tool.clone()
     }
 }
 

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -36,6 +36,7 @@ pub struct StyleToolbar {
     size_action: SimpleAction,
     size_spin_button: gtk::SpinButton,
     fill_enabled: bool,
+    round_caps_enabled: bool,
     visible: bool,
     output_dimensions: String,
     editing: bool,
@@ -76,6 +77,7 @@ pub enum StyleToolbarInput {
     ColorButtonSelected(ColorButtons),
     SetColor(Color),
     SetFill(bool),
+    SetRoundCaps(bool),
     SetSize(Size),
     ShowColorDialog,
     ColorDialogFinished(Option<Color>),
@@ -599,23 +601,19 @@ impl Component for StyleToolbar {
                 },
             },
             gtk::Separator {},
+            #[name(round_caps_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
                 set_tooltip: "Toggle Round Caps",
-                set_icon_name: if APP_CONFIG.read().default_round_caps() {
+                #[watch]
+                set_icon_name: if model.round_caps_enabled {
                     "circle-line-filled"
                 } else {
                     "square-filled"
                 },
-                connect_clicked[sender] => move |button| {
+                connect_clicked[sender] => move |_| {
                     sender.output_sender().emit(ToolbarEvent::ToggleRoundCaps);
-                    let new_icon = if button.icon_name() == Some("circle-line-filled".into()) {
-                        "square-filled"
-                    } else {
-                        "circle-line-filled"
-                    };
-                    button.set_icon_name(new_icon);
                 },
             },
             gtk::Separator {},
@@ -691,6 +689,9 @@ impl Component for StyleToolbar {
             }
             StyleToolbarInput::SetFill(fill_enabled) => {
                 self.fill_enabled = fill_enabled;
+            }
+            StyleToolbarInput::SetRoundCaps(round_caps_enabled) => {
+                self.round_caps_enabled = round_caps_enabled;
             }
             StyleToolbarInput::SetSize(size) => {
                 self.size_action.change_state(&size.to_variant());
@@ -781,6 +782,7 @@ impl Component for StyleToolbar {
             size_action: SimpleAction::from(size_action.clone()),
             size_spin_button: gtk::SpinButton::new(None::<&gtk::Adjustment>, 0.1, 2),
             fill_enabled: APP_CONFIG.read().default_fill_shapes(),
+            round_caps_enabled: APP_CONFIG.read().default_round_caps(),
             visible: !APP_CONFIG.read().default_hide_toolbars(),
             output_dimensions: String::new(),
             editing: false,
@@ -814,6 +816,11 @@ impl Component for StyleToolbar {
             &shortcut_registry,
             &widgets.fill_button,
             ShortcutCommand::ToggleFill,
+        );
+        update_hint(
+            &shortcut_registry,
+            &widgets.round_caps_button,
+            ShortcutCommand::ToggleRoundCaps,
         );
 
         let mut group = RelmActionGroup::<StyleToolbarActionGroup>::new();

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -1,7 +1,8 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use crate::{
-    configuration::APP_CONFIG,
+    configuration::{APP_CONFIG, Action},
+    keybindings::{ShortcutCommand, ShortcutRegistry},
     style::{Color, Size},
     tools::Tools,
 };
@@ -32,6 +33,9 @@ pub struct StyleToolbar {
     custom_color: Color,
     custom_color_pixbuf: Pixbuf,
     color_action: SimpleAction,
+    size_action: SimpleAction,
+    size_spin_button: gtk::SpinButton,
+    fill_enabled: bool,
     visible: bool,
     output_dimensions: String,
     editing: bool,
@@ -42,6 +46,7 @@ pub enum ToolbarEvent {
     FocusCanvas,
     ToolSelected(Tools),
     ColorSelected(Color),
+    SetFill(bool),
     SizeSelected(Size),
     Redo,
     Undo,
@@ -69,12 +74,16 @@ pub enum ToolsToolbarInput {
 #[derive(Debug, Copy, Clone)]
 pub enum StyleToolbarInput {
     ColorButtonSelected(ColorButtons),
+    SetColor(Color),
+    SetFill(bool),
+    SetSize(Size),
     ShowColorDialog,
     ColorDialogFinished(Option<Color>),
     SetVisibility(bool),
     ToggleVisibility,
     DimensionsChanged((i32, i32)),
     SetToolEditing(bool),
+    FocusAnnotationSizeFactor,
 }
 
 fn create_icon_pixbuf(color: Color) -> Pixbuf {
@@ -82,8 +91,23 @@ fn create_icon_pixbuf(color: Color) -> Pixbuf {
     pixbuf.fill(color.to_rgba_u32());
     pixbuf
 }
+
 fn create_icon(color: Color) -> gtk::Image {
     gtk::Image::from_pixbuf(Some(&create_icon_pixbuf(color)))
+}
+
+fn update_hint(
+    shortcut_registry: &ShortcutRegistry,
+    widget: &impl IsA<gtk::Widget>,
+    command: ShortcutCommand,
+) {
+    let command_name = command.to_string();
+    let shortcut_hint = shortcut_registry.get_binding_for_command(command);
+    let new_hint = match shortcut_hint {
+        Some(hint) => format!("{command_name} ({hint})"),
+        None => command_name,
+    };
+    widget.set_tooltip_text(Some(&new_hint));
 }
 
 #[relm4::component(pub)]
@@ -104,45 +128,40 @@ impl SimpleComponent for ToolsToolbar {
             #[watch]
             set_visible: model.visible,
 
+            #[name(original_scale_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "resize-large-regular",
-                set_tooltip: "1:1",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::OriginalScale);},
             },
+            #[name(fit_to_window_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "page-fit-regular",
-                set_tooltip: "Resize",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::Resize);},
             },
+            #[name(reset_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "recycling-bin",
-                set_tooltip: "Clear all",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::ClearAll);},
             },
             gtk::Separator {},
+            #[name(undo_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "arrow-undo-filled",
-                set_tooltip: "Undo (Ctrl-Z)",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::Undo);},
             },
+            #[name(redo_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "arrow-redo-filled",
-                set_tooltip: "Redo (Ctrl-Y)",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::Redo);},
             },
             gtk::Separator {},
@@ -150,126 +169,100 @@ impl SimpleComponent for ToolsToolbar {
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "cursor-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Pointer,
             },
             #[name(crop_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "crop-filled",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Crop,
             },
             #[name(brush_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "pen-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Brush,
             },
             #[name(line_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "minus-large",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Line,
             },
             #[name(arrow_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "arrow-up-right-filled",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Arrow,
             },
             #[name(rectangle_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "checkbox-unchecked-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Rectangle,
             },
             #[name(ellipse_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "circle-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Ellipse,
             },
             #[name(text_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "text-case-title-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Text,
             },
             #[name(marker_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "number-circle-1-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Marker,
             },
             #[name(blur_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "drop-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Blur,
             },
             #[name(highlight_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "highlight-regular",
-                // tooltip set programmatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Highlight,
             },
             gtk::Separator {},
+            #[name(copy_to_clipboard_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "copy-regular",
-                set_tooltip: "Copy to clipboard (Ctrl+C)",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::CopyClipboard);},
             },
+            #[name(save_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "save-regular",
-                set_tooltip: "Save (Ctrl+S)",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::SaveFile);},
-
                 set_visible: APP_CONFIG.read().output_filename().is_some()
             },
+            #[name(save_as_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
-
                 set_icon_name: "save-multiple-regular",
-                set_tooltip: "Save as (Ctrl+Shift+S)",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::SaveFileAs);},
             },
         },
@@ -347,28 +340,35 @@ impl SimpleComponent for ToolsToolbar {
             (Tools::Highlight, widgets.highlight_button.clone()),
         ]);
 
-        // reverse shortcuts mapping
-        let config = APP_CONFIG.read();
-        let tool_to_key_map: HashMap<&Tools, &char> = config
-            .keybinds()
-            .shortcuts()
-            .iter()
-            .inspect(|(hotkey, tool)| if hotkey.is_ascii_digit() {
-                eprintln!("Warning: hotkey `{}` for tool `{}` overrides built-in hotkey to select a color from the palette", hotkey, tool);
-            })
-            .map(|(k, v)| (v, k))
-            .collect();
+        let shortcut_registry = ShortcutRegistry::from_config();
 
         // Update tooltips based on configured keybinds
         for (tool, button) in &model.tool_buttons {
-            let display_name = tool.display_name();
+            update_hint(
+                &shortcut_registry,
+                button,
+                ShortcutCommand::SelectTool(*tool),
+            );
+        }
 
-            let tooltip = if let Some(key) = tool_to_key_map.get(tool) {
-                &format!("{} ({})", display_name, key.to_uppercase())
-            } else {
-                display_name
-            };
-            button.set_tooltip_text(Some(tooltip));
+        type SC = ShortcutCommand;
+        let other_commands = vec![
+            (SC::OriginalScale, &widgets.original_scale_button),
+            (SC::FitToWindow, &widgets.fit_to_window_button),
+            (SC::ClearAll, &widgets.reset_button),
+            (SC::Undo, &widgets.undo_button),
+            (SC::Redo, &widgets.redo_button),
+            // in between are the tools
+            (
+                SC::RunAction(Action::SaveToClipboard),
+                &widgets.copy_to_clipboard_button,
+            ),
+            (SC::RunAction(Action::SaveToFile), &widgets.save_button),
+            (SC::RunAction(Action::SaveToFileAs), &widgets.save_as_button),
+        ];
+
+        for (command, button) in other_commands {
+            update_hint(&shortcut_registry, button, command);
         }
 
         // Set initial active button correctly
@@ -471,6 +471,7 @@ impl Component for StyleToolbar {
             set_visible: model.visible,
 
             gtk::Separator {},
+            #[name(custom_color_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
@@ -492,6 +493,7 @@ impl Component for StyleToolbar {
                 connect_clicked => StyleToolbarInput::ShowColorDialog,
             },
             gtk::Separator {},
+            #[name(size_small_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
@@ -500,6 +502,7 @@ impl Component for StyleToolbar {
                 set_tooltip: "Small size",
                 ActionablePlus::set_action::<SizeAction>: Size::Small,
             },
+            #[name(size_medium_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
@@ -508,6 +511,7 @@ impl Component for StyleToolbar {
                 set_tooltip: "Medium size",
                 ActionablePlus::set_action::<SizeAction>: Size::Medium,
             },
+            #[name(size_large_button)]
             gtk::ToggleButton {
                 set_focusable: false,
                 set_hexpand: false,
@@ -579,24 +583,19 @@ impl Component for StyleToolbar {
                 set_tooltip: "Output dimensions (width x height)",
             },
             gtk::Separator {},
+            #[name(fill_button)]
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
 
-                set_icon_name: if APP_CONFIG.read().default_fill_shapes() {
+                #[watch]
+                set_icon_name: if model.fill_enabled {
                     "paint-bucket-filled"
                 } else {
                     "paint-bucket-regular"
                 },
-                set_tooltip: "Fill shape",
-                connect_clicked[sender] => move |button| {
+                connect_clicked[sender] => move |_| {
                     sender.output_sender().emit(ToolbarEvent::ToggleFill);
-                    let new_icon = if button.icon_name() == Some("paint-bucket-regular".into()) {
-                        "paint-bucket-filled"
-                    } else {
-                        "paint-bucket-regular"
-                    };
-                    button.set_icon_name(new_icon);
                 },
             },
             gtk::Separator {},
@@ -672,7 +671,30 @@ impl Component for StyleToolbar {
                     .output_sender()
                     .emit(ToolbarEvent::ColorSelected(color));
             }
+            StyleToolbarInput::SetColor(color) => {
+                let palette_match = APP_CONFIG
+                    .read()
+                    .color_palette()
+                    .palette()
+                    .iter()
+                    .position(|&p| p == color)
+                    .map(|index| ColorButtons::Palette(index as u64))
+                    .unwrap_or(ColorButtons::Custom);
 
+                // Only update custom_color if this is not a palette color
+                if matches!(palette_match, ColorButtons::Custom) {
+                    self.custom_color = color;
+                    self.custom_color_pixbuf = create_icon_pixbuf(color);
+                }
+
+                self.color_action.change_state(&palette_match.to_variant());
+            }
+            StyleToolbarInput::SetFill(fill_enabled) => {
+                self.fill_enabled = fill_enabled;
+            }
+            StyleToolbarInput::SetSize(size) => {
+                self.size_action.change_state(&size.to_variant());
+            }
             StyleToolbarInput::SetVisibility(visible) => self.visible = visible,
             StyleToolbarInput::ToggleVisibility => {
                 self.visible = !self.visible;
@@ -683,6 +705,9 @@ impl Component for StyleToolbar {
             StyleToolbarInput::SetToolEditing(editing) => {
                 self.editing = editing;
             }
+            StyleToolbarInput::FocusAnnotationSizeFactor => {
+                self.size_spin_button.grab_focus();
+            }
         }
     }
 
@@ -691,6 +716,8 @@ impl Component for StyleToolbar {
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        let shortcut_registry = ShortcutRegistry::from_config();
+
         for (i, &color) in APP_CONFIG
             .read()
             .color_palette()
@@ -705,6 +732,15 @@ impl Component for StyleToolbar {
                 .child(&create_icon(color))
                 .build();
             btn.set_action::<ColorAction>(ColorButtons::Palette(i as u64));
+
+            let color_tooltip = match shortcut_registry
+                .get_binding_for_command(ShortcutCommand::SelectColorIndex(i as u64))
+            {
+                Some(hint) => format!("color {} ({hint})", i + 1),
+                None => format!("color {}", i + 1),
+            };
+            btn.set_tooltip_text(Some(&color_tooltip));
+
             root.prepend(&btn);
         }
 
@@ -714,7 +750,6 @@ impl Component for StyleToolbar {
             &ColorButtons::Palette(0),
             move |_, state, value| {
                 *state = value;
-
                 sender_tmp.input(StyleToolbarInput::ColorButtonSelected(value));
             },
         );
@@ -739,10 +774,13 @@ impl Component for StyleToolbar {
         let custom_color_pixbuf = create_icon_pixbuf(custom_color);
 
         // create model
-        let model = StyleToolbar {
+        let mut model = StyleToolbar {
             custom_color,
             custom_color_pixbuf,
             color_action: SimpleAction::from(color_action.clone()),
+            size_action: SimpleAction::from(size_action.clone()),
+            size_spin_button: gtk::SpinButton::new(None::<&gtk::Adjustment>, 0.1, 2),
+            fill_enabled: APP_CONFIG.read().default_fill_shapes(),
             visible: !APP_CONFIG.read().default_hide_toolbars(),
             output_dimensions: String::new(),
             editing: false,
@@ -750,6 +788,33 @@ impl Component for StyleToolbar {
 
         // create widgets
         let widgets = view_output!();
+        model.size_spin_button = widgets.size_spin_button.clone();
+
+        update_hint(
+            &shortcut_registry,
+            &widgets.size_small_button,
+            ShortcutCommand::SelectSize(Size::Small),
+        );
+        update_hint(
+            &shortcut_registry,
+            &widgets.size_medium_button,
+            ShortcutCommand::SelectSize(Size::Medium),
+        );
+        update_hint(
+            &shortcut_registry,
+            &widgets.size_large_button,
+            ShortcutCommand::SelectSize(Size::Large),
+        );
+        update_hint(
+            &shortcut_registry,
+            &widgets.size_spin_button,
+            ShortcutCommand::FocusAnnotationSizeFactor,
+        );
+        update_hint(
+            &shortcut_registry,
+            &widgets.fill_button,
+            ShortcutCommand::ToggleFill,
+        );
 
         let mut group = RelmActionGroup::<StyleToolbarActionGroup>::new();
         group.add_action(color_action);


### PR DESCRIPTION
See issue #450.

Changes syntax for [keybinds] section in config file to

    "key" = "tool-or-command"

Also adds:
- bindings for all toolbar buttons
- commands for size selection
- automatic hint generation for all buttons

Removes:
- layout independent key bindings - instead bind what you want
- single letter binding restriction

Old style is still supported but will generate deprecation warnings.

The old code always sent key events into the IME handling before they were processed as key event.  Thus there were two places for bindings, bindings with a modifier and single letter bindings. But IME is for text input, thus it is now only activated for the text tool.