### PR TITLE
feat: tool dismiss/commit buttons in style toolbar

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -74,6 +74,8 @@ fn main() -> Result<(), io::Error> {
             "page-fit-regular",
             "resize-large-regular",
             "arrow-counterclockwise-regular",
+            "dismiss-regular",
+            "checkmark-regular",
         ],
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,9 @@ impl Component for App {
                 self.tools_toolbar
                     .sender()
                     .emit(ToolsToolbarInput::SetToolEditing(editing));
+                self.style_toolbar
+                    .sender()
+                    .emit(StyleToolbarInput::SetToolEditing(editing));
             }
         }
     }

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -880,12 +880,8 @@ impl SketchBoard {
             ToolbarEvent::SaveFileAs => self.handle_action(&[Action::SaveToFileAs]),
             ToolbarEvent::Resize => self.handle_resize(),
             ToolbarEvent::OriginalScale => self.handle_original_scale(),
-            /*            ToolbarEvent::CropDimensionsUpdated(dimensions) => {
-                sender
-                    .output_sender()
-                    .emit(SketchBoardOutput::DimensionsUpdate(Some(dimensions)));
-                ToolUpdateResult::Unmodified
-            }*/
+            ToolbarEvent::ToolCommit => self.active_tool.borrow_mut().handle_deactivated(),
+            ToolbarEvent::ToolDismiss => self.active_tool.borrow_mut().handle_dismissed(),
         }
     }
 

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -387,20 +387,6 @@ impl CropTool {
             }
         }
     }
-
-    fn handle_deactivate_and_reset(&mut self) -> ToolUpdateResult {
-        self.crop = None;
-        self.action = None;
-
-        if let Some(sender) = &self.sender {
-            sender
-                .send(SketchBoardInput::Output(
-                    SketchBoardOutput::DimensionsUpdate(None),
-                ))
-                .ok();
-        }
-        ToolUpdateResult::RedrawAndStopPropagation
-    }
 }
 
 impl Tool for CropTool {
@@ -429,7 +415,7 @@ impl Tool for CropTool {
             //FIXME: use if let guards as soon as they're stabilized (1.95)
             Key::Escape if self.crop.is_some() => {
                 if self.crop.as_mut().unwrap().active {
-                    self.handle_deactivate_and_reset()
+                    self.handle_dismissed()
                 } else {
                     ToolUpdateResult::Unmodified
                 }
@@ -452,7 +438,7 @@ impl Tool for CropTool {
                 if let Some(crop) = &self.crop
                     && crop.active
                 {
-                    self.handle_deactivate_and_reset()
+                    self.handle_dismissed()
                 } else {
                     ToolUpdateResult::Unmodified
                 }
@@ -484,6 +470,20 @@ impl Tool for CropTool {
         }
         self.action = None;
         ToolUpdateResult::Redraw
+    }
+
+    fn handle_dismissed(&mut self) -> ToolUpdateResult {
+        self.crop = None;
+        self.action = None;
+
+        if let Some(sender) = &self.sender {
+            sender
+                .send(SketchBoardInput::Output(
+                    SketchBoardOutput::DimensionsUpdate(None),
+                ))
+                .ok();
+        }
+        ToolUpdateResult::RedrawAndStopPropagation
     }
 
     fn get_drawable(&self) -> Option<&dyn Drawable> {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -44,6 +44,7 @@ mod text;
 pub enum ToolEvent {
     Activated,
     Deactivated,
+    Dismissed,
     Input(InputEvent),
     StyleChanged(Style),
 }
@@ -53,6 +54,7 @@ pub trait Tool {
         match event {
             ToolEvent::Activated => self.handle_activated(),
             ToolEvent::Deactivated => self.handle_deactivated(),
+            ToolEvent::Dismissed => self.handle_dismissed(),
             ToolEvent::Input(e) => self.handle_input_event(e),
             ToolEvent::StyleChanged(s) => self.handle_style_event(s),
         }
@@ -63,6 +65,10 @@ pub trait Tool {
     }
 
     fn handle_deactivated(&mut self) -> ToolUpdateResult {
+        ToolUpdateResult::Unmodified
+    }
+
+    fn handle_dismissed(&mut self) -> ToolUpdateResult {
         ToolUpdateResult::Unmodified
     }
 

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -827,7 +827,7 @@ impl Tool for TextTool {
                     }
                 },
                 Key::Escape => {
-                    tool_update_result = self.handle_deactivated();
+                    tool_update_result = self.handle_dismissed();
                 }
                 Key::BackSpace | Key::Delete => {
                     let ctrl_mask = match event.key {
@@ -1313,6 +1313,12 @@ impl Tool for TextTool {
         } else {
             ToolUpdateResult::Unmodified
         }
+    }
+
+    fn handle_dismissed(&mut self) -> ToolUpdateResult {
+        self.input_enabled = false;
+        self.text = None;
+        ToolUpdateResult::Redraw
     }
 
     fn active(&self) -> bool {

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -34,6 +34,7 @@ pub struct StyleToolbar {
     color_action: SimpleAction,
     visible: bool,
     output_dimensions: String,
+    editing: bool,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -52,6 +53,8 @@ pub enum ToolbarEvent {
     SaveFileAs,
     Resize,
     OriginalScale,
+    ToolCommit,
+    ToolDismiss,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -70,6 +73,7 @@ pub enum StyleToolbarInput {
     SetVisibility(bool),
     ToggleVisibility,
     DimensionsChanged((i32, i32)),
+    SetToolEditing(bool),
 }
 
 fn create_icon_pixbuf(color: Color) -> Pixbuf {
@@ -594,6 +598,30 @@ impl Component for StyleToolbar {
                     button.set_icon_name(new_icon);
                 },
             },
+            gtk::Separator {},
+            gtk::Button {
+                set_focusable: false,
+                set_hexpand: false,
+                set_icon_name: "dismiss-regular",
+                set_tooltip: "tool dismiss",
+                #[watch]
+                set_sensitive: model.editing,
+                connect_clicked[sender] => move |_| {
+                    sender.output_sender().emit(ToolbarEvent::ToolDismiss);
+                },
+            },
+            gtk::Button {
+                set_focusable: false,
+                set_hexpand: false,
+                set_icon_name: "checkmark-regular",
+                set_tooltip: "tool commit",
+                #[watch]
+                set_sensitive: model.editing,
+                connect_clicked[sender] => move |_| {
+                    sender.output_sender().emit(ToolbarEvent::ToolCommit);
+                },
+            },
+
         },
     }
 
@@ -631,6 +659,9 @@ impl Component for StyleToolbar {
             }
             StyleToolbarInput::DimensionsChanged((width, height)) => {
                 self.output_dimensions = format!("{}x{}", width, height);
+            }
+            StyleToolbarInput::SetToolEditing(editing) => {
+                self.editing = editing;
             }
         }
     }
@@ -694,6 +725,7 @@ impl Component for StyleToolbar {
             color_action: SimpleAction::from(color_action.clone()),
             visible: !APP_CONFIG.read().default_hide_toolbars(),
             output_dimensions: String::new(),
+            editing: false,
         };
 
         // create widgets


### PR DESCRIPTION
Adds tool dismiss/commit buttons. Introduces handle_dismissed method for tools.

The buttons only really work for crop and text right now, but should be useful once we get editable components.

Change text so Esc used handle_dismissed (README says so anyway), enter is already available for commit.


https://github.com/user-attachments/assets/88035651-4847-45e4-9a86-1445a65bc7e0


because it annoyed me while editing:
Closes: #472 
