### PR TITLE
feat: configurable interpolation mode for background image

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ interpolation = "linear" #default
 "s" = "focus-annotation-size-factor"
 "f" = "toggle-fill"
 "k" = "toggle-round-caps"
+"<Ctrl>+i" = "toggle-interpolation"
 
 # Font to use for text annotations
 [font]

--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ app-id = "org.satty.satty"
 # experimental feature (0.22.0): show thumbnail as notifcation icon
 # notification-thumbnail = "app-icon"
 notification-thumbnail = "screenshot"
+# how long we are waiting after notification thumbnail was sent before exiting (exit early or quit). This is based on the temporary file mtime.
+# for fast machines, the default value of 250ms is ridiculously high.
+notification-grace-period = 250
+# set interpolation for the background image
+# interpolation = "nearest-neighbor"
+interpolation = "linear" #default
 
 # Generic keyboard shortcuts (NEXTRELEASE)
 [keybinds]
@@ -448,6 +454,8 @@ Options:
           Experimental feature (0.21.0): Set toplevel app_id. Note that this has to match D-Bus well known name format, otherwise GTK does not accept it
       --notification-thumbnail <NOTIFICATION_THUMBNAIL>
           Experimental feature (0.22.0): use preview thumbnail in notifications where available [possible values: screenshot, app-icon]
+      --interpolation <INTERPOLATION>
+          interpolation of the background image [possible values: linear, nearest-neighbor]
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -163,6 +163,10 @@ pub struct CommandLine {
     #[arg(long)]
     pub notification_thumbnail: Option<NotificationThumbnail>,
 
+    /// interpolation of the background image
+    #[arg(long)]
+    pub interpolation: Option<Interpolation>,
+
     // --- deprecated options ---
     /// Right click to copy.
     /// Preferably use the `action_on_right_click` option instead.
@@ -173,6 +177,15 @@ pub struct CommandLine {
     #[arg(long, value_delimiter = ',')]
     pub action_on_enter: Option<Action>,
     // ---
+}
+
+#[derive(Debug, Default, Deserialize, Clone, Copy, ValueEnum, PartialEq)]
+#[value(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
+pub enum Interpolation {
+    #[default]
+    Linear,
+    NearestNeighbor,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, ValueEnum, PartialEq)]

--- a/config.toml
+++ b/config.toml
@@ -153,6 +153,7 @@ interpolation = "linear" #default
 "s" = "focus-annotation-size-factor"
 "f" = "toggle-fill"
 "k" = "toggle-round-caps"
+"<Ctrl>+i" = "toggle-interpolation"
 
 # Font to use for text annotations
 [font]

--- a/config.toml
+++ b/config.toml
@@ -86,6 +86,9 @@ notification-thumbnail = "screenshot"
 # how long we are waiting after notification thumbnail was sent before exiting (exit early or quit). This is based on the temporary file mtime.
 # for fast machines, the default value of 250ms is ridiculously high.
 notification-grace-period = 250
+# set interpolation for the background image
+# interpolation = "nearest-neighbor"
+interpolation = "linear" #default
 
 # Generic keyboard shortcuts (NEXTRELEASE)
 [keybinds]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use femtovg::ImageFlags;
 use hex_color::HexColor;
 use relm4::SharedState;
 use serde::Deserialize;
@@ -77,7 +76,7 @@ pub struct Configuration {
     app_id: Option<String>,
     notification_thumbnail: NotificationThumbnail,
     notification_grace_period: Duration,
-    interpolation_flags: ImageFlags,
+    use_linear_interpolation: bool,
 }
 
 #[derive(Default)]
@@ -369,9 +368,9 @@ impl Configuration {
             self.notification_grace_period = std::time::Duration::from_millis(v);
         }
         if let Some(v) = general.interpolation {
-            self.interpolation_flags = match v {
-                Interpolation::Linear => ImageFlags::empty(),
-                Interpolation::NearestNeighbor => ImageFlags::NEAREST,
+            self.use_linear_interpolation = match v {
+                Interpolation::Linear => true,
+                Interpolation::NearestNeighbor => false,
             }
         }
 
@@ -510,9 +509,9 @@ impl Configuration {
             self.notification_thumbnail = v;
         }
         if let Some(v) = command_line.interpolation {
-            self.interpolation_flags = match v {
-                Interpolation::Linear => ImageFlags::empty(),
-                Interpolation::NearestNeighbor => ImageFlags::NEAREST,
+            self.use_linear_interpolation = match v {
+                Interpolation::Linear => true,
+                Interpolation::NearestNeighbor => false,
             }
         }
 
@@ -694,8 +693,8 @@ impl Configuration {
         self.notification_grace_period
     }
 
-    pub fn interpolation_flags(&self) -> ImageFlags {
-        self.interpolation_flags
+    pub fn use_linear_interpolation(&self) -> bool {
+        self.use_linear_interpolation
     }
 }
 
@@ -740,7 +739,7 @@ impl Default for Configuration {
             app_id: None,
             notification_thumbnail: NotificationThumbnail::default(),
             notification_grace_period: Duration::from_millis(250),
-            interpolation_flags: ImageFlags::empty(),
+            use_linear_interpolation: false,
         }
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
+use femtovg::ImageFlags;
 use hex_color::HexColor;
 use relm4::SharedState;
+use serde::Deserialize;
+use serde::de::Deserializer;
 use std::time::Duration;
 use std::{
     collections::HashMap,
@@ -8,9 +11,6 @@ use std::{
     io::{self, Write},
     path::Path,
 };
-
-use serde::Deserialize;
-use serde::de::Deserializer;
 use thiserror::Error;
 use xdg::{BaseDirectories, BaseDirectoriesError};
 
@@ -20,8 +20,8 @@ use crate::{
 };
 
 use satty_cli::command_line::{
-    Action as CommandLineAction, CommandLine, EarlyExitTriggers, Fullscreen, NotificationThumbnail,
-    Resize,
+    Action as CommandLineAction, CommandLine, EarlyExitTriggers, Fullscreen, Interpolation,
+    NotificationThumbnail, Resize,
 };
 
 pub static APP_CONFIG: SharedState<Configuration> = SharedState::new();
@@ -77,6 +77,7 @@ pub struct Configuration {
     app_id: Option<String>,
     notification_thumbnail: NotificationThumbnail,
     notification_grace_period: Duration,
+    interpolation_flags: ImageFlags,
 }
 
 #[derive(Default)]
@@ -367,6 +368,12 @@ impl Configuration {
         if let Some(v) = general.notification_grace_period {
             self.notification_grace_period = std::time::Duration::from_millis(v);
         }
+        if let Some(v) = general.interpolation {
+            self.interpolation_flags = match v {
+                Interpolation::Linear => ImageFlags::empty(),
+                Interpolation::NearestNeighbor => ImageFlags::NEAREST,
+            }
+        }
 
         // --- deprecated options ---
         if let Some(v) = general.right_click_copy
@@ -501,6 +508,12 @@ impl Configuration {
         }
         if let Some(v) = command_line.notification_thumbnail {
             self.notification_thumbnail = v;
+        }
+        if let Some(v) = command_line.interpolation {
+            self.interpolation_flags = match v {
+                Interpolation::Linear => ImageFlags::empty(),
+                Interpolation::NearestNeighbor => ImageFlags::NEAREST,
+            }
         }
 
         // --- deprecated options ---
@@ -680,6 +693,10 @@ impl Configuration {
     pub fn notification_grace_period(&self) -> Duration {
         self.notification_grace_period
     }
+
+    pub fn interpolation_flags(&self) -> ImageFlags {
+        self.interpolation_flags
+    }
 }
 
 impl Default for Configuration {
@@ -723,6 +740,7 @@ impl Default for Configuration {
             app_id: None,
             notification_thumbnail: NotificationThumbnail::default(),
             notification_grace_period: Duration::from_millis(250),
+            interpolation_flags: ImageFlags::empty(),
         }
     }
 }
@@ -795,6 +813,7 @@ struct ConfigurationFileGeneral {
     app_id: Option<String>,
     notification_thumbnail: Option<NotificationThumbnail>,
     notification_grace_period: Option<u64>,
+    interpolation: Option<Interpolation>,
 
     // --- deprecated options ---
     right_click_copy: Option<bool>,

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -46,7 +46,9 @@ pub struct FemtoVGArea {
 pub struct FemtoVgAreaMut {
     source_image: Option<Rc<ImgVec<RGBA8>>>,
     background_image: Pixbuf,
-    background_image_id: Option<femtovg::ImageId>,
+    background_image_id_linear: Option<femtovg::ImageId>,
+    background_image_id_nearest: Option<femtovg::ImageId>,
+    use_linear: bool,
     transparent_background_id: Option<femtovg::ImageId>,
     active_tool: Rc<RefCell<dyn Tool>>,
     scale_factor: f32,
@@ -184,7 +186,9 @@ impl FemtoVGArea {
         self.inner().replace(FemtoVgAreaMut {
             source_image: None,
             background_image,
-            background_image_id: None,
+            background_image_id_linear: None,
+            background_image_id_nearest: None,
+            use_linear: APP_CONFIG.read().use_linear_interpolation(),
             transparent_background_id: None,
             active_tool,
             scale_factor: 1.0,
@@ -572,7 +576,11 @@ impl FemtoVgAreaMut {
             size.y as usize,
             PixelFormat::Rgba8,
             // this should not make a difference here at native res, but does not hurt either
-            APP_CONFIG.read().interpolation_flags(),
+            if self.use_linear {
+                ImageFlags::empty()
+            } else {
+                ImageFlags::NEAREST
+            },
         )?;
         canvas.set_render_target(femtovg::RenderTarget::Image(image_id));
 
@@ -727,11 +735,28 @@ impl FemtoVgAreaMut {
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         onscreen: bool,
     ) -> Result<()> {
-        let background_image_id = match self.background_image_id {
+        let background_image_id_linear = match self.background_image_id_linear {
             Some(id) => id,
             None => {
-                let id = Self::upload_background_image(canvas, &self.background_image)?;
-                self.background_image_id.replace(id);
+                let id = Self::upload_background_image(
+                    canvas,
+                    &self.background_image,
+                    ImageFlags::empty(),
+                )?;
+                self.background_image_id_linear.replace(id);
+                id
+            }
+        };
+
+        let background_image_id_nearest = match self.background_image_id_nearest {
+            Some(id) => id,
+            None => {
+                let id = Self::upload_background_image(
+                    canvas,
+                    &self.background_image,
+                    ImageFlags::NEAREST,
+                )?;
+                self.background_image_id_nearest.replace(id);
                 id
             }
         };
@@ -777,7 +802,19 @@ impl FemtoVgAreaMut {
 
         canvas.fill_path(
             &path,
-            &Paint::image(background_image_id, 0f32, 0f32, w, h, 0f32, 1f32),
+            &Paint::image(
+                if self.use_linear {
+                    background_image_id_linear
+                } else {
+                    background_image_id_nearest
+                },
+                0f32,
+                0f32,
+                w,
+                h,
+                0f32,
+                1f32,
+            ),
         );
 
         Ok(())
@@ -786,6 +823,7 @@ impl FemtoVgAreaMut {
     fn upload_background_image(
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         image: &Pixbuf,
+        interpolation_flags: ImageFlags,
     ) -> Result<ImageId> {
         let format = if image.has_alpha() {
             PixelFormat::Rgba8
@@ -797,7 +835,7 @@ impl FemtoVgAreaMut {
             image.width() as usize,
             image.height() as usize,
             format,
-            APP_CONFIG.read().interpolation_flags(),
+            interpolation_flags,
         )?;
 
         // extract values
@@ -851,6 +889,10 @@ impl FemtoVgAreaMut {
         }
 
         Ok(background_image_id)
+    }
+
+    pub(crate) fn toggle_interpolation(&mut self) {
+        self.use_linear = !self.use_linear;
     }
 
     fn create_transparency_bg(

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -571,7 +571,8 @@ impl FemtoVgAreaMut {
             size.x as usize,
             size.y as usize,
             PixelFormat::Rgba8,
-            ImageFlags::empty(),
+            // this should not make a difference here at native res, but does not hurt either
+            APP_CONFIG.read().interpolation_flags(),
         )?;
         canvas.set_render_target(femtovg::RenderTarget::Image(image_id));
 
@@ -796,7 +797,7 @@ impl FemtoVgAreaMut {
             image.width() as usize,
             image.height() as usize,
             format,
-            ImageFlags::empty(),
+            APP_CONFIG.read().interpolation_flags(),
         )?;
 
         // extract values

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -120,6 +120,15 @@ impl FemtoVGArea {
         self.imp().resize(0, 0);
     }
 
+    pub fn toggle_interpolation(&self) {
+        self.imp()
+            .inner()
+            .as_mut()
+            .expect("Did you call init before using FemtoVgArea?")
+            .toggle_interpolation();
+        self.request_render(&[]);
+    }
+
     pub fn set_pointer_offset(&self, offset: Vec2D) {
         self.imp()
             .inner()

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -46,6 +46,7 @@ pub enum ShortcutCommand {
     FocusAnnotationSizeFactor,
     ToggleFill,
     ToggleRoundCaps,
+    ToggleInterpolation, // maybe added to toolbar later
 }
 
 impl fmt::Display for ShortcutCommand {
@@ -100,6 +101,7 @@ impl fmt::Display for ShortcutCommand {
             ShortcutCommand::FocusAnnotationSizeFactor => "focus-annotation-size-factor",
             ShortcutCommand::ToggleFill => "toggle-fill",
             ShortcutCommand::ToggleRoundCaps => "toggle-round-caps",
+            ShortcutCommand::ToggleInterpolation => "toggle-interpolation",
         };
         write!(f, "{}", name)
     }
@@ -171,6 +173,7 @@ impl FromStr for ShortcutCommand {
             "focus-annotation-size-factor" => Ok(ShortcutCommand::FocusAnnotationSizeFactor),
             "toggle-fill" => Ok(ShortcutCommand::ToggleFill),
             "toggle-round-caps" => Ok(ShortcutCommand::ToggleRoundCaps),
+            "toggle-interpolation" => Ok(ShortcutCommand::ToggleInterpolation),
             _ => Err(ParseCommandError),
         }
     }
@@ -293,6 +296,7 @@ impl ShortcutRegistry {
         registry.add_key_binding("minus", SC::CycleSize);
         registry.add_key_binding("s", SC::FocusAnnotationSizeFactor);
         registry.add_key_binding("f", SC::ToggleFill);
+        registry.add_key_binding("<Control>i", SC::ToggleInterpolation);
 
         // merge with config keybinds, allowing config to override defaults
         for (kb_str, tool_or_cmd) in APP_CONFIG.read().keybinds() {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1336,6 +1336,10 @@ impl SketchBoard {
                 ));
                 ToolUpdateResult::Unmodified
             }
+            ShortcutCommand::ToggleInterpolation => {
+                self.renderer.toggle_interpolation();
+                ToolUpdateResult::Unmodified
+            }
             ShortcutCommand::Undo => self.handle_undo(),
             ShortcutCommand::Redo => self.handle_redo(),
             ShortcutCommand::ToggleToolbars => self.handle_toggle_toolbars_display(sender),


### PR DESCRIPTION
Closes: #613

The first commit just added config/cli for a static image interpolation determined per start. In the spirit of #613 I believe a toggle may be more interesting/important.

But while the first variant was simple, this created a new challenge of actually replacing the image ids. Rather than repeatedly dealing with create/update/delete etc we're now keeping two images. It's a bit wasteful from a memory point of view, but in theory this skips some code in `render_background_image` on repeated try and should be a tad faster. I'm not sure if there is a noticeable difference. If anyone's bored, try the other and compare the performance difference ;)

I did not add a toolbar icon but a shortcut (ctrl+i).