### PR TITLE
fix: ensure --initial-tool=crop reports dimensions

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -566,6 +566,10 @@ impl FemtoVgAreaMut {
             })
             .unwrap_or(bounds);
 
+        if size.x <= 0.0 || size.y <= 0.0 {
+            return Err(anyhow::anyhow!("Invalid crop"));
+        }
+
         // create render-target
         let image_id = canvas.create_image_empty(
             size.x as usize,

--- a/src/math.rs
+++ b/src/math.rs
@@ -268,6 +268,15 @@ pub fn rect_ensure_positive_size(pos: Vec2D, size: Vec2D) -> (Vec2D, Vec2D) {
 pub fn rect_ensure_in_bounds(rect: (Vec2D, Vec2D), bounds: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
     let (mut pos, mut size) = rect;
 
+    // outside of bounds entirely
+    if pos.x + size.x < bounds.0.x
+        || pos.y + size.y < bounds.0.y
+        || pos.x > bounds.1.x
+        || pos.y > bounds.1.y
+    {
+        return (Vec2D::zero(), Vec2D::zero());
+    }
+
     // The part sticking out has to be measured before pos is moved onto the
     // bound, otherwise the difference is always zero and size stays untouched.
     if pos.x < bounds.0.x {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1968,6 +1968,10 @@ impl Component for SketchBoard {
                 im_context: model.im_context.clone(),
                 widget: widget_ref,
             }));
+        model
+            .active_tool
+            .borrow_mut()
+            .set_sender(sender.input_sender().clone());
 
         ComponentParts { model, widgets }
     }


### PR DESCRIPTION
Closes #639

Must set set_sender in init().

Bug was there for a long time.