### PR TITLE
chore(deps): update fontconfig to 0.11 (incompatible)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fontconfig"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854f6a6479193c392bd820abcd2123b116f01eba7775b6bcfc26494be3285229"
+checksum = "0d0e1eb4148faaf675053b7299bc5b4c041c8c0c724cf77844d6be8dd0ac5b9d"
 dependencies = [
  "yeslogic-fontconfig-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libloading = "0.9"
 epoxy = "0.1.0"
 glow = "0.17.0"
 resource = "0.6.1"  # font emedding
-fontconfig = "0.10.2"  # font loading
+fontconfig = "0.11.0"  # font loading
 keycode = "1.0.0"
 
 [dependencies.relm4-icons]

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -214,10 +214,13 @@ impl FemtoVGArea {
         let fontconfig = Fontconfig::new();
 
         let mut load_font = |family: &str, style: Option<&str>| -> Result<FontId> {
-            let font = fontconfig
+            let fc = fontconfig
                 .as_ref()
-                .and_then(|fc| fc.find(family, style))
-                .ok_or_else(|| anyhow::anyhow!("Font family '{}' not found", family))?;
+                .ok_or(anyhow::anyhow!("Could not initialize Fontconfig"))?;
+
+            let font = fc
+                .find(family, style)
+                .map_err(|e| anyhow::anyhow!("Font family '{}' not found: {}", family, e))?;
 
             let face_index = font.index.unwrap_or(0).max(0) as u32;
 


### PR DESCRIPTION
`Fontconfig.find()` now is a Result rather than an Option, requiring a minor code change.