### PR TITLE
refactor: use custom component for tool buttons to allow grouping

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -79,6 +79,7 @@ fn main() -> Result<(), io::Error> {
             "arrow-counterclockwise-regular",
             "dismiss-regular",
             "checkmark-regular",
+            "caret-down-right-filled",
         ],
     );
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -128,6 +128,13 @@ pub trait Tool {
 }
 
 #[derive(Clone, Debug)]
+pub struct GroupableTool {
+    pub tool: Tools,
+    pub icon_name: String,
+    pub tooltip: String, // should be fine as long as there is no runtime shortcut editing
+}
+
+#[derive(Clone, Debug)]
 pub struct InputContext {
     pub im_context: IMMulticontext,
     pub widget: gtk::Widget,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -131,7 +131,7 @@ pub trait Tool {
 pub struct GroupableTool {
     pub tool: Tools,
     pub icon_name: String,
-    pub tooltip: String, // should be fine as long as there is no runtime shortcut editing
+    pub tooltip: Option<String>, // should be fine as long as there is no runtime shortcut editing
 }
 
 #[derive(Clone, Debug)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,1 +1,2 @@
+mod tool_group_button;
 pub mod toolbars;

--- a/src/ui/tool_group_button.rs
+++ b/src/ui/tool_group_button.rs
@@ -2,9 +2,9 @@ use crate::tools::{GroupableTool, Tools};
 use crate::ui::toolbars::ToolsAction;
 use relm4::actions::ActionablePlus;
 use relm4::factory::{DynamicIndex, FactoryComponent};
-use relm4::gtk::prelude::{BoxExt, ButtonExt, GestureExt, GestureSingleExt, PopoverExt, WidgetExt};
+use relm4::gtk::prelude::{BoxExt, ButtonExt, GestureExt, PopoverExt, WidgetExt};
 use relm4::gtk::{Align, Popover, ToggleButton};
-use relm4::{FactorySender, RelmWidgetExt, gtk, view};
+use relm4::{FactorySender, RelmWidgetExt, view};
 
 pub struct ToolGroupInit {
     pub group: Vec<GroupableTool>,
@@ -37,12 +37,14 @@ impl ToolGroupButton {
             && let g = &self.group[self.current]
         {
             widgets.button.set_icon_name(&g.icon_name);
-            let tooltip = if self.has_extra() {
-                format!("{}\n\n{}", g.tooltip, "right-click for more tools")
-            } else {
-                g.tooltip.clone()
-            };
-            widgets.button.set_tooltip(&tooltip);
+            if let Some(tt) = &g.tooltip {
+                let tooltip = if self.has_extra() {
+                    format!("{}\n\n{}", tt, "right-click for more tools")
+                } else {
+                    tt.clone()
+                };
+                widgets.button.set_tooltip(&tooltip);
+            }
             ActionablePlus::set_action::<ToolsAction>(&widgets.button, g.tool);
         }
     }
@@ -89,7 +91,7 @@ impl FactoryComponent for ToolGroupButton {
     }
 
     fn init_root(&self) -> Self::Root {
-        gtk::Overlay::new()
+        relm4::gtk::Overlay::new()
     }
 
     fn init_widgets(
@@ -107,41 +109,49 @@ impl FactoryComponent for ToolGroupButton {
                     set_focusable: false,
                     set_valign: Align::End,
                     set_halign: Align::Center,
-                    add_controller = gtk::GestureClick {
-                        set_button: 3,
-                        connect_pressed[sender] => move |gesture, _, _, _| {
-                            gesture.set_state(relm4::gtk::EventSequenceState::Claimed);
-                            sender.input(ToolGroupButtonInput::OpenPopover);
-                        }
-                    }
                 },
-                add_overlay = &relm4::gtk::Image {
-                    set_icon_name: Some("caret-down-right-filled"),
-                    set_pixel_size: 8,
-                    set_halign: Align::End,
-                    set_valign: Align::End,
-                    set_can_target: false,
-                    set_visible: self.has_extra(),
-                }
             },
         }
 
-        let rows = gtk::Box::new(gtk::Orientation::Vertical, 2);
-        for tool in &self.group {
-            let button = ToggleButton::builder()
-                .focusable(false)
-                .icon_name(&tool.icon_name)
-                .label(&tool.tooltip)
-                .tooltip_text(&tool.tooltip)
-                .build();
-            let popover = self.popover.clone();
-            button.connect_clicked(move |_| popover.popdown());
-            ActionablePlus::set_action::<ToolsAction>(&button, tool.tool);
-            rows.append(&button);
+        if self.has_extra() {
+            root.add_overlay(
+                &relm4::gtk::Image::builder()
+                    .icon_name("caret-down-right-filled")
+                    .pixel_size(8)
+                    .halign(Align::End)
+                    .valign(Align::End)
+                    .can_target(false)
+                    .build(),
+            );
+
+            let right_click_controller = relm4::gtk::GestureClick::builder().button(3).build();
+            right_click_controller.connect_pressed(move |gesture, _, _, _| {
+                gesture.set_state(relm4::gtk::EventSequenceState::Claimed);
+                sender.input(ToolGroupButtonInput::OpenPopover);
+            });
+            button.add_controller(right_click_controller);
+
+            let rows = relm4::gtk::Box::new(relm4::gtk::Orientation::Vertical, 2);
+            for tool in &self.group {
+                let button = ToggleButton::builder().focusable(false).build();
+                let inner_box = relm4::gtk::Box::new(relm4::gtk::Orientation::Horizontal, 2);
+                let icon = relm4::gtk::Image::from_icon_name(&tool.icon_name);
+                let label = relm4::gtk::Label::new(Some(&format!("{}", tool.tool)));
+                inner_box.append(&icon);
+                inner_box.append(&label);
+                button.set_child(Some(&inner_box));
+                if let Some(tooltip) = &tool.tooltip {
+                    button.set_tooltip(tooltip);
+                }
+                let popover = self.popover.clone();
+                button.connect_clicked(move |_| popover.popdown());
+                ActionablePlus::set_action::<ToolsAction>(&button, tool.tool);
+                rows.append(&button);
+            }
+            self.popover.set_child(Some(&rows));
+            self.popover.set_position(relm4::gtk::PositionType::Bottom);
+            self.popover.set_parent(&root);
         }
-        self.popover.set_child(Some(&rows));
-        self.popover.set_position(relm4::gtk::PositionType::Bottom);
-        self.popover.set_parent(&root);
 
         let widgets = ToolGroupWidgets { button };
         self.update_active_tool(&widgets);
@@ -174,7 +184,9 @@ impl FactoryComponent for ToolGroupButton {
     }
 
     fn update_view(&self, widgets: &mut Self::Widgets, _sender: FactorySender<Self>) {
-        self.update_active_tool(widgets);
+        if self.has_extra() {
+            self.update_active_tool(widgets);
+        }
         self.update_editing(widgets);
     }
 }

--- a/src/ui/tool_group_button.rs
+++ b/src/ui/tool_group_button.rs
@@ -1,0 +1,139 @@
+use crate::tools::{GroupableTool, Tools};
+use crate::ui::toolbars::ToolsAction;
+use relm4::actions::ActionablePlus;
+use relm4::factory::{DynamicIndex, FactoryComponent};
+use relm4::gtk::prelude::{ButtonExt, WidgetExt};
+use relm4::gtk::{Align, Popover, ToggleButton};
+use relm4::{FactorySender, RelmWidgetExt, gtk, view};
+
+pub struct ToolGroupInit {
+    pub group: Vec<GroupableTool>,
+    pub initial_tool: Tools,
+}
+
+pub struct ToolGroupWidgets {
+    button: ToggleButton,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolGroupButton {
+    group: Vec<GroupableTool>,
+    current: usize,
+    editing: bool,
+    is_active: bool,
+    popover: Popover,
+}
+
+#[derive(Debug, Clone)]
+pub enum ToolGroupButtonInput {
+    OpenPopover,
+    SelectedToolChanged(Tools),
+    SetEditing(bool),
+}
+
+impl ToolGroupButton {
+    pub fn update_active_tool(&self, widgets: &ToolGroupWidgets) {
+        if self.current < self.group.len()
+            && let g = &self.group[self.current]
+        {
+            widgets.button.set_icon_name(&g.icon_name);
+            widgets.button.set_tooltip(&g.tooltip);
+            ActionablePlus::set_action::<ToolsAction>(&widgets.button, g.tool);
+        }
+    }
+
+    pub fn update_editing(&self, widgets: &ToolGroupWidgets) {
+        if self.editing {
+            widgets.button.add_css_class("editing");
+        } else {
+            widgets.button.remove_css_class("editing");
+        }
+    }
+
+    pub fn has_extra(&self) -> bool {
+        self.group.len() > 1
+    }
+}
+
+impl FactoryComponent for ToolGroupButton {
+    type Init = ToolGroupInit;
+    type Input = ToolGroupButtonInput;
+    type Output = ();
+    type CommandOutput = ();
+    type Root = relm4::gtk::Overlay;
+    type Widgets = ToolGroupWidgets;
+    type ParentWidget = relm4::gtk::Box;
+    type Index = DynamicIndex;
+
+    fn init_model(init: Self::Init, _index: &DynamicIndex, _sender: FactorySender<Self>) -> Self {
+        let mut pos: usize = 0;
+        let mut is_active = false;
+
+        if let Some(p) = init.group.iter().position(|t| t.tool == init.initial_tool) {
+            pos = p;
+            is_active = true;
+        }
+
+        Self {
+            group: init.group,
+            current: pos,
+            editing: false,
+            is_active: is_active,
+            popover: relm4::gtk::Popover::new(),
+        }
+    }
+
+    fn init_root(&self) -> Self::Root {
+        gtk::Overlay::new()
+    }
+
+    fn init_widgets(
+        &mut self,
+        _index: &DynamicIndex,
+        root: Self::Root,
+        _returned_widget: &relm4::gtk::Widget,
+        _sender: FactorySender<Self>,
+    ) -> Self::Widgets {
+        view! {
+            #[local_ref]
+            root -> relm4::gtk::Overlay {
+                #[wrap(Some)]
+                set_child: button = &ToggleButton {
+                    set_focusable: false,
+                    set_valign: Align::End,
+                    set_halign: Align::Center,
+                }
+            },
+        }
+
+        let widgets = ToolGroupWidgets { button };
+        self.update_active_tool(&widgets);
+
+        widgets
+    }
+
+    fn update(&mut self, message: Self::Input, _sender: FactorySender<Self>) {
+        match message {
+            ToolGroupButtonInput::OpenPopover => {}
+            ToolGroupButtonInput::SelectedToolChanged(tools) => {
+                if let Some(i) = self.group.iter().position(|gt| gt.tool == tools) {
+                    self.is_active = true;
+                    self.current = i;
+                } else {
+                    self.is_active = false;
+                    self.editing = false;
+                }
+            }
+            ToolGroupButtonInput::SetEditing(editing) => {
+                if self.is_active {
+                    self.editing = editing;
+                }
+            }
+        }
+    }
+
+    fn update_view(&self, widgets: &mut Self::Widgets, _sender: FactorySender<Self>) {
+        self.update_active_tool(&widgets);
+        self.update_editing(&widgets);
+    }
+}

--- a/src/ui/tool_group_button.rs
+++ b/src/ui/tool_group_button.rs
@@ -2,7 +2,7 @@ use crate::tools::{GroupableTool, Tools};
 use crate::ui::toolbars::ToolsAction;
 use relm4::actions::ActionablePlus;
 use relm4::factory::{DynamicIndex, FactoryComponent};
-use relm4::gtk::prelude::{ButtonExt, WidgetExt};
+use relm4::gtk::prelude::{BoxExt, ButtonExt, GestureExt, GestureSingleExt, PopoverExt, WidgetExt};
 use relm4::gtk::{Align, Popover, ToggleButton};
 use relm4::{FactorySender, RelmWidgetExt, gtk, view};
 
@@ -37,7 +37,12 @@ impl ToolGroupButton {
             && let g = &self.group[self.current]
         {
             widgets.button.set_icon_name(&g.icon_name);
-            widgets.button.set_tooltip(&g.tooltip);
+            let tooltip = if self.has_extra() {
+                format!("{}\n\n{}", g.tooltip, "right-click for more tools")
+            } else {
+                g.tooltip.clone()
+            };
+            widgets.button.set_tooltip(&tooltip);
             ActionablePlus::set_action::<ToolsAction>(&widgets.button, g.tool);
         }
     }
@@ -78,7 +83,7 @@ impl FactoryComponent for ToolGroupButton {
             group: init.group,
             current: pos,
             editing: false,
-            is_active: is_active,
+            is_active,
             popover: relm4::gtk::Popover::new(),
         }
     }
@@ -92,7 +97,7 @@ impl FactoryComponent for ToolGroupButton {
         _index: &DynamicIndex,
         root: Self::Root,
         _returned_widget: &relm4::gtk::Widget,
-        _sender: FactorySender<Self>,
+        sender: FactorySender<Self>,
     ) -> Self::Widgets {
         view! {
             #[local_ref]
@@ -102,9 +107,41 @@ impl FactoryComponent for ToolGroupButton {
                     set_focusable: false,
                     set_valign: Align::End,
                     set_halign: Align::Center,
+                    add_controller = gtk::GestureClick {
+                        set_button: 3,
+                        connect_pressed[sender] => move |gesture, _, _, _| {
+                            gesture.set_state(relm4::gtk::EventSequenceState::Claimed);
+                            sender.input(ToolGroupButtonInput::OpenPopover);
+                        }
+                    }
+                },
+                add_overlay = &relm4::gtk::Image {
+                    set_icon_name: Some("caret-down-right-filled"),
+                    set_pixel_size: 8,
+                    set_halign: Align::End,
+                    set_valign: Align::End,
+                    set_can_target: false,
+                    set_visible: self.has_extra(),
                 }
             },
         }
+
+        let rows = gtk::Box::new(gtk::Orientation::Vertical, 2);
+        for tool in &self.group {
+            let button = ToggleButton::builder()
+                .focusable(false)
+                .icon_name(&tool.icon_name)
+                .label(&tool.tooltip)
+                .tooltip_text(&tool.tooltip)
+                .build();
+            let popover = self.popover.clone();
+            button.connect_clicked(move |_| popover.popdown());
+            ActionablePlus::set_action::<ToolsAction>(&button, tool.tool);
+            rows.append(&button);
+        }
+        self.popover.set_child(Some(&rows));
+        self.popover.set_position(relm4::gtk::PositionType::Bottom);
+        self.popover.set_parent(&root);
 
         let widgets = ToolGroupWidgets { button };
         self.update_active_tool(&widgets);
@@ -114,7 +151,11 @@ impl FactoryComponent for ToolGroupButton {
 
     fn update(&mut self, message: Self::Input, _sender: FactorySender<Self>) {
         match message {
-            ToolGroupButtonInput::OpenPopover => {}
+            ToolGroupButtonInput::OpenPopover => {
+                if self.has_extra() {
+                    self.popover.popup();
+                }
+            }
             ToolGroupButtonInput::SelectedToolChanged(tools) => {
                 if let Some(i) = self.group.iter().position(|gt| gt.tool == tools) {
                     self.is_active = true;
@@ -133,7 +174,7 @@ impl FactoryComponent for ToolGroupButton {
     }
 
     fn update_view(&self, widgets: &mut Self::Widgets, _sender: FactorySender<Self>) {
-        self.update_active_tool(&widgets);
-        self.update_editing(&widgets);
+        self.update_active_tool(widgets);
+        self.update_editing(widgets);
     }
 }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use crate::{
     configuration::{APP_CONFIG, Action},
@@ -7,7 +7,8 @@ use crate::{
     tools::Tools,
 };
 
-use gtk::ToggleButton;
+use crate::tools::GroupableTool;
+use crate::ui::tool_group_button::{ToolGroupButton, ToolGroupButtonInput, ToolGroupInit};
 use relm4::gtk::{
     gdk::Key,
     gdk_pixbuf::{
@@ -24,8 +25,7 @@ use relm4::{
 
 pub struct ToolsToolbar {
     visible: bool,
-    active_button: Option<ToggleButton>,
-    tool_buttons: HashMap<Tools, ToggleButton>,
+    tool_buttons: FactoryVecDeque<ToolGroupButton>,
     tool_action: SimpleAction,
 }
 
@@ -98,17 +98,21 @@ fn create_icon(color: Color) -> gtk::Image {
     gtk::Image::from_pixbuf(Some(&create_icon_pixbuf(color)))
 }
 
+fn get_hint(shortcut_registry: &ShortcutRegistry, command: ShortcutCommand) -> String {
+    let command_name = command.to_string();
+    let shortcut_hint = shortcut_registry.get_binding_for_command(command);
+    match shortcut_hint {
+        Some(hint) => format!("{command_name} ({hint})"),
+        None => command_name,
+    }
+}
+
 fn update_hint(
     shortcut_registry: &ShortcutRegistry,
     widget: &impl IsA<gtk::Widget>,
     command: ShortcutCommand,
 ) {
-    let command_name = command.to_string();
-    let shortcut_hint = shortcut_registry.get_binding_for_command(command);
-    let new_hint = match shortcut_hint {
-        Some(hint) => format!("{command_name} ({hint})"),
-        None => command_name,
-    };
+    let new_hint = get_hint(shortcut_registry, command);
     widget.set_tooltip_text(Some(&new_hint));
 }
 
@@ -167,82 +171,10 @@ impl SimpleComponent for ToolsToolbar {
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::Redo);},
             },
             gtk::Separator {},
-            #[name(pointer_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "cursor-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Pointer,
-            },
-            #[name(crop_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "crop-filled",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Crop,
-            },
-            #[name(brush_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "pen-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Brush,
-            },
-            #[name(line_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "minus-large",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Line,
-            },
-            #[name(arrow_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "arrow-up-right-filled",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Arrow,
-            },
-            #[name(rectangle_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "checkbox-unchecked-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Rectangle,
-            },
-            #[name(ellipse_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "circle-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Ellipse,
-            },
-            #[name(text_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "text-case-title-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Text,
-            },
-            #[name(marker_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "number-circle-1-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Marker,
-            },
-            #[name(blur_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "drop-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Blur,
-            },
-            #[name(highlight_button)]
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-                set_icon_name: "highlight-regular",
-                ActionablePlus::set_action::<ToolsAction>: Tools::Highlight,
+            #[local_ref]
+            tools_box -> gtk::Box {
+                set_orientation: gtk::Orientation::Horizontal,
+                set_spacing: 2,
             },
             gtk::Separator {},
             #[name(copy_to_clipboard_button)]
@@ -279,22 +211,12 @@ impl SimpleComponent for ToolsToolbar {
             ToolsToolbarInput::SwitchSelectedTool(tool) => {
                 // Change state of action, let GTK update the UI
                 self.tool_action.change_state(&tool.to_variant());
-
-                if let Some(button) = self.active_button.as_ref() {
-                    button.remove_css_class("editing");
-                }
-                if let Some(selected_tool_button) = self.tool_buttons.get(&tool) {
-                    self.active_button = Some(selected_tool_button.clone());
-                }
+                self.tool_buttons
+                    .broadcast(ToolGroupButtonInput::SelectedToolChanged(tool));
             }
             ToolsToolbarInput::SetToolEditing(editing) => {
-                if let Some(button) = self.active_button.as_ref() {
-                    if editing {
-                        button.add_css_class("editing");
-                    } else {
-                        button.remove_css_class("editing");
-                    }
-                }
+                self.tool_buttons
+                    .broadcast(ToolGroupButtonInput::SetEditing(editing));
             }
         }
     }
@@ -320,38 +242,102 @@ impl SimpleComponent for ToolsToolbar {
             },
         );
 
-        let mut model = ToolsToolbar {
-            visible: !APP_CONFIG.read().default_hide_toolbars(),
-            active_button: None,
-            tool_buttons: HashMap::new(),
-            tool_action: tool_action.clone().into(),
-        };
-        let widgets = view_output!();
-
-        model.tool_buttons = HashMap::from([
-            (Tools::Pointer, widgets.pointer_button.clone()),
-            (Tools::Crop, widgets.crop_button.clone()),
-            (Tools::Brush, widgets.brush_button.clone()),
-            (Tools::Line, widgets.line_button.clone()),
-            (Tools::Arrow, widgets.arrow_button.clone()),
-            (Tools::Rectangle, widgets.rectangle_button.clone()),
-            (Tools::Ellipse, widgets.ellipse_button.clone()),
-            (Tools::Text, widgets.text_button.clone()),
-            (Tools::Marker, widgets.marker_button.clone()),
-            (Tools::Blur, widgets.blur_button.clone()),
-            (Tools::Highlight, widgets.highlight_button.clone()),
-        ]);
-
         let shortcut_registry = ShortcutRegistry::from_config();
 
-        // Update tooltips based on configured keybinds
-        for (tool, button) in &model.tool_buttons {
-            update_hint(
-                &shortcut_registry,
-                button,
-                ShortcutCommand::SelectTool(*tool),
-            );
+        let tools = [
+            vec![GroupableTool {
+                tool: Tools::Pointer,
+                icon_name: "cursor-regular".into(),
+                tooltip: get_hint(
+                    &shortcut_registry,
+                    ShortcutCommand::SelectTool(Tools::Pointer),
+                ),
+            }],
+            vec![
+                GroupableTool {
+                    tool: Tools::Line,
+                    icon_name: "minus-large".into(),
+                    tooltip: get_hint(&shortcut_registry, ShortcutCommand::SelectTool(Tools::Line)),
+                },
+                GroupableTool {
+                    tool: Tools::Arrow,
+                    icon_name: "arrow-up-right-filled".into(),
+                    tooltip: get_hint(
+                        &shortcut_registry,
+                        ShortcutCommand::SelectTool(Tools::Arrow),
+                    ),
+                },
+            ],
+            vec![
+                GroupableTool {
+                    tool: Tools::Rectangle,
+                    icon_name: "checkbox-unchecked-regular".into(),
+                    tooltip: get_hint(
+                        &shortcut_registry,
+                        ShortcutCommand::SelectTool(Tools::Rectangle),
+                    ),
+                },
+                GroupableTool {
+                    tool: Tools::Ellipse,
+                    icon_name: "circle-regular".into(),
+                    tooltip: get_hint(
+                        &shortcut_registry,
+                        ShortcutCommand::SelectTool(Tools::Ellipse),
+                    ),
+                },
+            ],
+            vec![GroupableTool {
+                tool: Tools::Text,
+                icon_name: "text-case-title-regular".into(),
+                tooltip: get_hint(&shortcut_registry, ShortcutCommand::SelectTool(Tools::Text)),
+            }],
+            vec![GroupableTool {
+                tool: Tools::Marker,
+                icon_name: "number-circle-1-regular".into(),
+                tooltip: get_hint(
+                    &shortcut_registry,
+                    ShortcutCommand::SelectTool(Tools::Marker),
+                ),
+            }],
+            vec![GroupableTool {
+                tool: Tools::Blur,
+                icon_name: "drop-regular".into(),
+                tooltip: get_hint(&shortcut_registry, ShortcutCommand::SelectTool(Tools::Blur)),
+            }],
+            vec![GroupableTool {
+                tool: Tools::Highlight,
+                icon_name: "highlight-regular".into(),
+                tooltip: get_hint(
+                    &shortcut_registry,
+                    ShortcutCommand::SelectTool(Tools::Highlight),
+                ),
+            }],
+        ];
+
+        // Set initial active button correctly
+        let initial_tool = APP_CONFIG.read().initial_tool();
+        let mut tool_buttons = FactoryVecDeque::<ToolGroupButton>::builder()
+            .launch(relm4::gtk::Box::default())
+            .detach();
+
+        let mut guard = tool_buttons.guard();
+        for tg in tools {
+            let init = ToolGroupInit {
+                group: tg,
+                initial_tool: initial_tool,
+            };
+            guard.push_back(init);
         }
+        drop(guard);
+
+        let model = ToolsToolbar {
+            visible: !APP_CONFIG.read().default_hide_toolbars(),
+            tool_buttons,
+            tool_action: tool_action.clone().into(),
+        };
+
+        let tools_box = model.tool_buttons.widget();
+        let widgets = view_output!();
 
         type SC = ShortcutCommand;
         let other_commands = vec![
@@ -371,12 +357,6 @@ impl SimpleComponent for ToolsToolbar {
 
         for (command, button) in other_commands {
             update_hint(&shortcut_registry, button, command);
-        }
-
-        // Set initial active button correctly
-        let initial_tool = APP_CONFIG.read().initial_tool();
-        if let Some(button) = model.tool_buttons.get(&initial_tool) {
-            model.active_button = Some(button.clone());
         }
 
         let mut group = RelmActionGroup::<ToolsToolbarActionGroup>::new();
@@ -832,8 +812,8 @@ impl Component for StyleToolbar {
         ComponentParts { model, widgets }
     }
 }
-relm4::new_action_group!(ToolsToolbarActionGroup, "tools-toolbars");
-relm4::new_stateful_action!(ToolsAction, ToolsToolbarActionGroup, "tools", Tools, Tools);
+relm4::new_action_group!(pub ToolsToolbarActionGroup, "tools-toolbars");
+relm4::new_stateful_action!(pub ToolsAction, ToolsToolbarActionGroup, "tools", Tools, Tools);
 
 relm4::new_action_group!(StyleToolbarActionGroup, "style-toolbars");
 relm4::new_stateful_action!(

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -250,6 +250,16 @@ impl SimpleComponent for ToolsToolbar {
                 icon_name: "cursor-regular".into(),
                 tooltip: None,
             }],
+            vec![GroupableTool {
+                tool: Tools::Crop,
+                icon_name: "crop-filled".into(),
+                tooltip: None,
+            }],
+            vec![GroupableTool {
+                tool: Tools::Brush,
+                icon_name: "pen-regular".into(),
+                tooltip: None,
+            }],
             vec![
                 GroupableTool {
                     tool: Tools::Line,

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -324,7 +324,7 @@ impl SimpleComponent for ToolsToolbar {
         for tg in tools {
             let init = ToolGroupInit {
                 group: tg,
-                initial_tool: initial_tool,
+                initial_tool,
             };
             guard.push_back(init);
         }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -248,69 +248,51 @@ impl SimpleComponent for ToolsToolbar {
             vec![GroupableTool {
                 tool: Tools::Pointer,
                 icon_name: "cursor-regular".into(),
-                tooltip: get_hint(
-                    &shortcut_registry,
-                    ShortcutCommand::SelectTool(Tools::Pointer),
-                ),
+                tooltip: None,
             }],
             vec![
                 GroupableTool {
                     tool: Tools::Line,
                     icon_name: "minus-large".into(),
-                    tooltip: get_hint(&shortcut_registry, ShortcutCommand::SelectTool(Tools::Line)),
+                    tooltip: None,
                 },
                 GroupableTool {
                     tool: Tools::Arrow,
                     icon_name: "arrow-up-right-filled".into(),
-                    tooltip: get_hint(
-                        &shortcut_registry,
-                        ShortcutCommand::SelectTool(Tools::Arrow),
-                    ),
+                    tooltip: None,
                 },
             ],
             vec![
                 GroupableTool {
                     tool: Tools::Rectangle,
                     icon_name: "checkbox-unchecked-regular".into(),
-                    tooltip: get_hint(
-                        &shortcut_registry,
-                        ShortcutCommand::SelectTool(Tools::Rectangle),
-                    ),
+                    tooltip: None,
                 },
                 GroupableTool {
                     tool: Tools::Ellipse,
                     icon_name: "circle-regular".into(),
-                    tooltip: get_hint(
-                        &shortcut_registry,
-                        ShortcutCommand::SelectTool(Tools::Ellipse),
-                    ),
+                    tooltip: None,
                 },
             ],
             vec![GroupableTool {
                 tool: Tools::Text,
                 icon_name: "text-case-title-regular".into(),
-                tooltip: get_hint(&shortcut_registry, ShortcutCommand::SelectTool(Tools::Text)),
+                tooltip: None,
             }],
             vec![GroupableTool {
                 tool: Tools::Marker,
                 icon_name: "number-circle-1-regular".into(),
-                tooltip: get_hint(
-                    &shortcut_registry,
-                    ShortcutCommand::SelectTool(Tools::Marker),
-                ),
+                tooltip: None,
             }],
             vec![GroupableTool {
                 tool: Tools::Blur,
                 icon_name: "drop-regular".into(),
-                tooltip: get_hint(&shortcut_registry, ShortcutCommand::SelectTool(Tools::Blur)),
+                tooltip: None,
             }],
             vec![GroupableTool {
                 tool: Tools::Highlight,
                 icon_name: "highlight-regular".into(),
-                tooltip: get_hint(
-                    &shortcut_registry,
-                    ShortcutCommand::SelectTool(Tools::Highlight),
-                ),
+                tooltip: None,
             }],
         ];
 
@@ -321,7 +303,13 @@ impl SimpleComponent for ToolsToolbar {
             .detach();
 
         let mut guard = tool_buttons.guard();
-        for tg in tools {
+        for mut tg in tools {
+            for g in &mut tg {
+                g.tooltip = Some(get_hint(
+                    &shortcut_registry,
+                    ShortcutCommand::SelectTool(g.tool),
+                ));
+            }
             let init = ToolGroupInit {
                 group: tg,
                 initial_tool,


### PR DESCRIPTION
Closes: #538
prereq for #469

This allows grouping tools under one button. e.g. arrow and line, rectangle and circle. Right-click opens popover.

Used FactoryComponent along with FactoryVecDeque because that simplified reference storage on the toolbar. Controllers can't be cloned, that made a regular component quite tricky here, i've tried for quite a while to use a regular Component, this would likely have required more explicit lifetimes.

The downside of this is, ungrouped tools also have to use the new component. I can't exclude for 100% that a mixed use was possible, but the code would have been messier that way.

- [x] Would like to figure out to show both icon and label on the popover menuitems, but too tired now
- [x] Perhaps the new component can still be optimised a tad for the single tool case

I'm not implementing any variants here, that can be done later and needs new issues per variant. There will be some with pixelate, though.

Video slightly outdated, the popver buttons now show both icon and label.

https://github.com/user-attachments/assets/8ed3e6fd-50f6-41f1-ba7a-7b818fda4671

