### PR TITLE
feat: default rounded brush lines and round cap toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ default-hide-toolbars = false
 focus-toggles-toolbars = false
 # Fill shapes by default (since 0.20.0)
 default-fill-shapes = false
+# Round caps for `arrow` and `line` tools (always true for `brush` tool)
+default-round-caps = true
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]
 primary-highlighter = "block"
 # Disable notifications
@@ -307,7 +309,7 @@ Options:
       --corner-roundness <CORNER_ROUNDNESS>
           Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
-          Select the tool on startup [aliases: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
+          Select the tool on startup [alias: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
       --copy-command <COPY_COMMAND>
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>

--- a/build.rs
+++ b/build.rs
@@ -66,6 +66,7 @@ fn main() -> Result<(), io::Error> {
             "minus-large",
             "checkbox-unchecked-regular",
             "circle-regular",
+            "square-regular",
             "crop-filled",
             "arrow-up-right-filled",
             "rectangle-landscape-regular",

--- a/config.toml
+++ b/config.toml
@@ -38,6 +38,8 @@ default-hide-toolbars = false
 focus-toggles-toolbars = false
 # Fill shapes by default (since 0.20.0)
 default-fill-shapes = false
+# Round caps for arrow and line tools
+default-round-caps = true
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]
 primary-highlighter = "block"
 # Disable notifications

--- a/icons.toml
+++ b/icons.toml
@@ -17,6 +17,7 @@ icons = [
   "minus-large",
   "checkbox-unchecked-regular",
   "circle-regular",
+  "square-regular",
   "crop-filled",
   "arrow-up-right-filled",
   "rectangle-landscape-regular",

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -332,8 +332,8 @@ impl Configuration {
                 eprintln!("Error reading config file: {e}");
 
                 // swallow broken pipes
-                let _ = io::stdout().lock().flush();
-                let _ = io::stderr().lock().flush();
+                let _ = std::io::stdout().lock().flush();
+                let _ = std::io::stderr().lock().flush();
 
                 // exit
                 std::process::exit(3);

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -59,6 +59,7 @@ pub struct Configuration {
     default_hide_toolbars: bool,
     focus_toggles_toolbars: bool,
     default_fill_shapes: bool,
+    default_round_caps: bool,
     font: FontConfiguration,
     primary_highlighter: Highlighters,
     disable_notifications: bool,
@@ -331,8 +332,8 @@ impl Configuration {
                 eprintln!("Error reading config file: {e}");
 
                 // swallow broken pipes
-                let _ = std::io::stdout().lock().flush();
-                let _ = std::io::stderr().lock().flush();
+                let _ = io::stdout().lock().flush();
+                let _ = io::stderr().lock().flush();
 
                 // exit
                 std::process::exit(3);
@@ -392,6 +393,9 @@ impl Configuration {
         }
         if let Some(v) = general.default_fill_shapes {
             self.default_fill_shapes = v;
+        }
+        if let Some(v) = general.default_round_caps {
+            self.default_round_caps = v;
         }
         if let Some(v) = general.primary_highlighter {
             self.primary_highlighter = v;
@@ -667,6 +671,10 @@ impl Configuration {
         self.default_fill_shapes
     }
 
+    pub fn default_round_caps(&self) -> bool {
+        self.default_round_caps
+    }
+
     pub fn primary_highlighter(&self) -> Highlighters {
         self.primary_highlighter
     }
@@ -744,6 +752,7 @@ impl Default for Configuration {
             default_hide_toolbars: false,
             focus_toggles_toolbars: false,
             default_fill_shapes: false,
+            default_round_caps: true,
             font: FontConfiguration::default(),
             primary_highlighter: Highlighters::Block,
             disable_notifications: false,
@@ -831,6 +840,7 @@ struct ConfigurationFileGeneral {
     default_hide_toolbars: Option<bool>,
     focus_toggles_toolbars: Option<bool>,
     default_fill_shapes: Option<bool>,
+    default_round_caps: Option<bool>,
     primary_highlighter: Option<Highlighters>,
     disable_notifications: Option<bool>,
     no_window_decoration: Option<bool>,

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 
 use femtovg::imgref::Img;
 use femtovg::rgb::{ComponentBytes, RGBA};
+use gtk::prelude::*;
 use keycode::{KeyMap, KeyMappingId};
 use relm4::gtk::gdk_pixbuf::Pixbuf;
 use relm4::gtk::gdk_pixbuf::glib::Bytes;
@@ -12,8 +13,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::{fs, io};
-
-use gtk::prelude::*;
 
 use relm4::gtk::gdk::{DisplayManager, Key, ModifierType, Texture};
 use relm4::{Component, ComponentParts, ComponentSender, RelmWidgetExt, gtk};
@@ -867,6 +866,12 @@ impl SketchBoard {
             ToolbarEvent::ClearAll => self.handle_clear_all(),
             ToolbarEvent::ToggleFill => {
                 self.style.fill = !self.style.fill;
+                self.active_tool
+                    .borrow_mut()
+                    .handle_event(ToolEvent::StyleChanged(self.style))
+            }
+            ToolbarEvent::ToggleRoundCaps => {
+                self.style.round_caps = !self.style.round_caps;
                 self.active_tool
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 
 use femtovg::imgref::Img;
 use femtovg::rgb::{ComponentBytes, RGBA};
-use gtk::prelude::*;
 use keycode::{KeyMap, KeyMappingId};
 use relm4::gtk::gdk_pixbuf::Pixbuf;
 use relm4::gtk::gdk_pixbuf::glib::Bytes;
@@ -13,6 +12,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::{fs, io};
+
+use gtk::prelude::*;
 
 use relm4::gtk::gdk::{DisplayManager, Key, ModifierType, Texture};
 use relm4::{Component, ComponentParts, ComponentSender, RelmWidgetExt, gtk};

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use femtovg::Paint;
+use femtovg::{LineCap, LineJoin, Paint};
 use hex_color::HexColor;
 use relm4::gtk::gdk::RGBA;
 use relm4::gtk::gdk_pixbuf::{
@@ -199,6 +199,8 @@ impl From<Style> for Paint {
             .with_anti_alias(true)
             .with_font_size(value.size.to_text_size(value.annotation_size_factor) as f32)
             .with_color(value.color.into())
+            .with_line_join(LineJoin::Round)
+            .with_line_cap(LineCap::Round)
             .with_line_width(value.size.to_line_width(value.annotation_size_factor))
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use femtovg::{LineCap, LineJoin, Paint};
+use femtovg::{LineCap, Paint};
 use hex_color::HexColor;
 use relm4::gtk::gdk::RGBA;
 use relm4::gtk::gdk_pixbuf::{
@@ -16,6 +16,7 @@ pub struct Style {
     pub color: Color,
     pub size: Size,
     pub fill: bool,
+    pub round_caps: bool,
     pub annotation_size_factor: f32,
 }
 
@@ -41,6 +42,7 @@ impl Default for Style {
             color: Color::default(),
             size: Size::default(),
             fill: APP_CONFIG.read().default_fill_shapes(),
+            round_caps: APP_CONFIG.read().default_round_caps(),
             annotation_size_factor: APP_CONFIG.read().annotation_size_factor(),
         }
     }
@@ -156,12 +158,7 @@ impl Color {
 
 impl From<RGBA> for Color {
     fn from(value: RGBA) -> Self {
-        Self::new(
-            (value.red() * 255.0) as u8,
-            (value.green() * 255.0) as u8,
-            (value.blue() * 255.0) as u8,
-            (value.alpha() * 255.0) as u8,
-        )
+        Self::from_gdk(value)
     }
 }
 
@@ -199,8 +196,11 @@ impl From<Style> for Paint {
             .with_anti_alias(true)
             .with_font_size(value.size.to_text_size(value.annotation_size_factor) as f32)
             .with_color(value.color.into())
-            .with_line_join(LineJoin::Round)
-            .with_line_cap(LineCap::Round)
+            .with_line_cap(if value.round_caps {
+                LineCap::Round
+            } else {
+                LineCap::Butt
+            })
             .with_line_width(value.size.to_line_width(value.annotation_size_factor))
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -158,7 +158,12 @@ impl Color {
 
 impl From<RGBA> for Color {
     fn from(value: RGBA) -> Self {
-        Self::from_gdk(value)
+        Self::new(
+            (value.red() * 255.0) as u8,
+            (value.green() * 255.0) as u8,
+            (value.blue() * 255.0) as u8,
+            (value.alpha() * 255.0) as u8,
+        )
     }
 }
 

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -1,13 +1,12 @@
 use std::time::Instant;
 
-use femtovg::{FontId, Path};
-
 use crate::{
     configuration::APP_CONFIG,
     math::Vec2D,
     sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
     style::Style,
 };
+use femtovg::{FontId, LineCap, LineJoin, Paint, Path};
 
 use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 use relm4::Sender;
@@ -59,7 +58,12 @@ impl Drawable for BrushDrawable {
             path.line_to(start_point.x + p.x, start_point.y + p.y);
         }
 
-        canvas.stroke_path(&path, &self.style.into());
+        canvas.stroke_path(
+            &path,
+            &Paint::from(self.style)
+                .with_line_cap(LineCap::Round)
+                .with_line_join(LineJoin::Round),
+        );
         canvas.restore();
         Ok(())
     }

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -1,12 +1,13 @@
 use std::time::Instant;
 
+use femtovg::{FontId, LineCap, LineJoin, Paint, Path};
+
 use crate::{
     configuration::APP_CONFIG,
     math::Vec2D,
     sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
     style::Style,
 };
-use femtovg::{FontId, LineCap, LineJoin, Paint, Path};
 
 use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 use relm4::Sender;

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -47,6 +47,7 @@ pub enum ToolbarEvent {
     SaveFile,
     CopyClipboard,
     ToggleFill,
+    ToggleRoundCaps,
     AnnotationSizeFactorChanged(f32),
     ClearAll,
     SaveFileAs,
@@ -594,6 +595,26 @@ impl Component for StyleToolbar {
                     button.set_icon_name(new_icon);
                 },
             },
+            gtk::Separator {},
+            gtk::Button {
+                set_focusable: false,
+                set_hexpand: false,
+                set_tooltip: "Toggle Round Caps",
+                set_icon_name: if APP_CONFIG.read().default_round_caps() {
+                    "circle-regular"
+                } else {
+                    "square-regular"
+                },
+                connect_clicked[sender] => move |button| {
+                    sender.output_sender().emit(ToolbarEvent::ToggleRoundCaps);
+                    let new_icon = if button.icon_name() == Some("circle-regular".into()) {
+                        "square-regular"
+                    } else {
+                        "circle-regular"
+                    };
+                    button.set_icon_name(new_icon);
+                },
+            }
         },
     }
 


### PR DESCRIPTION
Closes #590 

This PR adds `.with_line_cap(LineCap::Round)` for `brush` tool as default drawing behavior, adds new button to the toolbar (`Toggle Round Caps`) next to the `fill` function. This button toggles round caps for `arrow` and `line` tools.


https://github.com/user-attachments/assets/36aaf000-e818-4db3-8a28-247545662b27


