### PR TITLE
fix: keep text outline stable under zoom

### DIFF
--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use femtovg::{Color, FontId, Paint, Path};
+use femtovg::{Color, FontId, LineJoin, Paint, Path};
 use relm4::gtk::glib::GString;
 use relm4::gtk::prelude::IMContextExt;
 use relm4::gtk::{
@@ -386,10 +386,18 @@ impl Drawable for Text {
         // When outlining, stroke each line with the outline color first, then fill on
         // top so the visible border wraps the glyphs. The stroke is widened because it
         // is centered on the glyph outline and half of it is hidden by the fill.
+        // Round the joins: when the canvas is scaled (zoom), femtovg strokes the real
+        // glyph contour, and the default miter join spikes ("explodes") at the sharp
+        // corners of glyphs. It also scales the stroke width by its internal font_scale
+        // (a quantized canvas average scale) on top of the transform, so a plain width
+        // would grow with zoom relative to the glyphs and mismatch the export; divide it
+        // back out. Mirrors femtovg's font_scale = quantize(avg_scale, 0.1).min(7.0).
+        let font_scale = ((canva_scale / 0.1 + 0.5).trunc() * 0.1).clamp(0.1, 7.0);
         let outline_paint = self.outline.outline_color(self.style.color).map(|color| {
             let mut paint = base_paint.clone();
             paint.set_color(color.into());
-            paint.set_line_width(base_paint.line_width() * 2.0);
+            paint.set_line_width(base_paint.line_width() * 2.0 / font_scale);
+            paint.set_line_join(LineJoin::Round);
             paint
         });
 


### PR DESCRIPTION
Fixes #596.

The Alt text outline stroked each glyph with a miter-joined stroke. When the canvas is scaled (zoom), femtovg renders text through direct path-stroking of the real glyph contour instead of the glyph atlas, and two issues surfaced there:

- the default **miter** join spikes at the sharp corners of glyph outlines, so the outline visually "explodes" the further you zoom in — this is the reported bug;
- femtovg additionally scales the stroke width by its internal `font_scale` (a quantized canvas average scale) *on top of* the transform, so the outline grew disproportionately with zoom and no longer matched the exported image.

Neither is visible in the export because that path uses only a translation (no scale) and goes through the glyph atlas, where the stroke width is taken raw.

**Fix:** stroke the outline with round joins and divide the width back out by that same `font_scale` (mirroring `quantize(avg_scale, 0.1).min(7.0)`). The border stays smooth and keeps a constant thickness relative to the glyphs at every zoom level, matching the export.

Verified by hand: large text, strong zoom, both `Inverted` and `Contrast` outline modes — outline stays smooth and its thickness is stable across zoom and matches the saved PNG.