### PR TITLE
feat: toggle text outline in inverted color with Alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Text:
 - <kbd>Ctrl+X</kbd> to cut selected text to clipboard. <sup>0.20.1</sup>
 - <kbd>Ctrl+V</kbd> to paste text from clipboard. <sup>0.20.1</sup>
 - <kbd>Alt+Ctrl</kbd> with <kbd>Left</kbd> or <kbd>Right</kbd> or <kbd>Up</kbd> or <kbd>Down</kbd> to move the text. Use <kbd>Alt+Ctrl+Shift</kbd> with arrow keys to nudge the text. <sup>0.20.1</sup>
-- Press <kbd>Alt</kbd> to toggle outlining the text with the inverted text color. <sup>NEXTRELEASE</sup>
+- Press <kbd>Alt</kbd> to toggle outlining the text with the inverted text color. <sup>experimental</sup> <sup>NEXTRELEASE</sup>
 
 Marker:
 - Hold <kbd>Alt</kbd> to get extra ring. <sup>NEXTRELEASE</sup>

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Text:
 - <kbd>Ctrl+X</kbd> to cut selected text to clipboard. <sup>0.20.1</sup>
 - <kbd>Ctrl+V</kbd> to paste text from clipboard. <sup>0.20.1</sup>
 - <kbd>Alt+Ctrl</kbd> with <kbd>Left</kbd> or <kbd>Right</kbd> or <kbd>Up</kbd> or <kbd>Down</kbd> to move the text. Use <kbd>Alt+Ctrl+Shift</kbd> with arrow keys to nudge the text. <sup>0.20.1</sup>
-- Press <kbd>Alt</kbd> to toggle outlining the text with the inverted text color. <sup>experimental</sup> <sup>NEXTRELEASE</sup>
+- Press <kbd>Alt</kbd> to cycle the text outline: none → inverted text color → contrast (black or white, by luminance). <sup>experimental</sup> <sup>NEXTRELEASE</sup>
 
 Marker:
 - Hold <kbd>Alt</kbd> to get extra ring. <sup>NEXTRELEASE</sup>

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Text:
 - <kbd>Ctrl+X</kbd> to cut selected text to clipboard. <sup>0.20.1</sup>
 - <kbd>Ctrl+V</kbd> to paste text from clipboard. <sup>0.20.1</sup>
 - <kbd>Alt+Ctrl</kbd> with <kbd>Left</kbd> or <kbd>Right</kbd> or <kbd>Up</kbd> or <kbd>Down</kbd> to move the text. Use <kbd>Alt+Ctrl+Shift</kbd> with arrow keys to nudge the text. <sup>0.20.1</sup>
+- Press <kbd>Alt</kbd> to toggle outlining the text with the inverted text color. <sup>NEXTRELEASE</sup>
 
 Marker:
 - Hold <kbd>Alt</kbd> to get extra ring. <sup>NEXTRELEASE</sup>

--- a/src/style.rs
+++ b/src/style.rs
@@ -114,6 +114,17 @@ impl Color {
         Self::new(255 - self.r, 255 - self.g, 255 - self.b, self.a)
     }
 
+    /// Returns black or white, whichever contrasts better with this color,
+    /// based on its perceived luminance (YIQ), preserving alpha.
+    pub fn contrast(self) -> Self {
+        let luminance = (self.r as u32 * 299 + self.g as u32 * 587 + self.b as u32 * 114) / 1000;
+        if luminance >= 128 {
+            Self::new(0, 0, 0, self.a)
+        } else {
+            Self::new(255, 255, 255, self.a)
+        }
+    }
+
     pub fn to_rgba_f64(self) -> (f64, f64, f64, f64) {
         (
             (self.r as f64) / 255.0,

--- a/src/style.rs
+++ b/src/style.rs
@@ -109,6 +109,11 @@ impl Color {
         Self::new(200, 37, 184, 255)
     }
 
+    /// Returns the color with its RGB channels inverted, preserving alpha.
+    pub fn inverted(self) -> Self {
+        Self::new(255 - self.r, 255 - self.g, 255 - self.b, self.a)
+    }
+
     pub fn to_rgba_f64(self) -> (f64, f64, f64, f64) {
         (
             (self.r as f64) / 255.0,

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -39,6 +39,7 @@ pub struct Text {
     line_ranges: RefCell<Vec<Range<usize>>>,
     cursor_visible: RefCell<bool>,
     draw_rect: RefCell<bool>,
+    outline: bool,
     font_ids: Vec<FontId>,
 }
 
@@ -83,6 +84,7 @@ impl Text {
             line_ranges: RefCell::new(Vec::new()),
             cursor_visible: RefCell::new(true),
             draw_rect: RefCell::new(true),
+            outline: false,
             font_ids: femtovg_area::font_stack().to_vec(),
         }
     }
@@ -352,13 +354,22 @@ impl Drawable for Text {
             canvas.stroke_path(&rect_paint, &paint);
         }
 
+        // When outlining, stroke each line with the inverted text color first, then
+        // fill on top so the visible border wraps the glyphs. The stroke is widened
+        // because it is centered on the glyph outline and half of it is hidden by the fill.
+        let outline_paint = self.outline.then(|| {
+            let mut paint = base_paint.clone();
+            paint.set_color(self.style.color.inverted().into());
+            paint.set_line_width(base_paint.line_width() * 2.0);
+            paint
+        });
+
         for line_range in &lines {
-            canvas.fill_text(
-                self.pos.x,
-                draw_baseline,
-                &text[line_range.clone()],
-                &base_paint,
-            )?;
+            let line = &text[line_range.clone()];
+            if let Some(outline_paint) = &outline_paint {
+                canvas.stroke_text(self.pos.x, draw_baseline, line, outline_paint)?;
+            }
+            canvas.fill_text(self.pos.x, draw_baseline, line, &base_paint)?;
             draw_baseline += line_height;
         }
 
@@ -710,6 +721,7 @@ pub struct TextTool {
     sender: Option<Sender<SketchBoardInput>>,
     drag_start_pos: Vec2D,
     dragged: Rc<RefCell<bool>>,
+    alt_tap: bool,
 }
 
 impl Tool for TextTool {
@@ -794,6 +806,11 @@ impl Tool for TextTool {
     }
 
     fn handle_key_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
+        // Any key other than Alt cancels a pending Alt tap: Alt is being used as a
+        // modifier (e.g. Ctrl+Alt+Arrow), not tapped on its own to toggle the outline.
+        if !matches!(event.key, Key::Alt_L | Key::Alt_R) {
+            self.alt_tap = false;
+        }
         let mut tool_update_result = ToolUpdateResult::StopPropagation;
         if let Some(t) = &mut self.text {
             match event.key {
@@ -828,6 +845,11 @@ impl Tool for TextTool {
                 },
                 Key::Escape => {
                     tool_update_result = self.handle_deactivated();
+                }
+                Key::Alt_L | Key::Alt_R => {
+                    // Start tracking a potential Alt tap; the outline is toggled on
+                    // release (see handle_key_release_event) if no other key was pressed.
+                    self.alt_tap = true;
                 }
                 Key::BackSpace | Key::Delete => {
                     let ctrl_mask = match event.key {
@@ -1076,6 +1098,17 @@ impl Tool for TextTool {
             tool_update_result = ToolUpdateResult::Unmodified;
         }
         tool_update_result
+    }
+
+    fn handle_key_release_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
+        if (event.key == Key::Alt_L || event.key == Key::Alt_R) && self.alt_tap {
+            self.alt_tap = false;
+            if let Some(t) = &mut self.text {
+                t.outline = !t.outline;
+                return ToolUpdateResult::RedrawAndStopPropagation;
+            }
+        }
+        ToolUpdateResult::Unmodified
     }
 
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -26,6 +26,35 @@ use relm4::gtk::gdk::DisplayManager;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+/// How the text outline is rendered, cycled through with the Alt key.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum OutlineMode {
+    #[default]
+    None,
+    Inverted,
+    Contrast,
+}
+
+impl OutlineMode {
+    /// Cycles None -> Inverted -> Contrast -> None.
+    fn next(self) -> Self {
+        match self {
+            Self::None => Self::Inverted,
+            Self::Inverted => Self::Contrast,
+            Self::Contrast => Self::None,
+        }
+    }
+
+    /// The outline color for the given text color, or None when disabled.
+    fn outline_color(self, text_color: crate::style::Color) -> Option<crate::style::Color> {
+        match self {
+            Self::None => None,
+            Self::Inverted => Some(text_color.inverted()),
+            Self::Contrast => Some(text_color.contrast()),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Text {
     pos: Vec2D,
@@ -39,7 +68,7 @@ pub struct Text {
     line_ranges: RefCell<Vec<Range<usize>>>,
     cursor_visible: RefCell<bool>,
     draw_rect: RefCell<bool>,
-    outline: bool,
+    outline: OutlineMode,
     font_ids: Vec<FontId>,
 }
 
@@ -84,7 +113,7 @@ impl Text {
             line_ranges: RefCell::new(Vec::new()),
             cursor_visible: RefCell::new(true),
             draw_rect: RefCell::new(true),
-            outline: false,
+            outline: OutlineMode::default(),
             font_ids: femtovg_area::font_stack().to_vec(),
         }
     }
@@ -354,12 +383,12 @@ impl Drawable for Text {
             canvas.stroke_path(&rect_paint, &paint);
         }
 
-        // When outlining, stroke each line with the inverted text color first, then
-        // fill on top so the visible border wraps the glyphs. The stroke is widened
-        // because it is centered on the glyph outline and half of it is hidden by the fill.
-        let outline_paint = self.outline.then(|| {
+        // When outlining, stroke each line with the outline color first, then fill on
+        // top so the visible border wraps the glyphs. The stroke is widened because it
+        // is centered on the glyph outline and half of it is hidden by the fill.
+        let outline_paint = self.outline.outline_color(self.style.color).map(|color| {
             let mut paint = base_paint.clone();
-            paint.set_color(self.style.color.inverted().into());
+            paint.set_color(color.into());
             paint.set_line_width(base_paint.line_width() * 2.0);
             paint
         });
@@ -847,7 +876,7 @@ impl Tool for TextTool {
                     tool_update_result = self.handle_deactivated();
                 }
                 Key::Alt_L | Key::Alt_R => {
-                    // Start tracking a potential Alt tap; the outline is toggled on
+                    // Start tracking a potential Alt tap; the outline mode is cycled on
                     // release (see handle_key_release_event) if no other key was pressed.
                     self.alt_tap = true;
                 }
@@ -1104,7 +1133,7 @@ impl Tool for TextTool {
         if (event.key == Key::Alt_L || event.key == Key::Alt_R) && self.alt_tap {
             self.alt_tap = false;
             if let Some(t) = &mut self.text {
-                t.outline = !t.outline;
+                t.outline = t.outline.next();
                 return ToolUpdateResult::RedrawAndStopPropagation;
             }
         }


### PR DESCRIPTION
Closes #573  

# What

Adds an optional outline to the text tool. While editing text, tapping <kbd>Alt</kbd> toggles an outline drawn in the inverted text color (255 - channel per RGB, alpha preserved). The outline is preserved when the text is committed.

Adds an optional outline to the text tool. While editing text, tapping <kbd>Alt</kbd> toggles an outline drawn in the inverted text color (255 - channel per RGB, alpha preserved). The outline is preserved when the text is committed.


https://github.com/user-attachments/assets/a43b4b83-dc34-4fe5-bddd-1351b5b005b8


## Why

Text can blend into the background and become unreadable. An inverted-color outline always contrasts with the fill, keeping annotations legible over any background, with no new color setting to configure.

## How

- Color::inverted() in style.rs — per-channel RGB inversion, alpha kept.
- In Text::draw, when the outline is enabled each line is stroked with the inverted color (line width ×2) underneath the fill, so the visible border wraps the glyphs. The outline flag lives on Text, so it is carried into the committed drawable via clone_box.
- Toggling uses a genuine Alt tap rather than the raw keydown: handle_key_event marks a tap candidate on Alt_L/Alt_R and clears it on any other key; handle_key_release_event flips outline only if the candidate survived. This prevents Alt-based combos (Ctrl+Alt+Arrow to move text) and key auto-repeat from flipping the state.

## Docs

- README.md: added the shortcut under the Text tool section with a NEXTRELEASE marker.

## Testing

- make fix (cargo fmt + clippy -D warnings) — clean.
- cargo build — clean.
- tested on NixOS with Hyprland.

## Notes

No new dependencies