### PR TITLE
ci: add aarch64 (arm64) Linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,30 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             archive: tar.gz
+            container: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            archive: tar.gz
+            container: ""
 
     runs-on: ${{ matrix.os }}
-    container:
-      image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+    # x86_64 builds in the gtk4-rs Fedora container (yum); aarch64 runs natively
+    # on GitHub's free arm64 runner with GTK installed via apt (empty container).
+    container: ${{ matrix.container }}
 
     permissions:
       contents: write
 
     steps:
-      - name: Install dependencies
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install dependencies (Fedora container, x86_64)
+        if: matrix.container != ''
         run: yum install -y gtk4-devel libadwaita-devel
+
+      - name: Install dependencies (Ubuntu host, aarch64)
+        if: matrix.container == ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-4-dev libadwaita-1-dev
 
       - uses: actions/checkout@v3
 
@@ -42,7 +54,6 @@ jobs:
         run: cargo build --release --locked --target ${{ matrix.target }} --features ci-release
 
       - name: Pack Artifacts
-        if: matrix.os == 'ubuntu-latest'
         env:
           RELEASE_NAME: satty-${{ matrix.target }}
           ARTIFACTS_DIR: target/${{ matrix.target }}/release


### PR DESCRIPTION
## What

Adds an **aarch64 (arm64) Linux** target to the `release` workflow, so each release also ships `satty-aarch64-unknown-linux-gnu.tar.gz` alongside the existing x86_64 tarball.

## Why

There are currently no prebuilt aarch64 binaries. Users on arm64 Linux (Asahi/Apple Silicon Linux, Raspberry Pi, Pinebook Pro, arm64 servers/VMs, etc.) have to build from source, which is slow on these devices.

## How

The existing build runs inside `ghcr.io/gtk-rs/gtk4-rs/gtk4:latest`, which is **amd64-only**, so it can't simply be reused on an arm64 runner. Instead the aarch64 leg:

- runs natively on GitHub's free **`ubuntu-24.04-arm`** runner (no cross-compilation),
- runs **without a container** (the container is now selected per-matrix-entry via `container: ${{ matrix.container }}`; empty string = run on host),
- installs GTK4/libadwaita via `apt` (`libgtk-4-dev libadwaita-1-dev`) instead of the Fedora container's `yum`.

The x86_64 leg is unchanged. Diff is +16/-5.

## Tested

Built green on a fork — both legs and the flatpak job succeed, and the aarch64 tarball is produced and attached to the release:

https://github.com/MAY4VFX/Satty/releases/tag/v0.99.0

The resulting binary runs correctly on a Pinebook Pro (RK3399, ARMv8.0) under Debian 13 / niri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
