### PR TITLE
feat: render emoji in the text tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "femtovg"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +906,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
+ "png",
 ]
 
 [[package]]
@@ -1161,6 +1171,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.12.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1418,7 @@ dependencies = [
  "fontconfig",
  "glow",
  "hex_color",
+ "image",
  "keycode",
  "libloading 0.9.0",
  "relm4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = "0.4.44"
 
 # opengl rendering backend
 femtovg = "0.25.0"
+image = { version = "0.25.0", default-features = false, features = ["png"] }  # png decoder for color emoji in femtovg
 libloading = "0.9"
 epoxy = "0.1.0"
 glow = "0.17.0"

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ style = "Regular"
 # specify fallback fonts (0.20.1)
 # Please note, there is no default setting for these and the fonts listed below
 # are not shipped with Satty but need to be available on the system.
+# An installed color emoji font (e.g. Noto Color Emoji) is picked up automatically
+# as the last fallback, so emoji render without extra configuration. (NEXTRELEASE)
 fallback = [
     "Noto Sans CJK SC",
     # "Noto Sans CJK JP",

--- a/config.toml
+++ b/config.toml
@@ -98,6 +98,8 @@ style = "Regular"
 # specify fallback fonts (0.20.1)
 # Please note, there is no default setting for these and the fonts listed below
 # are not shipped with Satty but need to be available on the system.
+# An installed color emoji font (e.g. Noto Color Emoji) is picked up automatically
+# as the last fallback, so emoji render without extra configuration. (NEXTRELEASE)
 fallback = [
     "Noto Sans CJK SC",
     # "Noto Sans CJK JP",

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -262,6 +262,19 @@ impl FemtoVGArea {
             }
         }
 
+        // Append a color emoji font as the last fallback so emoji render out of the box
+        // (femtovg's default image-loading feature draws their bitmap/COLR glyphs).
+        // fontconfig resolves the generic "emoji" family to the installed color emoji
+        // font, e.g. Noto Color Emoji. It is skipped if already loaded or unavailable.
+        match load_font("emoji", None) {
+            Ok(id) => {
+                loaded_fonts.push(id);
+            }
+            Err(e) => {
+                eprintln!("Emoji font: {}", e);
+            }
+        }
+
         Ok((text_context, loaded_fonts))
     }
 

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -266,6 +266,7 @@ impl FemtoVGArea {
         // (femtovg's default image-loading feature draws their bitmap/COLR glyphs).
         // fontconfig resolves the generic "emoji" family to the installed color emoji
         // font, e.g. Noto Color Emoji. It is skipped if already loaded or unavailable.
+        // reconsider with #309
         match load_font("emoji", None) {
             Ok(id) => {
                 loaded_fonts.push(id);


### PR DESCRIPTION
Fixes #536
## Summary

Enable color emoji rendering in the text tool. An installed color emoji font (e.g. Noto Color Emoji) is automatically picked up as the last fallback, so emoji work out of the box without any user configuration.

Text outlines (Alt toggle) are not applied to emoji — they are rendered as-is using their native bitmap colors, while regular text glyphs continue to receive the outline as before.

<img width="705" height="412" alt="image" src="https://github.com/user-attachments/assets/50dc8c55-9990-421d-b70b-16af4099d46c" />


## Problem

Emoji typed into the text tool were silently not rendered — only regular glyphs appeared.

Two things were missing:

1. **No emoji font in the fallback chain.** The font loading code only loaded the user-configured primary font and explicit fallbacks. Without a color emoji font in the stack, femtovg had no glyphs to fall back on for emoji codepoints.

2. **PNG decoder not compiled in.** femtovg supports color emoji via its `image-loading` feature (enabled by default), which decodes PNG glyph bitmaps embedded in color fonts (CBDT/sbix tables). However, femtovg declares `image = { default-features = false }` — meaning the `png` decoder is not included. The call to `image::load_from_memory_with_format(..., Png)` silently failed, and emoji glyphs were skipped entirely.

## Changes

- **`src/femtovg_area/imp.rs`**: Append the fontconfig generic `"emoji"` family as the last fallback font. fontconfig resolves this to the installed color emoji font (e.g. Noto Color Emoji). Skipped gracefully if already loaded or unavailable.
- **`Cargo.toml`**: Add `image` with `features = ["png"]` as a direct dependency. This is not a new dependency — `image` is already pulled in transitively through femtovg. The explicit entry activates the `png` feature via Cargo's feature unification, enabling the PNG decoder that femtovg needs for color glyph bitmaps.
- **`README.md`**, **`config.toml`**: Document that emoji fonts are picked up automatically.

## Outline behavior

femtovg internally separates color glyphs (bitmap emoji) from path-based glyphs during text rendering. When `stroke_text` is called, color glyphs are rendered with `line_width = 0` — the stroke outline is never applied to them. They appear using their native bitmap colors regardless of the outline paint. This is handled entirely within femtovg and requires no special-casing in Satty.

## Testing

- Typed emoji (e.g. 😀🎉🔥) in the text tool → rendered correctly as color bitmaps
- Mixed text + emoji on the same line → both render correctly
- Outline mode (Alt toggle) → outline applied to text glyphs only, emoji remain unaffected