### PR TITLE
fix: new clippy warnings via stable rustc

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -434,7 +434,7 @@ fn read_css_overrides() -> Option<String> {
     if !path.exists() {
         eprintln!(
             "CSS overrides file {} does not exist, using builtin CSS only.",
-            &path.display()
+            path.display()
         );
         return None;
     }
@@ -444,7 +444,7 @@ fn read_css_overrides() -> Option<String> {
         Err(e) => {
             eprintln!(
                 "failed to read CSS overrides from {} with error: {}",
-                &path.display(),
+                path.display(),
                 e
             );
             None

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -536,7 +536,7 @@ impl SketchBoard {
                 // Store the filepath for copy-filepath action
                 *self.last_saved_filepath.borrow_mut() = Some(output_filename.clone());
                 log_result(
-                    &format!("File saved to '{}'.", &output_filename),
+                    &format!("File saved to '{}'.", output_filename),
                     !APP_CONFIG.read().disable_notifications(),
                 )
             }
@@ -616,7 +616,7 @@ impl SketchBoard {
                             filename = Some(output_filename.clone());
                             Self::remember_save_as_dir(Path::new(&output_filename));
                             log_result(
-                                &format!("File saved to '{}'.", &output_filename),
+                                &format!("File saved to '{}'.", output_filename),
                                 !APP_CONFIG.read().disable_notifications(),
                             )
                         }


### PR DESCRIPTION
```
error: redundant reference in `format!` argument
   --> src/sketch_board.rs:533:53
    |
533 |                     &format!("File saved to '{}'.", &output_filename),
    |                                                     ^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `output_filename`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`

error: redundant reference in `format!` argument
   --> src/sketch_board.rs:610:65
    |
610 | ...                   &format!("File saved to '{}'.", &output_filename),
    |                                                       ^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `output_filename`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting

error: redundant reference in `eprintln!` argument
   --> src/main.rs:437:13
    |
437 |             &path.display()
    |             ^^^^^^^^^^^^^^^ help: remove the redundant `&`: `path.display()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting

error: redundant reference in `eprintln!` argument
   --> src/main.rs:447:17
    |
447 |                 &path.display(),
    |                 ^^^^^^^^^^^^^^^ help: remove the redundant `&`: `path.display()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting

```