### PR TITLE
fix: clip crop size to the part inside the image

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -23,7 +23,7 @@ use resource::resource;
 use crate::{
     APP_CONFIG,
     configuration::Action,
-    math::{Vec2D, rect_ensure_in_bounds, rect_round},
+    math::{Vec2D, crop_rect_in_bounds},
     sketch_board::SketchBoardInput,
     tools::{Drawable, RenderingMode, Tool, Tools},
 };
@@ -520,10 +520,8 @@ impl FemtoVgAreaMut {
             .iter()
             .find(|d| d.get_rendering_mode() == RenderingMode::Crop)
             .and_then(|d| {
-                d.bounds().map(|(tl, br)| {
-                    let rect = (tl, br - tl);
-                    rect_ensure_in_bounds(rect_round(rect), bounds)
-                })
+                d.bounds()
+                    .map(|(tl, br)| crop_rect_in_bounds((tl, br - tl), bounds))
             })
             .unwrap_or(bounds);
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -268,14 +268,16 @@ pub fn rect_ensure_positive_size(pos: Vec2D, size: Vec2D) -> (Vec2D, Vec2D) {
 pub fn rect_ensure_in_bounds(rect: (Vec2D, Vec2D), bounds: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
     let (mut pos, mut size) = rect;
 
+    // The part sticking out has to be measured before pos is moved onto the
+    // bound, otherwise the difference is always zero and size stays untouched.
     if pos.x < bounds.0.x {
+        size.x = (size.x - (bounds.0.x - pos.x)).max(0.0);
         pos.x = bounds.0.x;
-        size.x -= bounds.0.x - pos.x;
     }
 
     if pos.y < bounds.0.y {
+        size.y = (size.y - (bounds.0.y - pos.y)).max(0.0);
         pos.y = bounds.0.y;
-        size.y -= bounds.0.y - pos.y;
     }
 
     if pos.x + size.x > bounds.1.x {
@@ -297,4 +299,51 @@ pub fn ensure_bounding_box(a: Vec2D, b: Vec2D) -> (Vec2D, Vec2D) {
 pub fn rect_round(rect: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
     let (pos, size) = rect;
     (pos.round(), size.round())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Vec2D, rect_ensure_in_bounds};
+
+    fn bounds() -> (Vec2D, Vec2D) {
+        (Vec2D::zero(), Vec2D::new(200.0, 100.0))
+    }
+
+    #[test]
+    fn rect_ensure_in_bounds_clips_both_axes_when_overlapping_top_left() {
+        let rect = (Vec2D::new(-40.0, -30.0), Vec2D::new(100.0, 80.0));
+        assert_eq!(
+            rect_ensure_in_bounds(rect, bounds()),
+            (Vec2D::zero(), Vec2D::new(60.0, 50.0))
+        );
+    }
+
+    #[test]
+    fn rect_ensure_in_bounds_removes_width_when_rect_is_left_of_bounds() {
+        let rect = (Vec2D::new(-300.0, 10.0), Vec2D::new(100.0, 20.0));
+        let (_, size) = rect_ensure_in_bounds(rect, bounds());
+        assert_eq!(size.x, 0.0);
+    }
+
+    #[test]
+    fn rect_ensure_in_bounds_removes_height_when_rect_is_above_bounds() {
+        let rect = (Vec2D::new(10.0, -300.0), Vec2D::new(20.0, 100.0));
+        let (_, size) = rect_ensure_in_bounds(rect, bounds());
+        assert_eq!(size.y, 0.0);
+    }
+
+    #[test]
+    fn rect_ensure_in_bounds_clips_rect_straddling_all_four_edges() {
+        let rect = (Vec2D::new(-50.0, -50.0), Vec2D::new(400.0, 300.0));
+        assert_eq!(
+            rect_ensure_in_bounds(rect, bounds()),
+            (Vec2D::zero(), Vec2D::new(200.0, 100.0))
+        );
+    }
+
+    #[test]
+    fn rect_ensure_in_bounds_leaves_rect_inside_bounds_unchanged() {
+        let rect = (Vec2D::new(10.0, 20.0), Vec2D::new(30.0, 40.0));
+        assert_eq!(rect_ensure_in_bounds(rect, bounds()), rect);
+    }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -296,6 +296,13 @@ pub fn ensure_bounding_box(a: Vec2D, b: Vec2D) -> (Vec2D, Vec2D) {
     (a.min(b), a.max(b))
 }
 
+// The part of a crop rectangle that is actually inside the image: what a save
+// writes out, and therefore what the dimension readout has to be derived from.
+pub fn crop_rect_in_bounds(rect: (Vec2D, Vec2D), bounds: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
+    let (pos, size) = rect_ensure_in_bounds(rect_round(rect), bounds);
+    (pos, size.max(Vec2D::zero()))
+}
+
 pub fn rect_round(rect: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
     let (pos, size) = rect;
     (pos.round(), size.round())
@@ -303,7 +310,7 @@ pub fn rect_round(rect: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
 
 #[cfg(test)]
 mod tests {
-    use super::{Vec2D, rect_ensure_in_bounds};
+    use super::{Vec2D, crop_rect_in_bounds, rect_ensure_in_bounds};
 
     fn bounds() -> (Vec2D, Vec2D) {
         (Vec2D::zero(), Vec2D::new(200.0, 100.0))
@@ -345,5 +352,39 @@ mod tests {
     fn rect_ensure_in_bounds_leaves_rect_inside_bounds_unchanged() {
         let rect = (Vec2D::new(10.0, 20.0), Vec2D::new(30.0, 40.0));
         assert_eq!(rect_ensure_in_bounds(rect, bounds()), rect);
+    }
+
+    #[test]
+    fn crop_rect_in_bounds_reports_the_part_inside_the_image() {
+        let rect = (Vec2D::new(150.0, 10.0), Vec2D::new(100.0, 20.0));
+        assert_eq!(
+            crop_rect_in_bounds(rect, bounds()),
+            (Vec2D::new(150.0, 10.0), Vec2D::new(50.0, 20.0))
+        );
+    }
+
+    #[test]
+    fn crop_rect_in_bounds_rounds_before_clipping_like_the_render_target_does() {
+        // Clipping first would leave 9.5 and read as 10, but the render target
+        // is built from the rounded rect and comes out 9 wide.
+        let rect = (Vec2D::new(190.5, 10.0), Vec2D::new(9.9, 20.0));
+        assert_eq!(
+            crop_rect_in_bounds(rect, bounds()),
+            (Vec2D::new(191.0, 10.0), Vec2D::new(9.0, 20.0))
+        );
+    }
+
+    #[test]
+    fn crop_rect_in_bounds_reports_zero_for_a_crop_dragged_past_the_right_edge() {
+        let rect = (Vec2D::new(250.0, 10.0), Vec2D::new(100.0, 20.0));
+        let (_, size) = crop_rect_in_bounds(rect, bounds());
+        assert_eq!(size.x, 0.0);
+    }
+
+    #[test]
+    fn crop_rect_in_bounds_reports_zero_for_a_crop_dragged_past_the_bottom_edge() {
+        let rect = (Vec2D::new(10.0, 150.0), Vec2D::new(20.0, 100.0));
+        let (_, size) = crop_rect_in_bounds(rect, bounds());
+        assert_eq!(size.y, 0.0);
     }
 }

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -21,7 +21,7 @@ use crate::configuration::{APP_CONFIG, Action};
 use crate::femtovg_area::FemtoVGArea;
 use crate::ime::pango_adapter::spans_from_pango_attrs;
 use crate::keybindings::{ActionTrigger, ShortcutCommand, ShortcutRegistry};
-use crate::math::Vec2D;
+use crate::math::{Vec2D, crop_rect_in_bounds};
 use crate::notification::{log_result, log_result_with_pixbuf};
 use crate::style::{Color, Size, Style};
 use crate::tools::{PointerTool, TextTool, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
@@ -48,6 +48,7 @@ pub enum SketchBoardInput {
     Refresh,
     Exit,
     ScaleFactorChanged,
+    CropDimensionsUpdate((Vec2D, Vec2D)),
     Output(SketchBoardOutput),
 }
 
@@ -283,6 +284,9 @@ impl InputEvent {
 
 pub struct SketchBoard {
     renderer: FemtoVGArea,
+    // Mirrors the bounds render_native_resolution derives from the background
+    // image, which is set once at init and never replaced.
+    image_bounds: (Vec2D, Vec2D),
     ime_enabled: Rc<Cell<bool>>,
     shortcut_registry: ShortcutRegistry,
     active_tool: Rc<RefCell<dyn Tool>>,
@@ -1410,6 +1414,19 @@ impl SketchBoard {
         ToolUpdateResult::Redraw
     }
 
+    // Report what a save would produce, not the rectangle the user dragged:
+    // the same clip render_native_resolution applies before it sizes the
+    // render target, so the label and the file cannot disagree.
+    fn emit_crop_dimensions(&self, sender: &ComponentSender<Self>, rect: (Vec2D, Vec2D)) {
+        let (_, size) = crop_rect_in_bounds(rect, self.image_bounds);
+        sender
+            .output_sender()
+            .emit(SketchBoardOutput::DimensionsUpdate(Some((
+                size.x as i32,
+                size.y as i32,
+            ))));
+    }
+
     fn update_mouse_cursor(&self, pos: Vec2D) {
         if !self.renderer.hit_test(pos).is_empty() {
             let cursor = self.pointer_tool.borrow().get_cursor("grab");
@@ -1687,6 +1704,11 @@ impl Component for SketchBoard {
                 if let Some(index) = selected_index {
                     if let Some(mut drawable) = self.renderer.get_drawable_clone(index) {
                         drawable.translate(delta);
+                        if drawable.get_rendering_mode() == crate::tools::RenderingMode::Crop
+                            && let Some((tl, br)) = drawable.bounds()
+                        {
+                            self.emit_crop_dimensions(&sender, (tl, br - tl));
+                        }
                         self.renderer.replace_drawable(index, drawable);
                         self.update_pointer_tool_selection(index, false);
                         ToolUpdateResult::Redraw
@@ -1730,6 +1752,10 @@ impl Component for SketchBoard {
             SketchBoardInput::ScaleFactorChanged => {
                 self.renderer.resize(0, 0);
                 ToolUpdateResult::Redraw
+            }
+            SketchBoardInput::CropDimensionsUpdate(rect) => {
+                self.emit_crop_dimensions(&sender, rect);
+                ToolUpdateResult::Unmodified
             }
             SketchBoardInput::Output(output) => {
                 sender.output_sender().emit(output);
@@ -1812,6 +1838,11 @@ impl Component for SketchBoard {
         let config = APP_CONFIG.read();
         let tools = ToolsManager::new();
 
+        let image_bounds = (
+            Vec2D::zero(),
+            Vec2D::new(image.width() as f32, image.height() as f32),
+        );
+
         let im_context = gtk::IMMulticontext::new();
 
         let text_tool = tools.get_text_tool();
@@ -1825,6 +1856,7 @@ impl Component for SketchBoard {
 
         let mut model = Self {
             renderer: FemtoVGArea::default(),
+            image_bounds,
             ime_enabled: Rc::new(Cell::new(initial_ime_enabled)),
             shortcut_registry: ShortcutRegistry::from_config(),
             active_tool: tools.get(&config.initial_tool()),

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -1,9 +1,7 @@
 use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 use crate::{
     math::{self, Vec2D},
-    sketch_board::{
-        MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput, SketchBoardOutput,
-    },
+    sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
     tools::{RenderingMode, hit_test_rectangle},
 };
 use anyhow::Result;
@@ -32,10 +30,6 @@ impl Crop {
             size: Vec2D::zero(),
             active: true,
         }
-    }
-
-    pub fn get_rectangle(&self) -> (Vec2D, Vec2D) {
-        math::rect_ensure_positive_size(self.pos, self.size)
     }
 }
 
@@ -93,14 +87,11 @@ impl Drawable for Crop {
 
 impl CropTool {
     fn emit_crop_dimensions_update(&self) {
-        if let (Some(crop), Some(sender)) = (&self.crop, &self.sender) {
-            let (_pos, size) = crop.get_rectangle();
-            let width = size.x.round() as i32;
-            let height = size.y.round() as i32;
+        if let (Some(crop), Some(sender)) = (&self.crop, &self.sender)
+            && let Some((tl, br)) = crop.bounds()
+        {
             sender
-                .send(SketchBoardInput::Output(
-                    SketchBoardOutput::DimensionsUpdate(Some((width, height))),
-                ))
+                .send(SketchBoardInput::CropDimensionsUpdate((tl, br - tl)))
                 .ok();
         }
     }

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -9,10 +9,7 @@ use std::cell::Cell;
 use crate::{
     configuration::APP_CONFIG,
     math::{Vec2D, ensure_bounding_box},
-    sketch_board::{
-        KeyEventMsg, MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput,
-        SketchBoardOutput,
-    },
+    sketch_board::{KeyEventMsg, MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
     tools::RenderingMode,
 };
 
@@ -415,6 +412,20 @@ impl PointerTool {
         self.drag_start_pos.map_or(delta, |start| start + delta)
     }
 
+    // The crop readout has to track anything that moves or resizes the crop,
+    // since all of it changes what a save would produce. Sourced from the
+    // drawable's own bounds, which is the rect render_native_resolution clips.
+    fn emit_crop_dimensions_update(&self, crop: &dyn Drawable) {
+        if crop.get_rendering_mode() == RenderingMode::Crop
+            && let Some(sender) = &self.sender
+            && let Some((tl, br)) = crop.bounds()
+        {
+            sender
+                .send(SketchBoardInput::CropDimensionsUpdate((tl, br - tl)))
+                .ok();
+        }
+    }
+
     fn update_selection_bounds(&mut self, tl: Vec2D, br: Vec2D) {
         let (tl, br) = ensure_bounding_box(tl, br);
         self.selected_bounds = Some((tl, br));
@@ -583,6 +594,7 @@ impl Tool for PointerTool {
                     let delta = event.pos;
                     let mut preview = original.clone_box();
                     preview.translate(delta);
+                    self.emit_crop_dimensions_update(preview.as_ref());
                     let (tl, br) = *orig_bounds;
                     self.update_selection_bounds(tl + delta, br + delta);
                     self.preview = Some(preview);
@@ -597,19 +609,7 @@ impl Tool for PointerTool {
                     let (new_tl, new_br) = handle.resize(event, orig_bounds.0, orig_bounds.1);
                     let mut preview = original.clone_box();
                     preview.resize_bounds(new_tl, new_br);
-                    if preview.get_rendering_mode() == RenderingMode::Crop
-                        && let Some(sender) = &self.sender
-                    {
-                        let size = new_br - new_tl;
-                        sender
-                            .send(SketchBoardInput::Output(
-                                SketchBoardOutput::DimensionsUpdate(Some((
-                                    size.x.round() as i32,
-                                    size.y.round() as i32,
-                                ))),
-                            ))
-                            .ok();
-                    }
+                    self.emit_crop_dimensions_update(preview.as_ref());
 
                     self.update_selection_bounds(new_tl, new_br);
                     self.preview = Some(preview);


### PR DESCRIPTION
Fixes #337. Rebased onto `main` after #607.

### The clipping bug

`rect_ensure_in_bounds` moved the rectangle's top-left corner onto the bound and only afterwards tried to shrink the size by however much had been cut off:

```rust
if pos.x < bounds.0.x {
    pos.x = bounds.0.x;
    size.x -= bounds.0.x - pos.x;   // pos.x == bounds.0.x by now, so this is always -= 0
}
```

`pos.x` had already been reassigned, so the subtraction was unconditionally `-= 0.0`. The left/top branches only ever moved `pos` and never touched `size` at all, which is why review here is cheap: there is no old sizing behaviour to preserve, only dead code to replace. Hence the reported symptom, cropping from outside the image corrected the offset but kept the width/height the user had dragged, so the saved image did not match the visible crop rectangle. Same on the y axis.

The two statements are now swapped so the overhang is measured before `pos` is clamped, and the result is floored at `0.0` — a rectangle lying entirely outside the bound would otherwise come out negative (a 100px wide crop starting 300px left of the image gives -200).

### The dimension readout

Second commit, per your request: the label now reports what would be saved rather than the rectangle that was dragged.

Neither of the two places that fed it had access to the image size, so both now send the crop rect as `SketchBoardInput::CropDimensionsUpdate` and `SketchBoard` clips it before emitting `DimensionsUpdate`; it keeps the image bounds from the pixbuf it is initialised with.

The clip itself is a new `math::crop_rect_in_bounds`, which `render_native_resolution` now uses too. That is the point of naming it: the label and the file come out of the same function, so they cannot drift apart. The rounding order is part of that — `rect_round` then clip differs from clip then round at the edges. A crop at x=190.5 with width 9.9 on a 200-wide image saves 9 px; the readout says 9 now, and would have said 10 the other way round.

Both emit sites read the rect from the crop drawable's own `bounds()`, which is exactly what `render_native_resolution` clips, so there is no second derivation to keep in sync. That retires `Crop::get_rectangle`, whose only caller was the old readout.

`crop_rect_in_bounds` also floors the size at zero. Without that, a crop dragged fully past the right edge would read `-50`, since the lower clamps in `rect_ensure_in_bounds` still return negatives. The save already produces `0` there (`-100.0f32 as usize`), so the readout now agrees with it. I have left `rect_ensure_in_bounds` itself alone so `blur.rs`, its only other caller, is untouched — the symmetric one-liner is still on the table if you want it, but it did not need to ride along with this.

### Gestures the readout follows

Resizing a crop was not the only way to change what gets saved, so the emit is not only on the resize path:

- drawing the crop (`CropTool`, as before)
- resizing it by a handle (`PointerTool`, as before)
- **moving it** with the pointer tool — new here. Dragging a committed crop so it hangs off an edge changes the saved size, and on `main` the label did not move. That was harmless while the label meant "the crop rectangle"; it is not harmless now that it means "what will be saved".
- **nudging it** with the arrow keys (`NudgeSelection`) — same reasoning.

Undo/redo and dismissing a crop are *not* covered, and that is worth flagging: `DimensionsUpdate(None)` resolves to the full image dimensions in `main.rs`, but nothing in the tree sends `None` any more. `CropTool::handle_dismissed` used to, and it was removed in #607. So after undoing a crop the save reverts to the full image while the label keeps the crop's numbers. That is a pre-existing gap rather than something this PR introduces, and the affordance to fix it already exists, but I did not want to fold an unrelated regression into this diff. Happy to send it separately.

### What this means for a selection with no overlap

A crop dragged entirely off the left of the image now clips to a zero width instead of keeping its dragged width, so it reaches `create_image_empty(0, h)`.

That path is not new. On current `main`, a crop dragged entirely to the *right* never enters the top/left branches at all, hits `pos.x + size.x > bounds.1.x`, and comes out with `size.x = -100`; `-100.0f32 as usize` saturates to `0`, so the same call already happens today. This change adds the left/top route to it, a clean `0` rather than a wrong-but-positive width. It fails politely either way, `render_native_resolution`'s `Err` is handled with an `eprintln!` and a `Propagation::Stop`, not a panic.

Preventing the save outright is left to the separate PR you mentioned. What the readout change adds in the meantime is that the user can now see the `0` before they try.

### Second call site

`Blur::draw` uses `rect_ensure_in_bounds`, so a blur box dragged in from outside the image now clips instead of keeping its full width, and inherits the #337 fix for free. The committed path early-returns on a non-positive size; the editing preview does not guard, and draws a `rounded_rect` with a non-positive size. Flagging it since the issue only talks about crop.

### Tests

`src/math.rs` had no test module, so this adds one, following the pattern already in `sketch_board.rs`.

Five for `rect_ensure_in_bounds`: clipping on both axes at once, the two fully-outside cases, a rect straddling all four edges, and a fully-inside non-regression case. The first three fail on current `main`; the last two pass either way and are there to pin the function against a future refactor.

Four for `crop_rect_in_bounds`: the clip, the rounding order, and one per axis of the zero floor.

Note the lint workflow runs fmt, clippy and doc but not `cargo test`, so these are compiled and linted on CI but not executed.

### GenAI

Written with AI assistance, disclosed per CONTRIBUTING. I understand and vouch for it, it's a statement reorder, a lower bound, and a message hop to the one component that knows the image size.

I ran the tests against unpatched `main` to confirm they fail there, and checked each assertion earns its place by re-breaking the fix one piece at a time. For `rect_ensure_in_bounds`, dropping either `.max(0.0)` breaks exactly one test and reverting the y-axis reorder breaks two. For `crop_rect_in_bounds`, dropping `rect_round` breaks only the rounding test, dropping either half of the zero floor breaks only that axis's test, and dropping the clip breaks three. The per-axis floor tests exist because a first pass only covered x, and a mutant that clamped x but not y passed the whole suite.

One caveat worth stating plainly: I'm on macOS and can't build the GTK side of the crate. `src/math.rs` is pure std, so those tests really run. Everything outside it is `cargo fmt --check` clean against the repo, and clippy-clean only as isolated expressions in a scratch crate carrying the real signatures. CI's clippy job is the real check on the wiring, so it's worth letting it run before you read closely.

---
Used AI assistance on this; I reviewed and tested the change myself.
