### PR TITLE
fix: mask fontconfig named-instance bits from font.index

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -222,7 +222,16 @@ impl FemtoVGArea {
                 .find(family, style)
                 .map_err(|e| anyhow::anyhow!("Font family '{}' not found: {}", family, e))?;
 
-            let face_index = font.index.unwrap_or(0).max(0) as u32;
+            // font.index packs (instance_index << 16) | face_index; keep the face_index.
+            let raw_index = font.index.unwrap_or(0).max(0) as u32;
+            let face_index = raw_index & 0xffff;
+
+            if raw_index >> 16 != 0 {
+                eprintln!(
+                    "Font '{}': variable fonts are not fully supported, only the default variant will be used",
+                    font.name,
+                );
+            }
 
             if !loaded_paths.insert((font.path.clone(), face_index)) {
                 return Err(anyhow::anyhow!("Font '{}' already loaded", family));

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1188,8 +1188,11 @@ impl Component for SketchBoard {
                         relm4::gtk::glib::Propagation::Stop
                     },
 
-                    connect_key_released[sender] => move |controller, key, code, modifier | {
-                        if let Some(im_context) = controller.im_context() {
+                    connect_key_released[
+                        sender,
+                        im_context = model.im_context.clone(),
+                        ime_enabled = model.ime_enabled.clone()] => move |controller, key, code, modifier | {
+                        if ime_enabled.get() {
                             im_context.focus_in();
                             if !im_context.filter_keypress(controller.current_event().unwrap()) {
                                 sender.input(SketchBoardInput::new_key_release_event(KeyEventMsg::new(key, code, modifier)));


### PR DESCRIPTION
close #617 

---

During debugging, I found a regression introduced by 70cbbbb where key press and release use different `im_context`. I also fixed it in this change.

```rust
                    connect_key_pressed[
                        sender,
                        im_context = model.im_context.clone(),
                        ime_enabled = model.ime_enabled.clone()] => move |controller, key, code, modifier | {

// ---

                    connect_key_released[sender] => move |controller, key, code, modifier | {
                        if let Some(im_context) = controller.im_context() {

```