### PR TITLE
 feat: drop-shadow text effect + gamma-corrected contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Text:
 - <kbd>Ctrl+X</kbd> to cut selected text to clipboard. <sup>0.20.1</sup>
 - <kbd>Ctrl+V</kbd> to paste text from clipboard. <sup>0.20.1</sup>
 - <kbd>Alt+Ctrl</kbd> with <kbd>Left</kbd> or <kbd>Right</kbd> or <kbd>Up</kbd> or <kbd>Down</kbd> to move the text. Use <kbd>Alt+Ctrl+Shift</kbd> with arrow keys to nudge the text. <sup>0.20.1</sup>
-- Press <kbd>Alt</kbd> to cycle the text outline: none → inverted text color → contrast (black or white, by luminance). <sup>experimental</sup> <sup>NEXTRELEASE</sup>
+- Press <kbd>Alt</kbd> to cycle the text effect: none → inverted outline → contrast outline (black/white) → drop shadow. <sup>experimental</sup> <sup>NEXTRELEASE</sup>
 
 Marker:
 - Hold <kbd>Alt</kbd> to get extra ring. <sup>NEXTRELEASE</sup>

--- a/src/style.rs
+++ b/src/style.rs
@@ -114,11 +114,27 @@ impl Color {
         Self::new(255 - self.r, 255 - self.g, 255 - self.b, self.a)
     }
 
+    /// Returns the color with its alpha channel replaced.
+    pub fn with_alpha(self, a: u8) -> Self {
+        Self::new(self.r, self.g, self.b, a)
+    }
+
     /// Returns black or white, whichever contrasts better with this color,
-    /// based on its perceived luminance (YIQ), preserving alpha.
+    /// preserving alpha. Uses WCAG relative luminance (channels gamma-decoded to
+    /// linear light, then weighted); black and white are equal at L = 0.179.
     pub fn contrast(self) -> Self {
-        let luminance = (self.r as u32 * 299 + self.g as u32 * 587 + self.b as u32 * 114) / 1000;
-        if luminance >= 128 {
+        fn linearize(channel: u8) -> f32 {
+            let c = channel as f32 / 255.0;
+            if c <= 0.03928 {
+                c / 12.92
+            } else {
+                ((c + 0.055) / 1.055).powf(2.4)
+            }
+        }
+
+        let luminance =
+            0.2126 * linearize(self.r) + 0.7152 * linearize(self.g) + 0.0722 * linearize(self.b);
+        if luminance > 0.179 {
             Self::new(0, 0, 0, self.a)
         } else {
             Self::new(255, 255, 255, self.a)

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -26,31 +26,64 @@ use relm4::gtk::gdk::DisplayManager;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// How the text outline is rendered, cycled through with the Alt key.
+/// A decoration pass drawn behind the text fill.
+#[derive(Clone, Copy)]
+struct Decoration {
+    color: crate::style::Color,
+    kind: DecorationKind,
+}
+
+#[derive(Clone, Copy)]
+enum DecorationKind {
+    /// Stroke around the glyphs with the given line width.
+    Outline { width: f32 },
+    /// Offset duplicate of the text (drop shadow).
+    Shadow { offset: Vec2D },
+}
+
+/// Decorative text effect, cycled through with the Alt key.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-enum OutlineMode {
+enum TextEffect {
     #[default]
     None,
     Inverted,
     Contrast,
+    Shadow,
 }
 
-impl OutlineMode {
-    /// Cycles None -> Inverted -> Contrast -> None.
+impl TextEffect {
     fn next(self) -> Self {
         match self {
             Self::None => Self::Inverted,
             Self::Inverted => Self::Contrast,
-            Self::Contrast => Self::None,
+            Self::Contrast => Self::Shadow,
+            Self::Shadow => Self::None,
         }
     }
 
-    /// The outline color for the given text color, or None when disabled.
-    fn outline_color(self, text_color: crate::style::Color) -> Option<crate::style::Color> {
+    /// The decoration for the given text color and base stroke width (which scales
+    /// with the font size), or None when disabled.
+    fn decoration(self, text_color: crate::style::Color, line_width: f32) -> Option<Decoration> {
         match self {
             Self::None => None,
-            Self::Inverted => Some(text_color.inverted()),
-            Self::Contrast => Some(text_color.contrast()),
+            Self::Inverted => Some(Decoration {
+                color: text_color.inverted(),
+                kind: DecorationKind::Outline {
+                    width: line_width * 2.0,
+                },
+            }),
+            Self::Contrast => Some(Decoration {
+                color: text_color.contrast(),
+                kind: DecorationKind::Outline {
+                    width: line_width * 2.0,
+                },
+            }),
+            Self::Shadow => Some(Decoration {
+                color: text_color.contrast().with_alpha(160),
+                kind: DecorationKind::Shadow {
+                    offset: Vec2D::new(line_width * 1.5, line_width * 1.5),
+                },
+            }),
         }
     }
 }
@@ -68,7 +101,7 @@ pub struct Text {
     line_ranges: RefCell<Vec<Range<usize>>>,
     cursor_visible: RefCell<bool>,
     draw_rect: RefCell<bool>,
-    outline: OutlineMode,
+    effect: TextEffect,
     font_ids: Vec<FontId>,
 }
 
@@ -113,7 +146,7 @@ impl Text {
             line_ranges: RefCell::new(Vec::new()),
             cursor_visible: RefCell::new(true),
             draw_rect: RefCell::new(true),
-            outline: OutlineMode::default(),
+            effect: TextEffect::default(),
             font_ids: femtovg_area::font_stack().to_vec(),
         }
     }
@@ -383,20 +416,37 @@ impl Drawable for Text {
             canvas.stroke_path(&rect_paint, &paint);
         }
 
-        // When outlining, stroke each line with the outline color first, then fill on
-        // top so the visible border wraps the glyphs. The stroke is widened because it
-        // is centered on the glyph outline and half of it is hidden by the fill.
-        let outline_paint = self.outline.outline_color(self.style.color).map(|color| {
-            let mut paint = base_paint.clone();
-            paint.set_color(color.into());
-            paint.set_line_width(base_paint.line_width() * 2.0);
-            paint
-        });
+        // Decoration drawn behind the fill: an outline strokes each line (widened
+        // because the stroke is centered and half-hidden by the fill), a shadow fills
+        // an offset duplicate.
+        let decoration_paint = self
+            .effect
+            .decoration(self.style.color, base_paint.line_width())
+            .map(|dec| {
+                let mut paint = base_paint.clone();
+                paint.set_color(dec.color.into());
+                if let DecorationKind::Outline { width } = dec.kind {
+                    paint.set_line_width(width);
+                }
+                (dec.kind, paint)
+            });
 
         for line_range in &lines {
             let line = &text[line_range.clone()];
-            if let Some(outline_paint) = &outline_paint {
-                canvas.stroke_text(self.pos.x, draw_baseline, line, outline_paint)?;
+            if let Some((kind, paint)) = &decoration_paint {
+                match kind {
+                    DecorationKind::Shadow { offset } => {
+                        canvas.fill_text(
+                            self.pos.x + offset.x,
+                            draw_baseline + offset.y,
+                            line,
+                            paint,
+                        )?;
+                    }
+                    DecorationKind::Outline { .. } => {
+                        canvas.stroke_text(self.pos.x, draw_baseline, line, paint)?;
+                    }
+                }
             }
             canvas.fill_text(self.pos.x, draw_baseline, line, &base_paint)?;
             draw_baseline += line_height;
@@ -876,7 +926,7 @@ impl Tool for TextTool {
                     tool_update_result = self.handle_deactivated();
                 }
                 Key::Alt_L | Key::Alt_R => {
-                    // Start tracking a potential Alt tap; the outline mode is cycled on
+                    // Start tracking a potential Alt tap; the text effect is cycled on
                     // release (see handle_key_release_event) if no other key was pressed.
                     self.alt_tap = true;
                 }
@@ -1133,7 +1183,7 @@ impl Tool for TextTool {
         if (event.key == Key::Alt_L || event.key == Key::Alt_R) && self.alt_tap {
             self.alt_tap = false;
             if let Some(t) = &mut self.text {
-                t.outline = t.outline.next();
+                t.effect = t.effect.next();
                 return ToolUpdateResult::RedrawAndStopPropagation;
             }
         }


### PR DESCRIPTION
Follow-up to #574 (text outline). Two small, independent improvements — one commit each:

1. Drop-shadow effect <sup>3794dc2</sup>
  Generalizes the Alt-cycled outline into a small TextEffect set. Each variant yields a Decoration describing what's drawn behind the
fill (an outline stroke, or an offset shadow duplicate), so new effects are one enum variant + one match arm. New cycle: none → inverted outline → contrast outline → drop shadow.

2. Gamma-corrected contrast <sup>e8f623a</sup>
  Color::contrast() now uses WCAG relative luminance (sRGB channels gamma-decoded to linear light, then perceptually weighted), with the L = 0.179 black/white crossover, instead of a raw YIQ sum. More legible choice on mid-tones. Also adds a small Color::with_alpha helper.

README.md updated (effect list, still flagged experimental). make fix clean; both commits build standalone.