### PR TITLE
feat: add notification-thumbnail config/cmdline option to allow sending notification with image thumbnail rather than app icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1384,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1455,7 @@ dependencies = [
  "satty_cli",
  "serde",
  "serde_derive",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
@@ -1602,6 +1632,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ci-release = []
 satty_cli.workspace = true
 relm4 = { version = "0.10.1", features = ["macros", "libadwaita", "gnome_42"] }
 tokio = { version = "1.53.1", features = ["time"] }
+tempfile = "3.27"
 
 # error handling
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ default-hide-toolbars = false
 focus-toggles-toolbars = false
 # Fill shapes by default (since 0.20.0)
 default-fill-shapes = false
-# Round caps for `arrow` and `line` tools (always true for `brush` tool)
+# Round caps for arrow and line tools
 default-round-caps = true
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]
 primary-highlighter = "block"
@@ -219,8 +219,8 @@ title = "Satty"
 # experimental feature (0.21.0): set app_id, note this has to match D-Bus well-known name format, otherwise GTK does not accept it.
 app-id = "org.satty.satty"
 # experimental feature (NEXTRELEASE): show thumbnail as notifcation icon
-# notification-thumbnail = "thumbnail-file--icon"
-notification-thumbnail = "app-icon"
+# notification-thumbnail = "app-icon"
+notification-thumbnail = "screenshot"
 
 # Tool selection keyboard shortcuts (since 0.20.0)
 [keybinds]
@@ -360,7 +360,7 @@ Options:
       --app-id <APP_ID>
           Experimental feature (0.21.0): Set toplevel app_id. Note that this has to match D-Bus well known name format, otherwise GTK does not accept it
       --notification-thumbnail <NOTIFICATION_THUMBNAIL>
-          Experimental feature (NEXTRELEASE): use preview thumbnail in notifications where available [possible values: app-icon, thumbnail-file-icon]
+          Experimental feature (NEXTRELEASE): use preview thumbnail in notifications where available [possible values: screenshot, app-icon]
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ input-scale = 1.0
 title = "Satty"
 # experimental feature (0.21.0): set app_id, note this has to match D-Bus well-known name format, otherwise GTK does not accept it.
 app-id = "org.satty.satty"
+# experimental feature (NEXTRELEASE): show thumbnail as notifcation icon
+# notification-thumbnail = "thumbnail-file--icon"
+notification-thumbnail = "app-icon"
 
 # Tool selection keyboard shortcuts (since 0.20.0)
 [keybinds]
@@ -356,6 +359,8 @@ Options:
           Experimental feature (0.21.0): Set window title
       --app-id <APP_ID>
           Experimental feature (0.21.0): Set toplevel app_id. Note that this has to match D-Bus well known name format, otherwise GTK does not accept it
+      --notification-thumbnail <NOTIFICATION_THUMBNAIL>
+          Experimental feature (NEXTRELEASE): use preview thumbnail in notifications where available [possible values: app-icon, thumbnail-file-icon]
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -159,6 +159,10 @@ pub struct CommandLine {
     #[arg(long)]
     pub app_id: Option<String>,
 
+    /// Experimental feature (NEXTRELEASE): use preview thumbnail in notifications where available
+    #[arg(long)]
+    pub notification_thumbnail: Option<NotificationThumbnail>,
+
     // --- deprecated options ---
     /// Right click to copy.
     /// Preferably use the `action_on_right_click` option instead.
@@ -213,6 +217,22 @@ pub enum EarlyExitTriggers {
     Copy,
     Save,
     SaveAs,
+}
+
+// notifications can use image-path or image-data, see https://specifications.freedesktop.org/notification/latest-single/#icons-and-images
+// But gtk does not support it https://gitlab.gnome.org/GNOME/glib/-/work_items/1457 at this point.
+// an image lib dependency in glib is not wanted so options for an implementation there are
+// very limited.
+// options are: use different notification library or implement manually. For now, we
+// just offer image-path (which uses a temporary file).
+#[derive(Debug, Clone, Copy, Default, ValueEnum, Deserialize, PartialEq, Eq)]
+#[value(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
+pub enum NotificationThumbnail {
+    #[default]
+    AppIcon,
+    ThumbnailFileIcon,
+    //ThumbnailIcon
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -230,9 +230,9 @@ pub enum EarlyExitTriggers {
 #[serde(rename_all = "kebab-case")]
 pub enum NotificationThumbnail {
     #[default]
+    Screenshot,
     AppIcon,
-    ThumbnailFileIcon,
-    //ThumbnailIcon
+    //ScreenshotData
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/config.toml
+++ b/config.toml
@@ -79,8 +79,8 @@ title = "Satty"
 # experimental feature (0.21.0): set app_id, note this has to match D-Bus well-known name format, otherwise GTK does not accept it.
 app-id = "org.satty.satty"
 # experimental feature (NEXTRELEASE): show thumbnail as notifcation icon
-# notification-thumbnail = "thumbnail-file--icon"
-notification-thumbnail = "app-icon"
+# notification-thumbnail = "app-icon"
+notification-thumbnail = "screenshot"
 
 # Tool selection keyboard shortcuts (since 0.20.0)
 [keybinds]

--- a/config.toml
+++ b/config.toml
@@ -78,6 +78,9 @@ input-scale = 1.0
 title = "Satty"
 # experimental feature (0.21.0): set app_id, note this has to match D-Bus well-known name format, otherwise GTK does not accept it.
 app-id = "org.satty.satty"
+# experimental feature (NEXTRELEASE): show thumbnail as notifcation icon
+# notification-thumbnail = "thumbnail-file--icon"
+notification-thumbnail = "app-icon"
 
 # Tool selection keyboard shortcuts (since 0.20.0)
 [keybinds]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -20,7 +20,8 @@ use crate::{
 };
 
 use satty_cli::command_line::{
-    Action as CommandLineAction, CommandLine, EarlyExitTriggers, Fullscreen, Resize,
+    Action as CommandLineAction, CommandLine, EarlyExitTriggers, Fullscreen, NotificationThumbnail,
+    Resize,
 };
 
 pub static APP_CONFIG: SharedState<Configuration> = SharedState::new();
@@ -73,6 +74,7 @@ pub struct Configuration {
     input_scale: Option<f32>,
     title: Option<String>,
     app_id: Option<String>,
+    notification_thumbnail: NotificationThumbnail,
 }
 
 pub struct Keybinds {
@@ -427,6 +429,9 @@ impl Configuration {
         if let Some(v) = general.app_id {
             self.app_id = Some(v);
         }
+        if let Some(v) = general.notification_thumbnail {
+            self.notification_thumbnail = v;
+        }
 
         // --- deprecated options ---
         if let Some(v) = general.right_click_copy
@@ -559,6 +564,9 @@ impl Configuration {
         }
         if let Some(v) = command_line.app_id {
             self.app_id = Some(v);
+        }
+        if let Some(v) = command_line.notification_thumbnail {
+            self.notification_thumbnail = v;
         }
 
         // --- deprecated options ---
@@ -726,6 +734,10 @@ impl Configuration {
     pub fn app_id(&self) -> Option<&String> {
         self.app_id.as_ref()
     }
+
+    pub fn notification_thumbnail(&self) -> &NotificationThumbnail {
+        &self.notification_thumbnail
+    }
 }
 
 impl Default for Configuration {
@@ -766,6 +778,7 @@ impl Default for Configuration {
             input_scale: None,
             title: None,
             app_id: None,
+            notification_thumbnail: NotificationThumbnail::default(),
         }
     }
 }
@@ -851,6 +864,7 @@ struct ConfigurationFileGeneral {
     input_scale: Option<f32>,
     title: Option<String>,
     app_id: Option<String>,
+    notification_thumbnail: Option<NotificationThumbnail>,
 
     // --- deprecated options ---
     right_click_copy: Option<bool>,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -735,8 +735,8 @@ impl Configuration {
         self.app_id.as_ref()
     }
 
-    pub fn notification_thumbnail(&self) -> &NotificationThumbnail {
-        &self.notification_thumbnail
+    pub fn notification_thumbnail(&self) -> NotificationThumbnail {
+        self.notification_thumbnail
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use relm4::gtk::prelude::*;
 use std::io::Read;
 use std::ops::Deref;
 use std::process::exit;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, RwLock};
 use std::{fs, ptr};
 use std::{io, time::Duration};
 
@@ -18,8 +18,8 @@ use relm4::{
 
 use anyhow::{Context, Result, anyhow};
 use satty_cli::command_line::{Fullscreen, Resize};
+use tempfile::TempDir;
 
-use crate::notification::NOTIFICATION_THUMBNAIL_PATH;
 use sketch_board::SketchBoardOutput;
 use ui::toolbars::{StyleToolbar, StyleToolbarInput, ToolsToolbar, ToolsToolbarInput};
 use xdg::BaseDirectories;
@@ -40,6 +40,15 @@ use crate::tools::Tools;
 
 pub static START_TIME: LazyLock<chrono::DateTime<chrono::Local>> =
     LazyLock::new(chrono::Local::now);
+
+pub static TEMP_DIR: LazyLock<RwLock<Option<TempDir>>> =
+    LazyLock::new(|| match tempfile::TempDir::new() {
+        Ok(dir) => RwLock::new(Some(dir)),
+        Err(e) => {
+            eprintln!("Failed to create temporary directory: {}", e);
+            RwLock::new(None)
+        }
+    });
 
 macro_rules! generate_profile_output {
     ($e: expr) => {
@@ -519,13 +528,19 @@ fn run_satty() -> Result<()> {
         icons::icon_names::RESOURCE_PREFIX,
     );
 
-    relm4::main_application().connect_shutdown(move |_| {
-        if let Err(e) = std::fs::remove_file(&*NOTIFICATION_THUMBNAIL_PATH) {
-            eprintln!("Failed to remove thumbnail temp path: {e}");
-        }
-    });
-
     app.run::<App>(image);
+
+    match TEMP_DIR.write() {
+        Ok(mut temp_dir) => {
+            if let Some(dir) = temp_dir.take() {
+                dir.close()?;
+            }
+        }
+        Err(e) => {
+            eprintln!("{}", e);
+        }
+    }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,10 +534,10 @@ fn run_satty() -> Result<()> {
         Ok(mut temp_dir) => {
             // take is sufficient to have the dir deleted when it's dropped.
             // But that would hide any errors, so use explicit close instead.
-            if let Some(dir) = temp_dir.take() {
-                if let Err(e) = dir.close() {
-                    eprintln!("Failed to close temporary directory: {}", e);
-                }
+            if let Some(dir) = temp_dir.take()
+                && let Err(e) = dir.close()
+            {
+                eprintln!("Failed to close temporary directory: {}", e);
             }
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,8 +532,12 @@ fn run_satty() -> Result<()> {
 
     match TEMP_DIR.write() {
         Ok(mut temp_dir) => {
+            // take is sufficient to have the dir deleted when it's dropped.
+            // But that would hide any errors, so use explicit close instead.
             if let Some(dir) = temp_dir.take() {
-                dir.close()?;
+                if let Err(e) = dir.close() {
+                    eprintln!("Failed to close temporary directory: {}", e);
+                }
             }
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,13 @@
 use configuration::{APP_CONFIG, Configuration};
+use relm4::gtk::gdk_pixbuf::{Pixbuf, PixbufLoader};
+use relm4::gtk::gio::{Application, ApplicationFlags};
+use relm4::gtk::prelude::*;
 use std::io::Read;
 use std::ops::Deref;
 use std::process::exit;
 use std::sync::LazyLock;
 use std::{fs, ptr};
 use std::{io, time::Duration};
-
-use relm4::gtk::gdk_pixbuf::{Pixbuf, PixbufLoader};
-use relm4::gtk::gio::{Application, ApplicationFlags};
-use relm4::gtk::prelude::*;
 
 use relm4::gtk::gdk::Rectangle;
 
@@ -20,6 +19,7 @@ use relm4::{
 use anyhow::{Context, Result, anyhow};
 use satty_cli::command_line::{Fullscreen, Resize};
 
+use crate::notification::NOTIFICATION_THUMBNAIL_PATH;
 use sketch_board::SketchBoardOutput;
 use ui::toolbars::{StyleToolbar, StyleToolbarInput, ToolsToolbar, ToolsToolbarInput};
 use xdg::BaseDirectories;
@@ -518,6 +518,13 @@ fn run_satty() -> Result<()> {
         icons::icon_names::GRESOURCE_BYTES,
         icons::icon_names::RESOURCE_PREFIX,
     );
+
+    relm4::main_application().connect_shutdown(move |_| {
+        if let Err(e) = std::fs::remove_file(&*NOTIFICATION_THUMBNAIL_PATH) {
+            eprintln!("Failed to remove thumbnail temp path: {e}");
+        }
+    });
+
     app.run::<App>(image);
     Ok(())
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,11 +1,12 @@
 use relm4::gtk::gio::FileIcon;
 use relm4::gtk::gio::{Notification, prelude::ApplicationExt};
 
+use crate::configuration::APP_CONFIG;
 use relm4::gtk::{IconLookupFlags, IconTheme, TextDirection};
 
 pub fn log_result(msg: &str, notify: bool) {
     eprintln!("{msg}");
-    if notify {
+    if notify && !APP_CONFIG.read().disable_notifications() {
         show_notification(msg);
     }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,36 +1,100 @@
-use relm4::gtk::gio::FileIcon;
+use relm4::gtk::gio::{FileIcon, Icon};
 use relm4::gtk::gio::{Notification, prelude::ApplicationExt};
+use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use crate::configuration::APP_CONFIG;
-use relm4::gtk::{IconLookupFlags, IconTheme, TextDirection};
+use relm4::gtk::gdk_pixbuf::{InterpType, Pixbuf};
+use relm4::gtk::prelude::Cast;
+use relm4::gtk::{IconLookupFlags, IconTheme, TextDirection, gio};
+use satty_cli::command_line::NotificationThumbnail;
+
+pub static NOTIFICATION_THUMBNAIL_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
+    std::env::temp_dir().join(format!(
+        "satty-notification-thumbnail-{}.png",
+        std::process::id()
+    ))
+});
 
 pub fn log_result(msg: &str, notify: bool) {
     eprintln!("{msg}");
     if notify && !APP_CONFIG.read().disable_notifications() {
-        show_notification(msg);
+        show_notification(msg, None);
     }
 }
 
-fn show_notification(msg: &str) {
+pub fn log_result_with_pixbuf(msg: &str, pixbuf: Pixbuf) {
+    eprintln!("{msg}");
+
+    if APP_CONFIG.read().disable_notifications() {
+        return;
+    }
+
+    let notification_icon_kind = APP_CONFIG.read().notification_thumbnail();
+
+    let pixbuf = match notification_icon_kind {
+        NotificationThumbnail::AppIcon => None,
+        _ => {
+            let src_w = pixbuf.width();
+            let src_h = pixbuf.height();
+
+            if src_w == 0 || src_h == 0 {
+                None
+            } else {
+                let scale = f64::min(96.0 / src_w as f64, 96.0 / src_h as f64);
+
+                let new_w = ((src_w as f64) * scale).round().max(1.0) as i32;
+                let new_h = ((src_h as f64) * scale).round().max(1.0) as i32;
+
+                pixbuf.scale_simple(new_w, new_h, InterpType::Bilinear)
+            }
+        }
+    };
+
+    let icon = match pixbuf {
+        // glib doesn't support image-data at this point
+        /*
+        Some(p) if notification_icon_kind == NotificationThumbnail::ThumbnailIcon => {
+            Some(p.upcast::<Icon>())
+        }*/
+        Some(p) if notification_icon_kind == NotificationThumbnail::ThumbnailFileIcon => {
+            if p.savev(&*NOTIFICATION_THUMBNAIL_PATH, "png", &[]).is_err() {
+                None
+            } else {
+                let file = gio::File::for_path(&*NOTIFICATION_THUMBNAIL_PATH);
+                Some(FileIcon::new(&file).upcast::<Icon>())
+            }
+        }
+        _ => None,
+    };
+
+    show_notification(msg, icon);
+}
+
+fn show_notification(msg: &str, icon: Option<Icon>) {
     // construct
     let notification = Notification::new("Satty");
     notification.set_body(Some(msg));
 
-    // lookup sattys icon
-    let theme = IconTheme::default();
-    if theme.has_icon("satty")
-        && let Some(icon_file) = theme
-            .lookup_icon(
-                "satty",
-                &[],
-                96,
-                1,
-                TextDirection::Ltr,
-                IconLookupFlags::empty(),
-            )
-            .file()
-    {
-        notification.set_icon(&FileIcon::new(&icon_file));
+    if let Some(i) = icon {
+        notification.set_icon(&i);
+    } else {
+        // lookup sattys icon
+        let theme = IconTheme::default();
+        if theme.has_icon("satty")
+            && let Some(icon_file) = theme
+                .lookup_icon(
+                    "satty",
+                    &[],
+                    96,
+                    1,
+                    TextDirection::Ltr,
+                    IconLookupFlags::empty(),
+                )
+                .file()
+        {
+            notification.set_icon(&FileIcon::new(&icon_file));
+        }
     }
 
     // send notification

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,20 +1,13 @@
 use relm4::gtk::gio::{FileIcon, Icon};
 use relm4::gtk::gio::{Notification, prelude::ApplicationExt};
-use std::path::PathBuf;
-use std::sync::LazyLock;
 
+use crate::TEMP_DIR;
 use crate::configuration::APP_CONFIG;
 use relm4::gtk::gdk_pixbuf::{InterpType, Pixbuf};
 use relm4::gtk::prelude::Cast;
 use relm4::gtk::{IconLookupFlags, IconTheme, TextDirection, gio};
 use satty_cli::command_line::NotificationThumbnail;
-
-pub static NOTIFICATION_THUMBNAIL_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
-    std::env::temp_dir().join(format!(
-        "satty-notification-thumbnail-{}.png",
-        std::process::id()
-    ))
-});
+use tempfile::NamedTempFile;
 
 pub fn log_result(msg: &str, notify: bool) {
     eprintln!("{msg}");
@@ -51,13 +44,39 @@ pub fn log_result_with_pixbuf(msg: &str, pixbuf: Pixbuf) {
         }
     };
 
-    let icon = match pixbuf {
-        Some(p) if notification_icon_kind == NotificationThumbnail::ThumbnailFileIcon => {
-            if p.savev(&*NOTIFICATION_THUMBNAIL_PATH, "png", &[]).is_err() {
-                None
-            } else {
-                let file = gio::File::for_path(&*NOTIFICATION_THUMBNAIL_PATH);
+    // we can't just use a tempfile here because we need the path for the FileIcon.
+    // Also, we can't just use NamedTempFile with cleanup, because it gets dropped
+    // at the end of this function, which can be too early for the notification daemon.
+    let tempfile: Option<NamedTempFile> = match TEMP_DIR.read() {
+        Ok(guard) => match &*guard {
+            Some(d) if pixbuf.is_some() => {
+                if let Ok(tf) = tempfile::Builder::new()
+                    .disable_cleanup(true)
+                    .suffix(".png")
+                    .tempfile_in(d.path())
+                {
+                    Some(tf)
+                } else {
+                    eprintln!("Could not create temporary file");
+                    None
+                }
+            }
+            _ => None,
+        },
+        Err(e) => {
+            eprintln!("Error acquiring read guard for temp directory: {}", e);
+            None
+        }
+    };
+
+    let icon = match tempfile.as_ref() {
+        Some(f) => {
+            // this unwrap is safe because tempfile would not be Some otherwise, see above
+            if pixbuf.unwrap().savev(f, "png", &[]).is_ok() {
+                let file = gio::File::for_path(f);
                 Some(FileIcon::new(&file).upcast::<Icon>())
+            } else {
+                None
             }
         }
         _ => None,

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -52,11 +52,6 @@ pub fn log_result_with_pixbuf(msg: &str, pixbuf: Pixbuf) {
     };
 
     let icon = match pixbuf {
-        // glib doesn't support image-data at this point
-        /*
-        Some(p) if notification_icon_kind == NotificationThumbnail::ThumbnailIcon => {
-            Some(p.upcast::<Icon>())
-        }*/
         Some(p) if notification_icon_kind == NotificationThumbnail::ThumbnailFileIcon => {
             if p.savev(&*NOTIFICATION_THUMBNAIL_PATH, "png", &[]).is_err() {
                 None

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -417,10 +417,7 @@ impl SketchBoard {
                 home_dir.push(tilde_stripped);
                 output_filename = home_dir.to_string_lossy().into_owned();
             } else {
-                log_result(
-                    "~ found but could not determine homedir",
-                    !APP_CONFIG.read().disable_notifications(),
-                );
+                log_result("~ found but could not determine homedir", true);
                 return None;
             }
         }
@@ -505,7 +502,7 @@ impl SketchBoard {
         if output_filename != "-" && !output_filename.ends_with(".png") {
             log_result(
                 "The only supported format is png, but the filename does not end in png",
-                !APP_CONFIG.read().disable_notifications(),
+                true,
             );
             return;
         }
@@ -528,17 +525,11 @@ impl SketchBoard {
             return;
         }
         match fs::write(&output_filename, data) {
-            Err(e) => log_result(
-                &format!("Error while saving file: {e}"),
-                !APP_CONFIG.read().disable_notifications(),
-            ),
+            Err(e) => log_result(&format!("Error while saving file: {e}"), true),
             Ok(_) => {
                 // Store the filepath for copy-filepath action
                 *self.last_saved_filepath.borrow_mut() = Some(output_filename.clone());
-                log_result(
-                    &format!("File saved to '{}'.", output_filename),
-                    !APP_CONFIG.read().disable_notifications(),
-                )
+                log_result(&format!("File saved to '{}'.", output_filename), true)
             }
         };
     }
@@ -607,18 +598,12 @@ impl SketchBoard {
                     };
 
                     match fs::write(&output_filename, &data) {
-                        Err(e) => log_result(
-                            &format!("Error while saving file: {e}"),
-                            !APP_CONFIG.read().disable_notifications(),
-                        ),
+                        Err(e) => log_result(&format!("Error while saving file: {e}"), true),
                         Ok(_) => {
                             exit_app = APP_CONFIG.read().early_exit_save_as();
                             filename = Some(output_filename.clone());
                             Self::remember_save_as_dir(Path::new(&output_filename));
-                            log_result(
-                                &format!("File saved to '{}'.", output_filename),
-                                !APP_CONFIG.read().disable_notifications(),
-                            )
+                            log_result(&format!("File saved to '{}'.", output_filename), true)
                         }
                     };
                 }
@@ -687,10 +672,7 @@ impl SketchBoard {
         match result {
             Err(e) => eprintln!("Error saving {e}"),
             Ok(()) => {
-                log_result(
-                    "Copied to clipboard.",
-                    !APP_CONFIG.read().disable_notifications(),
-                );
+                log_result("Copied to clipboard.", true);
 
                 // TODO: rethink order and messaging patterns
                 if APP_CONFIG.read().save_after_copy() {
@@ -726,14 +708,8 @@ impl SketchBoard {
         };
 
         match result {
-            Err(e) => log_result(
-                &format!("Error copying filepath: {e}"),
-                !APP_CONFIG.read().disable_notifications(),
-            ),
-            Ok(()) => log_result(
-                &format!("Filepath copied to clipboard: {}", filepath),
-                !APP_CONFIG.read().disable_notifications(),
-            ),
+            Err(e) => log_result(&format!("Error copying filepath: {e}"), true),
+            Ok(()) => log_result(&format!("Filepath copied to clipboard: {}", filepath), true),
         }
     }
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -22,7 +22,7 @@ use crate::configuration::{APP_CONFIG, Action};
 use crate::femtovg_area::FemtoVGArea;
 use crate::ime::pango_adapter::spans_from_pango_attrs;
 use crate::math::Vec2D;
-use crate::notification::log_result;
+use crate::notification::{log_result, log_result_with_pixbuf};
 use crate::style::Style;
 use crate::tools::{Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
 use crate::ui::toolbars::ToolbarEvent;
@@ -529,7 +529,10 @@ impl SketchBoard {
             Ok(_) => {
                 // Store the filepath for copy-filepath action
                 *self.last_saved_filepath.borrow_mut() = Some(output_filename.clone());
-                log_result(&format!("File saved to '{}'.", output_filename), true)
+                log_result_with_pixbuf(
+                    &format!("File saved to '{}'.", output_filename),
+                    image.clone(),
+                )
             }
         };
     }
@@ -603,7 +606,10 @@ impl SketchBoard {
                             exit_app = APP_CONFIG.read().early_exit_save_as();
                             filename = Some(output_filename.clone());
                             Self::remember_save_as_dir(Path::new(&output_filename));
-                            log_result(&format!("File saved to '{}'.", output_filename), true)
+                            log_result_with_pixbuf(
+                                &format!("File saved to '{}'.", output_filename),
+                                pixbuf.clone(),
+                            )
                         }
                     };
                 }
@@ -672,7 +678,7 @@ impl SketchBoard {
         match result {
             Err(e) => eprintln!("Error saving {e}"),
             Ok(()) => {
-                log_result("Copied to clipboard.", true);
+                log_result_with_pixbuf("Copied to clipboard.", image.clone());
 
                 // TODO: rethink order and messaging patterns
                 if APP_CONFIG.read().save_after_copy() {


### PR DESCRIPTION
Closes: #426 

Also gets rid of redundant `!APP_CONFIG.read().disable_notifications()` by placing that one centrally in `log_result`.