### PR TITLE
feat: use unaliased image in zoom and export

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -46,7 +46,8 @@ pub struct FemtoVGArea {
 pub struct FemtoVgAreaMut {
     source_image: Option<Rc<ImgVec<RGBA8>>>,
     background_image: Pixbuf,
-    background_image_id: Option<femtovg::ImageId>,
+    background_image_id_aliased: Option<femtovg::ImageId>,
+    background_image_id_noaliasing: Option<femtovg::ImageId>,
     transparent_background_id: Option<femtovg::ImageId>,
     active_tool: Rc<RefCell<dyn Tool>>,
     scale_factor: f32,
@@ -128,7 +129,11 @@ impl GLAreaImpl for FemtoVGArea {
         let mut actions = self.request_render.borrow_mut();
 
         // if we got requested to render a frame
-        if let Some(a) = actions.take() {
+        if let Some(a) = actions.take()
+            // only render if there are actions (save, copy, etc.) to process
+            && !a.is_empty()
+        {
+            println!("Rendering requested for actions: {:?}", a);
             // render image
             let image = match self
                 .inner()
@@ -184,7 +189,8 @@ impl FemtoVGArea {
         self.inner().replace(FemtoVgAreaMut {
             source_image: None,
             background_image,
-            background_image_id: None,
+            background_image_id_noaliasing: None,
+            background_image_id_aliased: None,
             transparent_background_id: None,
             active_tool,
             scale_factor: 1.0,
@@ -571,12 +577,14 @@ impl FemtoVgAreaMut {
             return Err(anyhow::anyhow!("Invalid crop"));
         }
 
+        println!("Rendering native resolution with size: {:?}", size);
+
         // create render-target
         let image_id = canvas.create_image_empty(
             size.x as usize,
             size.y as usize,
             PixelFormat::Rgba8,
-            ImageFlags::empty(),
+            ImageFlags::NEAREST, // No aliasing
         )?;
         canvas.set_render_target(femtovg::RenderTarget::Image(image_id));
 
@@ -737,12 +745,35 @@ impl FemtoVgAreaMut {
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         onscreen: bool,
     ) -> Result<()> {
-        let background_image_id = match self.background_image_id {
-            Some(id) => id,
-            None => {
-                let id = super::create_image_from_pixbuf(canvas, &self.background_image)?;
-                self.background_image_id.replace(id);
-                id
+        let scale = canvas.transform().average_scale().max(f32::EPSILON);
+
+        // on screen use aliased background image unless zoomed in significantly
+        let background_image_id = if onscreen && scale < 5.0 {
+            match self.background_image_id_aliased {
+                Some(id) => id,
+                None => {
+                    let id = super::create_image_from_pixbuf(
+                        canvas,
+                        &self.background_image,
+                        ImageFlags::empty(),
+                    )?;
+                    self.background_image_id_aliased.replace(id);
+                    id
+                }
+            }
+        } else {
+            // for export or when zoomed in significantly, use non-aliased background image
+            match self.background_image_id_noaliasing {
+                Some(id) => id,
+                None => {
+                    let id = super::create_image_from_pixbuf(
+                        canvas,
+                        &self.background_image,
+                        ImageFlags::NEAREST | ImageFlags::GENERATE_MIPMAPS,
+                    )?;
+                    self.background_image_id_noaliasing.replace(id);
+                    id
+                }
             }
         };
 

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -133,7 +133,7 @@ impl GLAreaImpl for FemtoVGArea {
             // only render if there are actions (save, copy, etc.) to process
             && !a.is_empty()
         {
-            println!("Rendering requested for actions: {:?}", a);
+            eprintln!("Rendering requested for actions: {:?}", a);
             // render image
             let image = match self
                 .inner()
@@ -577,7 +577,7 @@ impl FemtoVgAreaMut {
             return Err(anyhow::anyhow!("Invalid crop"));
         }
 
-        println!("Rendering native resolution with size: {:?}", size);
+        eprintln!("Rendering native resolution with size: {:?}", size);
 
         // create render-target
         let image_id = canvas.create_image_empty(

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -33,7 +33,11 @@ pub fn font_stack() -> &'static [FontId] {
     FONT_STACK.get().map(Vec::as_slice).unwrap_or(&[])
 }
 
-pub fn create_image_from_pixbuf(canvas: &mut Canvas<OpenGl>, image: &Pixbuf) -> Result<ImageId> {
+pub fn create_image_from_pixbuf(
+    canvas: &mut Canvas<OpenGl>,
+    image: &Pixbuf,
+    flags: ImageFlags,
+) -> Result<ImageId> {
     let format = if image.has_alpha() {
         PixelFormat::Rgba8
     } else {
@@ -44,7 +48,7 @@ pub fn create_image_from_pixbuf(canvas: &mut Canvas<OpenGl>, image: &Pixbuf) -> 
         image.width() as usize,
         image.height() as usize,
         format,
-        ImageFlags::empty(),
+        flags,
     )?;
 
     // extract values

--- a/src/tools/image.rs
+++ b/src/tools/image.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 
 use anyhow::Result;
-use femtovg::{ImageId, Paint, Path};
+use femtovg::{ImageFlags, ImageId, Paint, Path};
 use relm4::gtk::gdk_pixbuf::Pixbuf;
 use relm4::gtk::prelude::*;
 use relm4::{RelmWidgetExt, Sender, gtk};
@@ -173,7 +173,7 @@ impl Drawable for Image {
         let image_id = match self.cached_image_id.get() {
             Some(id) => id,
             None => {
-                let id = create_image_from_pixbuf(canvas, &self.pixbuf)?;
+                let id = create_image_from_pixbuf(canvas, &self.pixbuf, ImageFlags::empty())?;
                 self.cached_image_id.set(Some(id));
                 id
             }


### PR DESCRIPTION
See #645
Closes #613

- In zoom > 5 image becomes crisp and pixels are recognized.
- Fixes unnecessary rendering in native resolution - it is only required when a action is triggered. Found this while zooming unaliased image became slow for large images.