### PR TITLE
fix(build): replace epoxy-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,12 +93,6 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -141,7 +135,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -328,18 +322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
-name = "epoxy"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b96028ce3ff03972312fd8243281858e80fc0f9838b1f035676b6c199214d9e"
-dependencies = [
- "gl_generator",
- "libc",
- "pkg-config",
- "shared_library",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,7 +361,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31eebf3ab1b76359ccd5f850c07a7c6b2722c64d9127c40e02358e83f3ff9b1a"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytemuck",
  "fnv",
  "glow",
@@ -660,23 +642,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "gl_generator"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
-
-[[package]]
 name = "glib"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -974,7 +945,7 @@ checksum = "29541831d33940ea1c68a1b8980382c1a507c95a528a98c0e335b361b9726975"
 dependencies = [
  "arraydeque",
  "arrayvec",
- "bitflags 2.13.1",
+ "bitflags",
  "keycode_macro",
 ]
 
@@ -989,18 +960,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "khronos_api"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libadwaita"
@@ -1190,7 +1149,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1389,7 +1348,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1408,7 +1367,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytemuck",
  "core_maths",
  "log",
@@ -1440,7 +1399,6 @@ dependencies = [
  "clap_complete_fig",
  "clap_complete_nushell",
  "clap_mangen",
- "epoxy",
  "femtovg",
  "fontconfig",
  "glow",
@@ -1532,16 +1490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "shared_library"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-dependencies = [
- "lazy_static",
- "libc",
 ]
 
 [[package]]
@@ -1988,15 +1936,6 @@ name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
-
-[[package]]
-name = "xml-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "yeslogic-fontconfig-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ chrono = "0.4.44"
 femtovg = "0.27.0"
 image = { version = "0.25.0", default-features = false, features = ["png"] }  # png decoder for color emoji in femtovg
 libloading = "0.9"
-epoxy = "0.1.0"
 glow = "0.18.0"
 resource = "0.6.1"  # font emedding
 fontconfig = "0.11.0"  # font loading

--- a/src/epoxy.rs
+++ b/src/epoxy.rs
@@ -1,0 +1,50 @@
+use libloading::Library;
+use std::ffi::c_void;
+use std::sync::OnceLock;
+use std::{panic, ptr};
+
+static EPOXY: OnceLock<Library> = OnceLock::new();
+
+pub fn load_epoxy() -> &'static Library {
+    // TODO: rework with get_or_try_init once
+    // https://github.com/rust-lang/rust/issues/109737
+    // becomes stable
+    EPOXY.get_or_init(|| {
+        #[cfg(target_os = "macos")]
+        let filename = "libepoxy.0.dylib";
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let filename = "libepoxy.so.0";
+        #[cfg(windows)]
+        let filename = "libepoxy-0.dll";
+
+        let library = unsafe { Library::new(filename) };
+
+        #[cfg(windows)]
+        let library = library.or_else(|_| unsafe { Library::new("epoxy-0.dll") });
+
+        // if this fails, we can't start anyway so ok for now.
+        library.unwrap()
+    })
+}
+
+pub fn get_proc_addr(name: &str) -> *const c_void {
+    let library = match panic::catch_unwind(load_epoxy) {
+        Ok(library) => library,
+        Err(_) => {
+            eprintln!("failed to load epoxy");
+            return ptr::null();
+        }
+    };
+
+    let symbol = format!("epoxy_{name}");
+
+    unsafe {
+        library
+            .get::<*const c_void>(&symbol)
+            .map(|sym| {
+                let entry = sym.try_as_raw_ptr().unwrap() as *const *const c_void;
+                *entry
+            })
+            .unwrap_or(ptr::null())
+    }
+}

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -23,8 +23,8 @@ use resource::resource;
 use crate::{
     APP_CONFIG,
     configuration::Action,
-    math::{Vec2D, crop_rect_in_bounds},
     epoxy,
+    math::{Vec2D, crop_rect_in_bounds},
     sketch_board::SketchBoardInput,
     tools::{Drawable, RenderingMode, Tool, Tools},
 };

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -24,6 +24,7 @@ use crate::{
     APP_CONFIG,
     configuration::Action,
     math::{Vec2D, crop_rect_in_bounds},
+    epoxy,
     sketch_board::SketchBoardInput,
     tools::{Drawable, RenderingMode, Tool, Tools},
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 use std::ops::Deref;
 use std::process::exit;
 use std::sync::{LazyLock, RwLock};
-use std::{fs, ptr};
+use std::{fs, panic};
 use std::{io, time::Duration};
 
 use relm4::gtk::gdk::Rectangle;
@@ -25,6 +25,7 @@ use ui::toolbars::{StyleToolbar, StyleToolbarInput, ToolsToolbar, ToolsToolbarIn
 use xdg::BaseDirectories;
 
 mod configuration;
+mod epoxy;
 mod femtovg_area;
 mod icons;
 mod ime;
@@ -514,28 +515,16 @@ fn read_css_overrides() -> Option<String> {
     }
 }
 
-fn load_gl() -> Result<()> {
-    // Load GL pointers from epoxy (GL context management library used by GTK).
-    #[cfg(target_os = "macos")]
-    let library = unsafe { libloading::os::unix::Library::new("libepoxy.0.dylib") }?;
-    #[cfg(all(unix, not(target_os = "macos")))]
-    let library = unsafe { libloading::os::unix::Library::new("libepoxy.so.0") }?;
-    #[cfg(windows)]
-    let library = libloading::os::windows::Library::open_already_loaded("libepoxy-0.dll")
-        .or_else(|_| libloading::os::windows::Library::open_already_loaded("epoxy-0.dll"))?;
-
-    epoxy::load_with(|name| {
-        unsafe { library.get::<_>(name.as_bytes()) }
-            .map(|symbol| *symbol)
-            .unwrap_or(ptr::null())
-    });
-
-    Ok(())
-}
-
 fn run_satty() -> Result<()> {
     // load OpenGL
-    load_gl()?;
+    if panic::catch_unwind(|| {
+        epoxy::load_epoxy();
+    })
+    .is_err()
+    {
+        return Err(anyhow::anyhow!("failed to load epoxy"));
+    }
+
     generate_profile_output!("loaded gl");
 
     // load app config


### PR DESCRIPTION
Closes: #615

epoxy-rs is 8 years old. One of its transient dependencies (xml-rs) was pulled recently, making it impossible to build Satty via cargo install.

A fix is available upstream at https://github.com/mjkoo/epoxy-rs/pull/10, but we don't know if it'll get merged. We could have created a vendor fork from the above epoxy-rs PR, however we're really only using `get_proc_addr`, which provides symbol names for libepoxy.

The code is very similar between epoxy-rs and gtk4-rs examples. Moreover, the relevant gtk4-rs example was also replaced with direct use of libepoxy, see https://github.com/gtk-rs/gtk4-rs/commit/bf5186fe730407db387fa09482a6f2c86981abe8

This PR adopts some of the example code into Satty and removes the need to use epoxy-rs.

The code could be a bit nicer if we used `OnceLock::get_or_try_init`, however that is a nightly feature. -> #626