### PR TITLE
Fix editing of crop and text

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -652,7 +652,10 @@ impl FemtoVgAreaMut {
         }
 
         // draw active tool when not already drawn in stack order
-        if draw_active_tool && let Some(preview) = self.active_tool.borrow().get_drawable() {
+        if draw_active_tool
+            && self.active_tool.borrow().get_tool_type() != Tools::Crop
+            && let Some(preview) = self.active_tool.borrow().get_drawable()
+        {
             preview.draw(canvas, font, bounds)?;
         }
 

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -390,6 +390,14 @@ impl FemtoVgAreaMut {
         self.drawables.get(index).map(|d| d.clone_box())
     }
 
+    pub fn find_drawable_index_by_mode(&self, mode: RenderingMode) -> Option<usize> {
+        self.drawables
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(index, drawable)| (drawable.get_rendering_mode() == mode).then_some(index))
+    }
+
     pub fn replace_drawable(&mut self, index: usize, drawable: Box<dyn Drawable>) {
         if index < self.drawables.len() {
             self.drawables[index] = drawable;
@@ -649,11 +657,17 @@ impl FemtoVgAreaMut {
         }
 
         // draw crop on top of everything but pointer tool selection overlay
-        for (i, d) in self.drawables.iter().enumerate() {
-            if self.hidden_drawable_index != Some(i)
-                && d.get_rendering_mode() == RenderingMode::Crop
-            {
-                d.draw(canvas, font, bounds)?;
+        if self.active_tool.borrow().get_tool_type() == Tools::Crop
+            && let Some(crop) = self.active_tool.borrow().get_drawable()
+        {
+            crop.draw(canvas, font, bounds)?;
+        } else {
+            for (i, d) in self.drawables.iter().enumerate() {
+                if self.hidden_drawable_index != Some(i)
+                    && d.get_rendering_mode() == RenderingMode::Crop
+                {
+                    d.draw(canvas, font, bounds)?;
+                }
             }
         }
 

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     configuration::Action,
     math::Vec2D,
     sketch_board::SketchBoardInput,
-    tools::{Drawable, Tool},
+    tools::{Drawable, RenderingMode, Tool},
 };
 
 static FONT_STACK: OnceLock<Vec<FontId>> = OnceLock::new();
@@ -211,6 +211,14 @@ impl FemtoVGArea {
             .as_ref()
             .expect("Did you call init before using FemtoVgArea?")
             .get_drawable_clone(index)
+    }
+
+    pub fn find_drawable_index_by_mode(&self, mode: RenderingMode) -> Option<usize> {
+        self.imp()
+            .inner()
+            .as_ref()
+            .expect("Did you call init before using FemtoVgArea?")
+            .find_drawable_index_by_mode(mode)
     }
 
     pub fn replace_drawable(&mut self, index: usize, drawable: Box<dyn Drawable>) {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1090,7 +1090,10 @@ impl SketchBoard {
     ) -> Option<ToolUpdateResult> {
         let idx = self.renderer.hit_test(pos).first().copied()?;
         let drawable = self.renderer.get_drawable_clone(idx)?;
-        let (text_pos, content, style) = drawable.edit_info()?;
+        let text = drawable
+            .as_any()
+            .downcast_ref::<crate::tools::Text>()?
+            .clone();
 
         // Remove the committed drawable and clear selection
         self.pointer_tool.borrow_mut().deselect();
@@ -1098,9 +1101,7 @@ impl SketchBoard {
         self.renderer.remove_drawable(idx);
 
         // Pre-populate the text tool and switch to it
-        self.text_tool
-            .borrow_mut()
-            .load_for_editing(text_pos, &content, style);
+        self.text_tool.borrow_mut().load_for_editing(text);
         self.return_to_pointer_after_text_commit = true;
 
         sender

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -24,7 +24,9 @@ use crate::keybindings::{ActionTrigger, ShortcutCommand, ShortcutRegistry};
 use crate::math::{Vec2D, crop_rect_in_bounds};
 use crate::notification::{log_result, log_result_with_pixbuf};
 use crate::style::{Color, Size, Style};
-use crate::tools::{PointerTool, TextTool, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
+use crate::tools::{
+    PointerTool, RenderingMode, TextTool, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager,
+};
 use crate::ui::toolbars::ToolbarEvent;
 use xdg::BaseDirectories;
 
@@ -940,7 +942,6 @@ impl SketchBoard {
                     .is_none()
             {
                 // switch back to previous tool
-                self.temporary_pointer_previous_tool = None;
                 self.handle_toolbar_event(
                     ToolbarEvent::ToolSelected(previous_tool),
                     sender.clone(),
@@ -1123,8 +1124,22 @@ impl SketchBoard {
                 ToolUpdateResult::Unmodified
             }
             ToolbarEvent::ToolSelected(tool) => {
-                self.temporary_pointer_previous_tool = None;
                 self.return_to_pointer_after_text_commit = false;
+
+                let mut target_tool = tool;
+
+                if tool == Tools::Crop
+                    && self.temporary_pointer_previous_tool != Some(Tools::Crop)
+                    && let Some(index) = self
+                        .renderer
+                        .find_drawable_index_by_mode(RenderingMode::Crop)
+                {
+                    self.temporary_pointer_previous_tool = Some(Tools::Crop);
+                    target_tool = Tools::Pointer;
+                    self.update_pointer_tool_selection(index, false);
+                } else {
+                    self.temporary_pointer_previous_tool = None;
+                }
 
                 // deactivate old tool and save drawable, if any
                 let old_tool = self.active_tool.clone();
@@ -1142,7 +1157,7 @@ impl SketchBoard {
                 }
 
                 // change active tool
-                self.active_tool = self.tools.get(&tool);
+                self.active_tool = self.tools.get(&target_tool);
                 self.renderer.set_active_tool(self.active_tool.clone());
                 let widget_ref: gtk::Widget = self.renderer.clone().upcast();
                 self.active_tool
@@ -1162,7 +1177,11 @@ impl SketchBoard {
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style));
 
-                ToolUpdateResult::Redraw
+                sender
+                    .output_sender()
+                    .emit(SketchBoardOutput::ToolSwitchShortcut(target_tool));
+
+                ToolUpdateResult::RedrawAndStopPropagation
             }
             ToolbarEvent::ColorSelected(color) => {
                 self.style.color = color;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::fmt;
 use std::str::FromStr;
 use std::{
@@ -158,6 +159,21 @@ pub trait DrawableClone {
     fn clone_box(&self) -> Box<dyn Drawable>;
 }
 
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T: Any> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
 impl<T> DrawableClone for T
 where
     T: 'static + Drawable + Clone,
@@ -167,7 +183,7 @@ where
     }
 }
 
-pub trait Drawable: DrawableClone + Debug {
+pub trait Drawable: DrawableClone + Debug + AsAny {
     fn draw(&self, canvas: &mut Canvas<OpenGl>, font: FontId, bounds: (Vec2D, Vec2D))
     -> Result<()>;
     fn handle_undo(&mut self) {}
@@ -191,12 +207,6 @@ pub trait Drawable: DrawableClone + Debug {
     fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
         let _ = (tl, br);
     }
-    // Returns position, text content and style if this drawable is an editable text, for
-    // re-opening it in the text tool. Returns None for all other drawable types.
-    fn edit_info(&self) -> Option<(Vec2D, String, crate::style::Style)> {
-        None
-    }
-
     fn get_style(&self) -> Option<&Style> {
         None
     }
@@ -258,7 +268,7 @@ pub use highlight::{HighlightTool, Highlighters};
 pub use line::LineTool;
 pub use pointer::PointerTool;
 pub use rectangle::RectangleTool;
-pub use text::TextTool;
+pub use text::{Text, TextTool};
 
 use self::{brush::BrushTool, marker::MarkerTool};
 

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -263,15 +263,6 @@ impl Drawable for Text {
         );
     }
 
-    fn edit_info(&self) -> Option<(Vec2D, String, crate::style::Style)> {
-        let content = self.text_buffer.text(
-            &self.text_buffer.start_iter(),
-            &self.text_buffer.end_iter(),
-            false,
-        );
-        Some((self.pos, content.to_string(), self.style))
-    }
-
     fn get_style(&self) -> Option<&Style> {
         Some(&self.style)
     }
@@ -1918,13 +1909,18 @@ impl TextTool {
 
     // Pre-populate the tool with an existing text drawable so the user can edit it.
     // Call this before switching to the Text tool.
-    pub fn load_for_editing(&mut self, pos: Vec2D, content: &str, style: Style) {
-        let t = Text::new(pos, style, self.im_context.clone());
-        t.text_buffer.insert_at_cursor(content);
-        // Move cursor to end
-        t.text_buffer.place_cursor(&t.text_buffer.end_iter());
-        self.text = Some(t);
-        self.style = style;
+    pub fn load_for_editing(&mut self, mut text: Text) {
+        text.editing = true;
+        text.preedit = None;
+        text.im_context = self.im_context.clone();
+        text.text_buffer.place_cursor(&text.text_buffer.end_iter());
+        text.text_buffer
+            .select_range(&text.text_buffer.end_iter(), &text.text_buffer.end_iter());
+        *text.cursor_visible.borrow_mut() = true;
+        *text.draw_rect.borrow_mut() = true;
+
+        self.style = text.style;
+        self.text = Some(text);
         self.set_input_enabled(true);
         self.editing_existing = true;
     }


### PR DESCRIPTION
Fixes some issues from PR #607 - see issue #159. 

- feat: when switching to crop tool select active crop
- fix: double draw of crop while creating
- fix: preserve text properties when editing by pointer tool
