### PR TITLE
feat: add Ctrl modifier to keep resize aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Newly created annotations can be autoselected if enabled in the config.
 - Drag the resize handles - mouse cursor will change - to change the size. 
   - Hold <kbd>Alt</kbd> for centered resize
   - Hold <kbd>Shift</kbd> to snap to defined aspect ratios. <sup>NEXTRELEASE</sup>
+  - Hold <kbd>Control</kbd> at corners for aspect ratio preserving resize. <sup>NEXTRELEASE</sup>
+  - Hold mutiple to combine them.
 - Grab an annotation - mouse cursor will change to a hand - to move.
 - Scroll up/down with the mouse wheel to change the annotation's layer.
 - Nudge (small move) with the cursor keys.
@@ -137,7 +139,8 @@ Arrow and line:
 Crop <sup>NEXTRELEASE</sup>, rectangle, ellipse, blur <sup>0.22.0</sup>, highlight block mode<sup>0.22.0</sup>, pixelate<sup>NEXTRELASE</sup>, fringe-pixelate<sup>NEXTRELEASE</sup>, fringe<sup>NEXTRELEASE</sup>, image<sup>NEXTRELEASE</sup>: 
 - <kbd>Alt</kbd> to center the tool around origin.
 - <kbd>Shift</kbd> to snap to defined aspect ratios. <sup>NEXTRELEASE</sup>
-- Hold both to combine them.
+- Hold <kbd>Control</kbd> to preserve aspect ratio. Draws square if starting from zero size. <sup>NEXTRELEASE</sup>
+- Hold mutiple to combine them.
 
 Text:
 - Press <kbd>Shift+Enter</kbd> to insert line break.

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -22,7 +22,7 @@ use super::{
 pub struct Blur {
     origin: Vec2D,
     top_left: Vec2D,
-    size: Option<Vec2D>,
+    size: Vec2D,
     style: Style,
     centered: bool,
     editing: bool,
@@ -31,10 +31,10 @@ pub struct Blur {
 
 impl Blur {
     fn calculate_shape(&mut self, sender: &Sender<SketchBoardInput>, event: &MouseEventMsg) {
-        let drag_box = DragBox::from_origin_delta(self.origin, event, sender);
+        let drag_box = DragBox::from_origin_delta(self.origin, self.size, event, sender);
         self.centered = drag_box.centered;
         self.top_left = drag_box.top_left;
-        self.size = Some(drag_box.size);
+        self.size = drag_box.size;
     }
 
     fn blur(
@@ -83,10 +83,9 @@ impl Drawable for Blur {
     }
 
     fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
-        let size = self.size?;
         Some(math::ensure_bounding_box(
             self.top_left,
-            self.top_left + size,
+            self.top_left + self.size,
         ))
     }
 
@@ -103,7 +102,7 @@ impl Drawable for Blur {
     fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         self.top_left = tl;
-        self.size = Some(br - tl);
+        self.size = br - tl;
         *self.cached_image.borrow_mut() = None;
     }
 
@@ -122,10 +121,7 @@ impl Drawable for Blur {
         _font: femtovg::FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        let size = match self.size {
-            Some(s) => s,
-            None => return Ok(()), // early exit if none
-        };
+        let size = self.size;
         let (pos, size) = math::rect_ensure_in_bounds(
             math::rect_ensure_positive_size(self.top_left, size),
             bounds,
@@ -235,7 +231,7 @@ impl Tool for BlurTool {
                 self.blur = Some(Blur {
                     origin: event.pos,
                     top_left: event.pos,
-                    size: None,
+                    size: Vec2D::zero(),
                     style: self.style,
                     centered: false,
                     editing: true,

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -55,7 +55,7 @@ impl Drawable for BrushDrawable {
             Some(bounds) => bounds,
             None => return false,
         };
-        hit_test_rectangle(pos, tl, Some(br - tl), tolerance, true)
+        hit_test_rectangle(pos, tl, br - tl, tolerance, true)
     }
 
     fn translate(&mut self, delta: Vec2D) {

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -31,7 +31,7 @@ pub struct CropTool {
 
 impl Crop {
     pub fn calculate_shape(&mut self, sender: &Sender<SketchBoardInput>, event: &MouseEventMsg) {
-        let drag_box = DragBox::from_origin_delta(self.origin, event, sender);
+        let drag_box = DragBox::from_origin_delta(self.origin, self.size, event, sender);
         self.centered = drag_box.centered;
         self.top_left = drag_box.top_left;
         self.size = drag_box.size;
@@ -51,7 +51,7 @@ impl Drawable for Crop {
     }
 
     fn hit_test(&self, pos: Vec2D, tolerance: f32) -> bool {
-        hit_test_rectangle(pos, self.top_left, Some(self.size), tolerance, false)
+        hit_test_rectangle(pos, self.top_left, self.size, tolerance, false)
     }
 
     fn translate(&mut self, delta: Vec2D) {

--- a/src/tools/drag_box.rs
+++ b/src/tools/drag_box.rs
@@ -13,24 +13,40 @@ pub struct DragBox {
     pub top_left: Vec2D,
     pub size: Vec2D,
     pub centered: bool,
+    pub keep_aspect: bool,
 }
 
 impl DragBox {
     pub fn from_origin_delta(
         origin: Vec2D,
+        orig_size: Vec2D,
         event: &MouseEventMsg,
         sender: &Sender<SketchBoardInput>,
     ) -> Self {
-        let centered = event.modifier.intersects(ModifierType::ALT_MASK);
         let aspect = event.modifier.intersects(ModifierType::SHIFT_MASK);
+        let keep_aspect = event.modifier.intersects(ModifierType::CONTROL_MASK);
+        let centered = event.modifier.intersects(ModifierType::ALT_MASK);
 
-        let mut size = event.pos;
+        let mut new_size = event.pos;
+        let sign_x = new_size.x.signum();
+        let sign_y = new_size.y.signum();
+        let width = new_size.x.abs();
+        let height = new_size.y.abs();
 
-        if aspect && size.y.abs() > f32::EPSILON {
-            let sign_x = size.x.signum();
-            let sign_y = size.y.signum();
-            let width = size.x.abs();
-            let height = size.y.abs();
+        if keep_aspect {
+            let aspect_ratio =
+                if orig_size.x.abs() <= f32::EPSILON || orig_size.y.abs() <= f32::EPSILON {
+                    // start with square
+                    1.0
+                } else {
+                    orig_size.x.abs() / orig_size.y.abs()
+                };
+            if width >= height * aspect_ratio {
+                new_size.y = width / aspect_ratio * sign_y;
+            } else {
+                new_size.x = height * aspect_ratio * sign_x;
+            }
+        } else if aspect && new_size.y.abs() > f32::EPSILON {
             let aspect_ratio = width / height;
             let config = APP_CONFIG.read();
             let closest_aspect_ratio =
@@ -41,23 +57,24 @@ impl DragBox {
             } else {
                 (width, width / aspect_ratio)
             };
-            size.x = width * sign_x;
-            size.y = height * sign_y;
+            new_size.x = width * sign_x;
+            new_size.y = height * sign_y;
         }
 
         let size_factor = if centered { 2.0 } else { 1.0 };
-        size = size * size_factor;
+        new_size = new_size * size_factor;
 
         let top_left = if centered {
-            origin.min(origin - size.abs() / size_factor)
+            origin.min(origin - new_size.abs() / size_factor)
         } else {
-            origin.min(origin + size)
+            origin.min(origin + new_size)
         };
 
         let drag_box = Self {
             top_left,
-            size: size.abs(),
+            size: new_size.abs(),
             centered,
+            keep_aspect: aspect || keep_aspect,
         };
         sender
             .send(SketchBoardInput::ShapeDimensionsUpdate(drag_box.size))

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -17,7 +17,7 @@ use super::{
 pub struct Ellipse {
     origin: Vec2D,
     middle: Vec2D,
-    radii: Option<Vec2D>,
+    radii: Vec2D,
     style: Style,
     centered: bool,
     finishing: bool,
@@ -25,16 +25,12 @@ pub struct Ellipse {
 
 impl Drawable for Ellipse {
     fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
-        let radii = self.radii?.abs();
+        let radii = self.radii.abs();
         Some((self.middle - radii, self.middle + radii))
     }
 
     fn hit_test(&self, pos: Vec2D, tolerance: f32) -> bool {
-        let Some(radii) = self.radii else {
-            return false;
-        };
-
-        let d = (pos - self.middle) / (radii + tolerance);
+        let d = (pos - self.middle) / (self.radii + tolerance);
         if d * d > 1.0 {
             // outside the outer tolerance
             return false;
@@ -46,7 +42,7 @@ impl Drawable for Ellipse {
         }
 
         // outside the inner tolerance
-        let inner_d = (pos - self.middle) / (radii - tolerance);
+        let inner_d = (pos - self.middle) / (self.radii - tolerance);
         inner_d * inner_d > 1.0
     }
 
@@ -60,7 +56,7 @@ impl Drawable for Ellipse {
         let center = (tl + br) / 2.0;
         self.middle = center;
         self.origin = center;
-        self.radii = Some((br - tl).abs() / 2.0);
+        self.radii = (br - tl).abs() / 2.0;
         self.centered = false;
         self.finishing = true;
     }
@@ -79,14 +75,9 @@ impl Drawable for Ellipse {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        let radii = match self.radii {
-            Some(s) => s,
-            None => return Ok(()), // early exit if none
-        };
-
         canvas.save();
         let mut path = Path::new();
-        path.ellipse(self.middle.x, self.middle.y, radii.x, radii.y);
+        path.ellipse(self.middle.x, self.middle.y, self.radii.x, self.radii.y);
 
         if !self.finishing && self.centered {
             draw_center_marker(canvas, self.middle);
@@ -104,10 +95,10 @@ impl Drawable for Ellipse {
 
 impl Ellipse {
     fn calculate_shape(&mut self, sender: &Sender<SketchBoardInput>, event: &MouseEventMsg) {
-        let drag_box = DragBox::from_origin_delta(self.origin, event, sender);
+        let drag_box = DragBox::from_origin_delta(self.origin, self.radii * 2.0, event, sender);
         self.centered = drag_box.centered;
         self.middle = drag_box.middle();
-        self.radii = Some(drag_box.size.abs() * 0.5);
+        self.radii = drag_box.size.abs() * 0.5;
     }
 }
 
@@ -147,7 +138,7 @@ impl Tool for EllipseTool {
                 self.ellipse = Some(Ellipse {
                     origin: event.pos,
                     middle: event.pos,
-                    radii: None,
+                    radii: Vec2D::zero(),
                     style: self.style,
                     centered: true,
                     finishing: false,

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -46,7 +46,7 @@ impl From<command_line::Highlighters> for Highlighters {
 struct BlockHighlight {
     origin: Vec2D,
     top_left: Vec2D,
-    size: Option<Vec2D>,
+    size: Vec2D,
     centered: bool,
     finishing: bool,
 }
@@ -105,12 +105,7 @@ impl Highlight for Highlighter<FreehandHighlight> {
 
 impl Highlight for Highlighter<BlockHighlight> {
     fn highlight(&self, canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>) -> Result<()> {
-        let size = match self.data.size {
-            Some(s) => s,
-            None => return Ok(()), // early exit if size is none
-        };
-
-        let (pos, size) = math::rect_ensure_positive_size(self.data.top_left, size);
+        let (pos, size) = math::rect_ensure_positive_size(self.data.top_left, self.data.size);
 
         if !self.data.finishing && self.data.centered {
             draw_center_marker(canvas, self.data.origin);
@@ -139,10 +134,10 @@ impl Highlight for Highlighter<BlockHighlight> {
 
 impl BlockHighlight {
     fn calculate_shape(&mut self, sender: &Sender<SketchBoardInput>, event: &MouseEventMsg) {
-        let drag_box = DragBox::from_origin_delta(self.origin, event, sender);
+        let drag_box = DragBox::from_origin_delta(self.origin, self.size, event, sender);
         self.centered = drag_box.centered;
         self.top_left = drag_box.top_left;
-        self.size = Some(drag_box.size);
+        self.size = drag_box.size;
     }
 }
 
@@ -163,13 +158,10 @@ pub struct HighlightTool {
 impl Drawable for HighlightKind {
     fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
         match self {
-            HighlightKind::Block(h) => {
-                let size = h.data.size?;
-                Some(math::ensure_bounding_box(
-                    h.data.top_left,
-                    h.data.top_left + size,
-                ))
-            }
+            HighlightKind::Block(h) => Some(math::ensure_bounding_box(
+                h.data.top_left,
+                h.data.top_left + h.data.size,
+            )),
             HighlightKind::Freehand(h) => {
                 let mut min_x = f32::MAX;
                 let mut min_y = f32::MAX;
@@ -201,7 +193,7 @@ impl Drawable for HighlightKind {
             Some(bounds) => bounds,
             None => return false,
         };
-        hit_test_rectangle(pos, tl, Some(br - tl), tolerance, true)
+        hit_test_rectangle(pos, tl, br - tl, tolerance, true)
     }
 
     fn translate(&mut self, delta: Vec2D) {
@@ -222,7 +214,7 @@ impl Drawable for HighlightKind {
         match self {
             HighlightKind::Block(h) => {
                 h.data.top_left = tl;
-                h.data.size = Some(br - tl);
+                h.data.size = br - tl;
             }
             HighlightKind::Freehand(h) => {
                 // Resize freehand by scaling all points from current bounds to new bounds.
@@ -352,7 +344,7 @@ impl Tool for HighlightTool {
                                 data: BlockHighlight {
                                     origin: event.pos,
                                     top_left: event.pos,
-                                    size: None,
+                                    size: Vec2D::zero(),
                                     centered: false,
                                     finishing: false,
                                 },

--- a/src/tools/image.rs
+++ b/src/tools/image.rs
@@ -38,12 +38,12 @@ impl ImagePlacement {
 
     // the placement a drag from `origin` asks for, given its end event
     fn from_drag(origin: Vec2D, event: &MouseEventMsg, sender: &Sender<SketchBoardInput>) -> Self {
-        let drag_box = DragBox::from_origin_delta(origin, event, sender);
+        let drag_box = DragBox::from_origin_delta(origin, Vec2D::zero(), event, sender);
         // the same box on screen, so that what counts as a click does not
         // change with the zoom
         let screen_box =
         // FIXME was using screen_pos in old version - now we pass event and dragbox used pos
-            DragBox::from_origin_delta(Vec2D::zero(),  event, sender);
+            DragBox::from_origin_delta(Vec2D::zero(), Vec2D::zero(), event, sender);
 
         if screen_box.size.x < Self::MIN_BOX_SIZE || screen_box.size.y < Self::MIN_BOX_SIZE {
             Self::Center(drag_box.middle())
@@ -161,7 +161,7 @@ impl Drawable for Image {
     }
 
     fn hit_test(&self, pos: Vec2D, tolerance: f32) -> bool {
-        hit_test_rectangle(pos, self.top_left, Some(self.size), tolerance, true)
+        hit_test_rectangle(pos, self.top_left, self.size, tolerance, true)
     }
 
     fn translate(&mut self, delta: Vec2D) {
@@ -326,6 +326,7 @@ impl Tool for ImageTool {
                     origin: event.pos,
                     drag_box: DragBox::from_origin_delta(
                         event.pos,
+                        Vec2D::zero(),
                         &event,
                         self.sender.as_ref().unwrap(),
                     ),
@@ -336,8 +337,12 @@ impl Tool for ImageTool {
                 let Some(drag) = &mut self.drag else {
                     return ToolUpdateResult::Unmodified;
                 };
-                drag.drag_box =
-                    DragBox::from_origin_delta(drag.origin, &event, self.sender.as_ref().unwrap());
+                drag.drag_box = DragBox::from_origin_delta(
+                    drag.origin,
+                    Vec2D::zero(),
+                    &event,
+                    self.sender.as_ref().unwrap(),
+                );
                 ToolUpdateResult::Redraw
             }
             MouseEventType::EndDrag => {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -253,14 +253,10 @@ pub trait Drawable: DrawableClone + Debug + AsAny {
 pub fn hit_test_rectangle(
     pos: Vec2D,
     top_left: Vec2D,
-    size: Option<Vec2D>,
+    size: Vec2D,
     tolerance: f32,
     filled: bool,
 ) -> bool {
-    let Some(size) = size else {
-        return false;
-    };
-
     // ensure a valid bounding box - dragging br to the left/up of tl is possible
     // and then the hit test should still work as expected
     let (tl, br) = ensure_bounding_box(top_left, top_left + size);

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -31,7 +31,7 @@ pub enum PixelateMode {
 pub struct Pixelate {
     origin: Vec2D,
     top_left: Vec2D,
-    size: Option<Vec2D>,
+    size: Vec2D,
     style: Style,
     centered: bool,
     editing: bool,
@@ -56,10 +56,10 @@ impl Pixelate {
     }
 
     fn calculate_shape(&mut self, sender: &Sender<SketchBoardInput>, event: &MouseEventMsg) {
-        let drag_box = DragBox::from_origin_delta(self.origin, event, sender);
+        let drag_box = DragBox::from_origin_delta(self.origin, self.size, event, sender);
         self.centered = drag_box.centered;
         self.top_left = drag_box.top_left;
-        self.size = Some(drag_box.size);
+        self.size = drag_box.size;
     }
 
     fn pixelate(
@@ -273,10 +273,9 @@ impl Drawable for Pixelate {
     }
 
     fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
-        let size = self.size?;
         Some(math::ensure_bounding_box(
             self.top_left,
-            self.top_left + size,
+            self.top_left + self.size,
         ))
     }
 
@@ -293,7 +292,7 @@ impl Drawable for Pixelate {
     fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         self.top_left = tl;
-        self.size = Some(br - tl);
+        self.size = br - tl;
         *self.cached_image.borrow_mut() = None;
     }
 
@@ -322,13 +321,8 @@ impl Drawable for Pixelate {
         _font: FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        let size = match self.size {
-            Some(s) => s,
-            None => return Ok(()), // early exit if none
-        };
-
         let (pos, size) = math::rect_ensure_in_bounds(
-            math::rect_ensure_positive_size(self.top_left, size),
+            math::rect_ensure_positive_size(self.top_left, self.size),
             bounds,
         );
 
@@ -443,7 +437,7 @@ impl Tool for PixelateTool {
                 self.pixelate = Some(Pixelate {
                     origin: event.pos,
                     top_left: event.pos,
-                    size: None,
+                    size: Vec2D::zero(),
                     centered: false,
                     editing: true,
                     style: self.style,

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -68,26 +68,93 @@ impl ResizeHandle {
     pub fn resize(&self, event: MouseEventMsg, tl: Vec2D, br: Vec2D) -> (Vec2D, Vec2D) {
         let mut new_tl = tl;
         let mut new_br = br;
-        let delta = event.pos;
+        let mut delta = event.pos;
 
-        let centered = event.modifier.intersects(ModifierType::ALT_MASK);
         let aspect = event.modifier.intersects(ModifierType::SHIFT_MASK);
+        let keep_aspect = event.modifier.intersects(ModifierType::CONTROL_MASK);
+        let centered = event.modifier.intersects(ModifierType::ALT_MASK);
 
-        // keep center fixed if Alt is held down
         type RH = ResizeHandle;
-        match self {
-            RH::TopRight => {
-                new_tl.y += delta.y;
-                new_br.x += delta.x;
-                if centered {
-                    new_tl.x -= delta.x;
-                    new_br.y -= delta.y;
+
+        // keep aspect ratio if Ctrl is held down on corners
+        if keep_aspect && (br.y - tl.y) > f32::EPSILON {
+            let size = br - tl;
+            let aspect_ratio = size.x.abs() / size.y.abs();
+            let center_scale = if centered { 1.0 } else { 2.0 };
+
+            // Adjusts a (width-delta, height-delta) pair, in the "both attached to
+            // br" sign convention, so it maintains aspect_ratio. Which axis is
+            // dominant is picked by whichever the mouse actually moved further
+            // in order to keep the mouse pointer on the edge.
+            // When centered, wh is applied to *both* opposite corners, so the
+            // real total size change is 2*wh, not wh - the signum heuristic below
+            // needs that same total to pick the correct axis near a size inversion.
+            let total_scale = 2.0 / center_scale;
+            let fix_aspect = |mut wh: Vec2D| -> Vec2D {
+                let size_delta = size + wh * total_scale;
+                let sdxs = size_delta.x.signum();
+                let sdys = size_delta.y.signum();
+                if sdxs * wh.x >= sdys * wh.y * aspect_ratio {
+                    wh.y = wh.x / aspect_ratio;
+                } else {
+                    wh.x = wh.y * aspect_ratio;
+                }
+                wh
+            };
+
+            match self {
+                RH::TopLeft => {
+                    // w and h are both attached to tl (-dx/-dy grow them)
+                    let wh = fix_aspect(delta * -1.0);
+                    delta = wh * -1.0;
+                }
+                RH::BottomRight => {
+                    // w and h are both attached to br (dx/dy grow them)
+                    delta = fix_aspect(delta);
+                }
+                RH::TopRight => {
+                    // w is attached to br (dx grows it), h to tl (-dy grows it).
+                    let wh = fix_aspect(Vec2D::new(delta.x, -delta.y));
+                    delta = Vec2D::new(wh.x, -wh.y);
+                }
+                RH::BottomLeft => {
+                    // w is attached to tl (-dx grows it), h to br (dy grows it).
+                    let wh = fix_aspect(Vec2D::new(-delta.x, delta.y));
+                    delta = Vec2D::new(-wh.x, wh.y);
+                }
+                RH::TopCenter => {
+                    // h is attached to tl (-dy grows it); w follows via aspect ratio.
+                    delta.x = -delta.y * aspect_ratio;
+                    new_tl.x -= delta.x / center_scale;
+                    new_br.x += delta.x / center_scale;
+                }
+                RH::BottomCenter => {
+                    // h is attached to br (dy grows it); w follows via aspect ratio.
+                    delta.x = delta.y * aspect_ratio;
+                    new_tl.x -= delta.x / center_scale;
+                    new_br.x += delta.x / center_scale;
+                }
+                RH::MiddleLeft => {
+                    // w is attached to tl (-dx grows it); h follows via aspect ratio.
+                    delta.y = -delta.x / aspect_ratio;
+                    new_tl.y -= delta.y / center_scale;
+                    new_br.y += delta.y / center_scale;
+                }
+                RH::MiddleRight => {
+                    // w is attached to br (dx grows it); h follows via aspect ratio.
+                    delta.y = delta.x / aspect_ratio;
+                    new_tl.y -= delta.y / center_scale;
+                    new_br.y += delta.y / center_scale;
                 }
             }
-            RH::MiddleRight => {
-                new_br.x += delta.x;
+        }
+
+        // keep center fixed if Alt is held down
+        match self {
+            RH::TopLeft => {
+                new_tl += delta;
                 if centered {
-                    new_tl.x -= delta.x;
+                    new_br -= delta;
                 }
             }
             RH::BottomRight => {
@@ -96,10 +163,12 @@ impl ResizeHandle {
                     new_tl -= delta;
                 }
             }
-            RH::BottomCenter => {
-                new_br.y += delta.y;
+            RH::TopRight => {
+                new_tl.y += delta.y;
+                new_br.x += delta.x;
                 if centered {
-                    new_tl.y -= delta.y;
+                    new_tl.x -= delta.x;
+                    new_br.y -= delta.y;
                 }
             }
             RH::BottomLeft => {
@@ -110,22 +179,28 @@ impl ResizeHandle {
                     new_br.x -= delta.x;
                 }
             }
-            RH::MiddleLeft => {
-                new_tl.x += delta.x;
-                if centered {
-                    new_br.x -= delta.x;
-                }
-            }
             RH::TopCenter => {
                 new_tl.y += delta.y;
                 if centered {
                     new_br.y -= delta.y;
                 }
             }
-            RH::TopLeft => {
-                new_tl += delta;
+            RH::BottomCenter => {
+                new_br.y += delta.y;
                 if centered {
-                    new_br -= delta;
+                    new_tl.y -= delta.y;
+                }
+            }
+            RH::MiddleLeft => {
+                new_tl.x += delta.x;
+                if centered {
+                    new_br.x -= delta.x;
+                }
+            }
+            RH::MiddleRight => {
+                new_br.x += delta.x;
+                if centered {
+                    new_tl.x -= delta.x;
                 }
             }
         }
@@ -138,17 +213,17 @@ impl ResizeHandle {
 
             let closest_aspect_ratio = get_closest_aspect_ratio(w / h, config.aspect_ratios());
             let aspect_ratio = closest_aspect_ratio.0 / closest_aspect_ratio.1;
-            let size = if h.abs() < f32::EPSILON {
+            let size = if h.abs() <= f32::EPSILON {
                 Vec2D::new(w, h) // fallback
             } else {
                 match self {
                     RH::TopCenter | RH::BottomCenter => Vec2D::new(h * aspect_ratio, h),
                     RH::MiddleLeft | RH::MiddleRight => Vec2D::new(w, w / aspect_ratio),
                     _ => {
-                        if h > w * aspect_ratio {
-                            Vec2D::new(h * aspect_ratio, h)
-                        } else {
+                        if w.abs() >= h.abs() * aspect_ratio {
                             Vec2D::new(w, w / aspect_ratio)
+                        } else {
+                            Vec2D::new(h * aspect_ratio, h)
                         }
                     }
                 }

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -19,7 +19,7 @@ use super::{
 pub struct Rectangle {
     origin: Vec2D,
     top_left: Vec2D,
-    size: Option<Vec2D>,
+    size: Vec2D,
     style: Style,
     centered: bool,
     finishing: bool,
@@ -27,10 +27,9 @@ pub struct Rectangle {
 
 impl Drawable for Rectangle {
     fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
-        let size = self.size?;
         Some(math::ensure_bounding_box(
             self.top_left,
-            self.top_left + size,
+            self.top_left + self.size,
         ))
     }
 
@@ -46,7 +45,7 @@ impl Drawable for Rectangle {
     fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         self.top_left = tl;
-        self.size = Some(br - tl);
+        self.size = br - tl;
         self.origin = tl;
         self.centered = false;
         self.finishing = true;
@@ -66,18 +65,13 @@ impl Drawable for Rectangle {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        let size = match self.size {
-            Some(s) => s,
-            None => return Ok(()), // early exit if none
-        };
-
         canvas.save();
         let mut path = Path::new();
         path.rounded_rect(
             self.top_left.x,
             self.top_left.y,
-            size.x,
-            size.y,
+            self.size.x,
+            self.size.y,
             APP_CONFIG.read().corner_roundness(),
         );
 
@@ -97,10 +91,10 @@ impl Drawable for Rectangle {
 
 impl Rectangle {
     fn calculate_shape(&mut self, sender: &Sender<SketchBoardInput>, event: &MouseEventMsg) {
-        let drag_box = DragBox::from_origin_delta(self.origin, event, sender);
+        let drag_box = DragBox::from_origin_delta(self.origin, self.size, event, sender);
         self.centered = drag_box.centered;
         self.top_left = drag_box.top_left;
-        self.size = Some(drag_box.size);
+        self.size = drag_box.size;
     }
 }
 
@@ -135,7 +129,7 @@ impl Tool for RectangleTool {
                 self.rectangle = Some(Rectangle {
                     origin: event.pos,
                     top_left: event.pos,
-                    size: None,
+                    size: Vec2D::zero(),
                     style: self.style,
                     centered: false,
                     finishing: false,

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -249,7 +249,7 @@ impl Drawable for Text {
             Some(bounds) => bounds,
             None => return false,
         };
-        hit_test_rectangle(pos, tl, Some(br - tl), tolerance, true)
+        hit_test_rectangle(pos, tl, br - tl, tolerance, true)
     }
 
     fn translate(&mut self, delta: Vec2D) {

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -693,7 +693,7 @@ impl Component for StyleToolbar {
             }
             StyleToolbarInput::DimensionsChanged(size) => {
                 self.output_dimensions = format!("{}x{}", size.x as u32, size.y as u32);
-                if size.x == 0.0 || size.y == 0.0 {
+                if size.x.abs() < f32::EPSILON || size.y.abs() < f32::EPSILON {
                     self.aspect_ratio = "".to_string();
                     return;
                 }


### PR DESCRIPTION
Closes #633

See also #647

Brings old Shift (square drawing) back with Ctrl as a "side" effect,
for size (0, 0) - as when beginning a drag - we cannot determine the 
aspect ration so we use 1:1 as a fallback and thus create a square.