### PR TITLE
fix!: unclash right mouse button in crop tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Default single-key shortcuts:
 ### Tool Modifiers and Keys
 
 Crop:
-- Press <kbd>Esc</kbd> or right mouse button while editing to reset crop altogether <sup>0.21.0</sup>.
+- Press <kbd>Esc</kbd> or <kbd>Ctrl</kbd>+right mouse<sup>NEXTRELEASE</sup> <sup>experimental</sup> button while editing to reset crop altogether <sup>0.21.0</sup>.
 - Press <kbd>Enter</kbd> while editing to finish editing crop and keep the crop area active <sup>0.21.0</sup>.
 - Left click crop area when tool is active but not editing to resume editing<sup>0.21.0</sup>.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Default single-key shortcuts:
 
 Crop:
 - Press <kbd>Esc</kbd> or <kbd>Ctrl</kbd>+right mouse<sup>NEXTRELEASE</sup> <sup>experimental</sup> button while editing to reset crop altogether <sup>0.21.0</sup>.
-- Press <kbd>Enter</kbd> while editing to finish editing crop and keep the crop area active <sup>0.21.0</sup>.
+- Press <kbd>Enter</kbd> or <kbd>Ctrl</kbd>+left mouse<sup>NEXTRELEASE</sup> <sup>experimental</sup> while editing to finish editing crop and keep the crop area active <sup>0.21.0</sup>.
 - Left click crop area when tool is active but not editing to resume editing<sup>0.21.0</sup>.
 
 Arrow and line:

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -435,6 +435,9 @@ impl Tool for CropTool {
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let ctrl_pressed = event.modifier.intersects(ModifierType::CONTROL_MASK);
         match event.type_ {
+            MouseEventType::Click if event.button == MouseButton::Primary && ctrl_pressed => {
+                self.handle_deactivated()
+            }
             MouseEventType::Click
                 if event.button == MouseButton::Secondary
                     && ctrl_pressed
@@ -443,13 +446,13 @@ impl Tool for CropTool {
             {
                 self.handle_dismissed()
             }
-            MouseEventType::BeginDrag if event.button == MouseButton::Primary => {
+            MouseEventType::BeginDrag if event.button == MouseButton::Primary && !ctrl_pressed => {
                 self.begin_drag(event.pos)
             }
-            MouseEventType::EndDrag if event.button == MouseButton::Primary => {
+            MouseEventType::EndDrag if event.button == MouseButton::Primary && !ctrl_pressed => {
                 self.end_drag(event.pos)
             }
-            MouseEventType::UpdateDrag if event.button == MouseButton::Primary => {
+            MouseEventType::UpdateDrag if event.button == MouseButton::Primary && !ctrl_pressed => {
                 self.update_drag(event.pos)
             }
             _ => ToolUpdateResult::Unmodified,

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -1,5 +1,6 @@
 use std::f32::consts::PI;
 
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
 use crate::{
     math::{self, Vec2D},
     sketch_board::{
@@ -9,9 +10,8 @@ use crate::{
 };
 use anyhow::Result;
 use femtovg::{Color, Paint, Path};
+use relm4::adw::gdk::ModifierType;
 use relm4::{Sender, gtk::gdk::Key};
-
-use super::{Drawable, Tool, ToolUpdateResult, Tools};
 
 #[derive(Debug, Clone)]
 pub struct Crop {
@@ -433,15 +433,15 @@ impl Tool for CropTool {
     }
 
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
+        let ctrl_pressed = event.modifier.intersects(ModifierType::CONTROL_MASK);
         match event.type_ {
-            MouseEventType::Click if event.button == MouseButton::Secondary => {
-                if let Some(crop) = &self.crop
-                    && crop.active
-                {
-                    self.handle_dismissed()
-                } else {
-                    ToolUpdateResult::Unmodified
-                }
+            MouseEventType::Click
+                if event.button == MouseButton::Secondary
+                    && ctrl_pressed
+                    && let Some(crop) = &self.crop
+                    && crop.active =>
+            {
+                self.handle_dismissed()
             }
             MouseEventType::BeginDrag if event.button == MouseButton::Primary => {
                 self.begin_drag(event.pos)


### PR DESCRIPTION
Closes: #560
Addresses complaint in #470

When using right mouse button for actions, in crop it may be counter-intuitive that right click resets crop.

For now, add Ctrl modifier to the right click. This is experimental because in the future tool related bindings/shortcut may become configurable.

Also add Ctrl+Left click to finish crop editing.

PR builds on #561, because that one offers a mouse-only way to apply and reset crop.