### PR TITLE
feat: make clear-all undoable as an atomic history action

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -50,7 +50,8 @@ pub struct FemtoVgAreaMut {
     scale_factor: f32,
     offset: Vec2D,
     drawables: Vec<Box<dyn Drawable>>,
-    redo_stack: Vec<Box<dyn Drawable>>,
+    undo_stack: Vec<HistoryEntry>,
+    redo_stack: Vec<HistoryEntry>,
     zoom_scale: f32,
     last_scale: f32,
     pointer_offset: Vec2D,
@@ -58,6 +59,11 @@ pub struct FemtoVgAreaMut {
     drag_offset: Vec2D,
     is_drag: bool,
     is_reset: bool,
+}
+
+enum HistoryEntry {
+    Drawable(Box<dyn Drawable>),
+    ClearAll(Vec<Box<dyn Drawable>>),
 }
 
 #[glib::object_subclass]
@@ -172,6 +178,7 @@ impl FemtoVGArea {
             scale_factor: 1.0,
             offset: Vec2D::zero(),
             drawables: Vec::new(),
+            undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             zoom_scale: initial_scale,
             pointer_offset: Vec2D::zero(),
@@ -304,49 +311,82 @@ impl FemtoVGArea {
 
 impl FemtoVgAreaMut {
     pub fn commit(&mut self, drawable: Box<dyn Drawable>) {
+        self.undo_stack
+            .push(HistoryEntry::Drawable(drawable.clone_box()));
         self.drawables.push(drawable);
         self.redo_stack.clear();
     }
 
     pub fn undo(&mut self) -> bool {
-        match self.drawables.pop() {
-            Some(mut d) => {
-                // notify of the undo action
-                d.handle_undo();
-
-                // push to redo stack
-                self.redo_stack.push(d);
+        match self.undo_stack.pop() {
+            Some(HistoryEntry::Drawable(history_drawable)) => {
+                let mut drawable = self.drawables.pop().unwrap_or(history_drawable);
+                drawable.handle_undo();
+                self.redo_stack.push(HistoryEntry::Drawable(drawable));
+                true
+            }
+            Some(HistoryEntry::ClearAll(drawables)) => {
+                self.restore_clear_all(drawables);
                 true
             }
             None => false,
         }
     }
+
     pub fn redo(&mut self) -> bool {
         match self.redo_stack.pop() {
-            Some(mut d) => {
-                // notify of the redo action
-                d.handle_redo();
-
-                // push to drawable stack
-                self.drawables.push(d);
-
+            Some(HistoryEntry::Drawable(mut drawable)) => {
+                drawable.handle_redo();
+                self.undo_stack
+                    .push(HistoryEntry::Drawable(drawable.clone_box()));
+                self.drawables.push(drawable);
+                true
+            }
+            Some(HistoryEntry::ClearAll(_)) => {
+                self.apply_clear_all();
                 true
             }
             None => false,
         }
     }
-    pub fn reset(&mut self) -> bool {
-        let mut any_undone = false;
-        while let Some(mut d) = self.drawables.pop() {
-            // notify of the undo action
-            d.handle_undo();
 
-            // push to redo stack
-            self.redo_stack.push(d);
-
-            any_undone = true;
+    pub fn clear_all(&mut self) -> bool {
+        if self.drawables.is_empty() {
+            return false;
         }
-        any_undone
+
+        self.apply_clear_all();
+        self.redo_stack.clear();
+        true
+    }
+
+    fn apply_clear_all(&mut self) {
+        let mut drawables = std::mem::take(&mut self.drawables);
+        Self::handle_drawables_undo(&mut drawables);
+        self.undo_stack.push(HistoryEntry::ClearAll(drawables));
+    }
+
+    fn restore_clear_all(&mut self, mut drawables: Vec<Box<dyn Drawable>>) {
+        Self::handle_drawables_redo(&mut drawables);
+        self.redo_stack
+            .push(HistoryEntry::ClearAll(Self::clone_drawables(&drawables)));
+        self.drawables = drawables;
+    }
+
+    fn handle_drawables_undo(drawables: &mut [Box<dyn Drawable>]) {
+        for d in drawables.iter_mut().rev() {
+            d.handle_undo();
+        }
+    }
+
+    fn handle_drawables_redo(drawables: &mut [Box<dyn Drawable>]) {
+        for d in drawables.iter_mut() {
+            d.handle_redo();
+        }
+    }
+
+    fn clone_drawables(drawables: &[Box<dyn Drawable>]) -> Vec<Box<dyn Drawable>> {
+        drawables.iter().map(|d| d.clone_box()).collect()
     }
 
     pub fn set_active_tool(&mut self, active_tool: Rc<RefCell<dyn Tool>>) {

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -72,12 +72,12 @@ impl FemtoVGArea {
     pub fn request_render(&self, actions: &[Action]) {
         self.imp().request_render(actions);
     }
-    pub fn reset(&mut self) -> bool {
+    pub fn clear_all(&mut self) -> bool {
         self.imp()
             .inner()
             .as_mut()
             .expect("Did you call init before using FemtoVgArea?")
-            .reset()
+            .clear_all()
     }
 
     pub fn abs_canvas_to_image_coordinates(&self, input: Vec2D) -> Vec2D {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -757,7 +757,7 @@ impl SketchBoard {
         }
     }
 
-    fn handle_reset(&mut self) -> ToolUpdateResult {
+    fn handle_clear_all(&mut self) -> ToolUpdateResult {
         // can't use lazy || here
         if self.deactivate_active_tool() | self.renderer.clear_all() {
             ToolUpdateResult::Redraw
@@ -864,7 +864,7 @@ impl SketchBoard {
             ToolbarEvent::CopyClipboard => self.handle_action(&[Action::SaveToClipboard]),
             ToolbarEvent::Undo => self.handle_undo(),
             ToolbarEvent::Redo => self.handle_redo(),
-            ToolbarEvent::Reset => self.handle_reset(),
+            ToolbarEvent::ClearAll => self.handle_clear_all(),
             ToolbarEvent::ToggleFill => {
                 self.style.fill = !self.style.fill;
                 self.active_tool
@@ -1213,7 +1213,7 @@ impl Component for SketchBoard {
                                 self.renderer.request_render(&[]);
                                 ToolUpdateResult::Unmodified
                             } else if ke.modifier.is_empty() && ke.key == Key::Delete {
-                                self.handle_reset()
+                                self.handle_clear_all()
                             } else if ke.modifier.is_empty()
                                 && (ke.key == Key::Escape
                                     || ke.key == Key::Return

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -759,7 +759,7 @@ impl SketchBoard {
 
     fn handle_reset(&mut self) -> ToolUpdateResult {
         // can't use lazy || here
-        if self.deactivate_active_tool() | self.renderer.reset() {
+        if self.deactivate_active_tool() | self.renderer.clear_all() {
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -48,7 +48,7 @@ pub enum ToolbarEvent {
     CopyClipboard,
     ToggleFill,
     AnnotationSizeFactorChanged(f32),
-    Reset,
+    ClearAll,
     SaveFileAs,
     Resize,
     OriginalScale,
@@ -120,8 +120,8 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "recycling-bin",
-                set_tooltip: "Reset",
-                connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::Reset);},
+                set_tooltip: "Clear all",
+                connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::ClearAll);},
             },
             gtk::Separator {},
             gtk::Button {


### PR DESCRIPTION
 ## Summary

  Closes #524 

  This changes the current reset/clear-all behavior so it is represented as an atomic history entry instead of moving all drawables directly into the redo stack.

  After this change:

  ```text
  draw A
  draw B
  clear all
  Ctrl+Z -> restores A and B
  Ctrl+Y -> clears all again
```

  The toolbar action is also renamed from Reset to Clear all to better match the user-facing behavior and the distinction discussed in the issue.

  ## Implementation

  - Adds `HistoryEntry::ClearAll(Vec<Box<dyn Drawable>>)` for atomic clear-all history.
  - Keeps visible drawables separate from undo/redo history.
  - Updates undo/redo handling so clear-all can be undone and redone as one action.
  - Renames the renderer action from `reset()` to `clear_all().`
  - Renames the toolbar event and tooltip from `Reset` to `Clear all`.