### PR TITLE
chore: update rust-overlay flake input to fix the dev shell build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748140821,
-        "narHash": "sha256-GZcjWLQtDifSYMd1ueLDmuVTcQQdD5mONIBTqABooOk=",
+        "lastModified": 1782962170,
+        "narHash": "sha256-HsaK9yDDypMB2TPxAYz0mPKtmYhgNwFQa72b3Ko6kRE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "476b2ba7dc99ddbf70b1f45357dbbdbdbdfb4422",
+        "rev": "e3fa5cf86b93914b8f312b2a1ca14fbb139c655c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Closes #564 

`nix flake update rust-overlay` — the pinned revision provides rustc 1.87 while the dependencies in `Cargo.lock` require up to rustc 1.92, so `nix develop --command cargo build` fails out of the box (see the issue for the full error).

With this update the dev shell provides rustc 1.96.1 and `cargo build`, `cargo clippy` and `cargo test` all work again. `nixpkgs` is left untouched to keep the change minimal.