### PR TITLE
fix: sleep for a bit if there was a recent notifcation thumbnail

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,6 +83,9 @@ app-id = "org.satty.satty"
 # experimental feature (0.22.0): show thumbnail as notifcation icon
 # notification-thumbnail = "app-icon"
 notification-thumbnail = "screenshot"
+# how long we are waiting after notification thumbnail was sent before exiting (exit early or quit). This is based on the temporary file mtime.
+# for fast machines, the default value of 250ms is ridiculously high.
+notification-grace-period = 250
 
 # Generic keyboard shortcuts (NEXTRELEASE)
 [keybinds]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,13 +1,13 @@
+use clap::Parser;
+use hex_color::HexColor;
+use relm4::SharedState;
+use std::time::Duration;
 use std::{
     collections::HashMap,
     fs,
     io::{self, Write},
     path::Path,
 };
-
-use clap::Parser;
-use hex_color::HexColor;
-use relm4::SharedState;
 
 use serde::Deserialize;
 use serde::de::Deserializer;
@@ -76,6 +76,7 @@ pub struct Configuration {
     title: Option<String>,
     app_id: Option<String>,
     notification_thumbnail: NotificationThumbnail,
+    notification_grace_period: Duration,
 }
 
 #[derive(Default)]
@@ -362,6 +363,9 @@ impl Configuration {
         }
         if let Some(v) = general.notification_thumbnail {
             self.notification_thumbnail = v;
+        }
+        if let Some(v) = general.notification_grace_period {
+            self.notification_grace_period = std::time::Duration::from_millis(v);
         }
 
         // --- deprecated options ---
@@ -672,6 +676,10 @@ impl Configuration {
     pub fn notification_thumbnail(&self) -> NotificationThumbnail {
         self.notification_thumbnail
     }
+
+    pub fn notification_grace_period(&self) -> Duration {
+        self.notification_grace_period
+    }
 }
 
 impl Default for Configuration {
@@ -714,6 +722,7 @@ impl Default for Configuration {
             title: None,
             app_id: None,
             notification_thumbnail: NotificationThumbnail::default(),
+            notification_grace_period: Duration::from_millis(250),
         }
     }
 }
@@ -785,6 +794,7 @@ struct ConfigurationFileGeneral {
     title: Option<String>,
     app_id: Option<String>,
     notification_thumbnail: Option<NotificationThumbnail>,
+    notification_grace_period: Option<u64>,
 
     // --- deprecated options ---
     right_click_copy: Option<bool>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,16 @@
 use configuration::{APP_CONFIG, Configuration};
+use relm4::gtk::gdk::Rectangle;
 use relm4::gtk::gdk_pixbuf::{Pixbuf, PixbufLoader};
 use relm4::gtk::gio::{Application, ApplicationFlags};
 use relm4::gtk::prelude::*;
 use std::io::Read;
 use std::ops::Deref;
+use std::path::Path;
 use std::process::exit;
 use std::sync::{LazyLock, RwLock};
-use std::{fs, panic};
+use std::time::SystemTime;
+use std::{fs, panic, thread};
 use std::{io, time::Duration};
-
-use relm4::gtk::gdk::Rectangle;
 
 use relm4::{
     Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmApp,
@@ -573,10 +574,24 @@ fn run_satty() -> Result<()> {
         Ok(mut temp_dir) => {
             // take is sufficient to have the dir deleted when it's dropped.
             // But that would hide any errors, so use explicit close instead.
-            if let Some(dir) = temp_dir.take()
-                && let Err(e) = dir.close()
-            {
-                eprintln!("Failed to close temporary directory: {}", e);
+            if let Some(dir) = temp_dir.take() {
+                // get the last modified file from the temp directory, with its timestamp
+                // we can determine if we sent a notification recently.
+                // this works so long as we only have notification thumbs there.
+                if let Some(mtime) = newest_mtime(dir.path())
+                    && let Ok(elapsed) = SystemTime::now().duration_since(mtime)
+                    && elapsed < Duration::from_millis(250)
+                {
+                    eprintln!(
+                        "last notification sent {:?} ago, sleeping some more.",
+                        elapsed
+                    );
+                    thread::sleep(Duration::from_millis(250) - elapsed);
+                }
+
+                if let Err(e) = dir.close() {
+                    eprintln!("Failed to close temporary directory: {}", e);
+                }
             }
         }
         Err(e) => {
@@ -585,6 +600,15 @@ fn run_satty() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn newest_mtime(dir: &Path) -> Option<SystemTime> {
+    fs::read_dir(dir)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.metadata().ok())
+        .filter_map(|meta| meta.modified().ok())
+        .max()
 }
 
 fn main() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -575,18 +575,20 @@ fn run_satty() -> Result<()> {
             // take is sufficient to have the dir deleted when it's dropped.
             // But that would hide any errors, so use explicit close instead.
             if let Some(dir) = temp_dir.take() {
+                let grace_period = APP_CONFIG.read().notification_grace_period();
                 // get the last modified file from the temp directory, with its timestamp
                 // we can determine if we sent a notification recently.
                 // this works so long as we only have notification thumbs there.
                 if let Some(mtime) = newest_mtime(dir.path())
                     && let Ok(elapsed) = SystemTime::now().duration_since(mtime)
-                    && elapsed < Duration::from_millis(250)
+                    && elapsed < grace_period
                 {
+                    let sleep_time = grace_period - elapsed;
                     eprintln!(
-                        "last notification sent {:?} ago, sleeping some more.",
-                        elapsed
+                        "last notification sent {:?} ago, sleeping additional {:?}.",
+                        elapsed, sleep_time
                     );
-                    thread::sleep(Duration::from_millis(250) - elapsed);
+                    thread::sleep(sleep_time);
                 }
 
                 if let Err(e) = dir.close() {


### PR DESCRIPTION
Closes: #634

Notification thumbnails are files referenced in dbus notifications by path. Since these are temporary files, we clean them up. However, when using early exit upon save, this might be before the notification daemon can read them. Unfortunately, there is no feedback mechanism.

With this PR, satty reads the latest file's mtime in the TempDir and determines whether that file was created long ago.

The value of 250ms seems rather long on my systems, I never notice any issue with single digit ms values even without this patch. But on slower systems, it might not be enough.

In worst case, this needs a configurable value, or at least useful documentation.