### PR TITLE
fix: show center marker in pointer tool

### DIFF
--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -127,10 +127,6 @@ impl Drawable for Blur {
             bounds,
         );
         if self.editing {
-            if self.centered {
-                draw_center_marker(canvas, self.origin);
-            }
-
             // set style
             let mut color = Color::black();
             color.set_alphaf(0.6);
@@ -152,9 +148,6 @@ impl Drawable for Blur {
             if size.x <= 0.0 || size.y <= 0.0 {
                 return Ok(());
             }
-
-            canvas.save();
-            canvas.flush();
 
             // create new cached image
             if self.cached_image.borrow().is_none() {
@@ -189,9 +182,21 @@ impl Drawable for Blur {
                     1f32,
                 ),
             );
-            canvas.restore();
         }
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -17,7 +17,7 @@ pub struct Crop {
     top_left: Vec2D,
     size: Vec2D,
     centered: bool,
-    finishing: bool,
+    editing: bool,
     active: bool,
 }
 
@@ -70,10 +70,6 @@ impl Drawable for Crop {
         _font: femtovg::FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.origin);
-        }
-
         let size = self.size;
 
         let shadow_paint = Paint::color(Color::rgbaf(0.0, 0.0, 0.0, 0.5))
@@ -88,12 +84,22 @@ impl Drawable for Crop {
         let mut border_path = Path::new();
         border_path.rect(self.top_left.x, self.top_left.y, size.x, size.y);
 
-        canvas.save();
         canvas.fill_path(&shadow_path, &shadow_paint);
         canvas.stroke_path(&border_path, &border_paint);
 
-        canvas.restore();
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -127,7 +133,7 @@ impl Tool for CropTool {
                     top_left: event.pos,
                     size: Vec2D::zero(),
                     centered: false,
-                    finishing: false,
+                    editing: true,
                     active: true,
                 });
                 ToolUpdateResult::Redraw
@@ -141,7 +147,7 @@ impl Tool for CropTool {
                     self.crop = None;
                     return ToolUpdateResult::Redraw;
                 }
-                crop.finishing = true;
+                crop.editing = false;
                 crop.calculate_shape(self.sender.as_ref().unwrap(), &event);
                 ToolUpdateResult::Commit(crop.clone_box())
             }

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -20,7 +20,7 @@ pub struct Ellipse {
     radii: Vec2D,
     style: Style,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 impl Drawable for Ellipse {
@@ -58,7 +58,7 @@ impl Drawable for Ellipse {
         self.origin = center;
         self.radii = (br - tl).abs() / 2.0;
         self.centered = false;
-        self.finishing = true;
+        self.editing = false;
     }
 
     fn get_style(&self) -> Option<&Style> {
@@ -75,21 +75,26 @@ impl Drawable for Ellipse {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
         let mut path = Path::new();
         path.ellipse(self.middle.x, self.middle.y, self.radii.x, self.radii.y);
-
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.middle);
-        }
 
         if self.style.fill {
             canvas.fill_path(&path, &self.style.into());
         }
         canvas.stroke_path(&path, &self.style.into());
-        canvas.restore();
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.middle);
+        }
 
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -140,8 +145,8 @@ impl Tool for EllipseTool {
                     middle: event.pos,
                     radii: Vec2D::zero(),
                     style: self.style,
-                    centered: true,
-                    finishing: false,
+                    centered: false,
+                    editing: true,
                 });
 
                 ToolUpdateResult::Redraw
@@ -152,7 +157,7 @@ impl Tool for EllipseTool {
                 }
 
                 if let Some(ellipse) = &mut self.ellipse {
-                    ellipse.finishing = true;
+                    ellipse.editing = false;
                     if event.pos == Vec2D::zero() {
                         self.ellipse = None;
 

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -48,7 +48,7 @@ struct BlockHighlight {
     top_left: Vec2D,
     size: Vec2D,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -107,10 +107,6 @@ impl Highlight for Highlighter<BlockHighlight> {
     fn highlight(&self, canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>) -> Result<()> {
         let (pos, size) = math::rect_ensure_positive_size(self.data.top_left, self.data.size);
 
-        if !self.data.finishing && self.data.centered {
-            draw_center_marker(canvas, self.data.origin);
-        }
-
         let mut shadow_path = Path::new();
         shadow_path.rounded_rect(
             pos.x,
@@ -128,6 +124,11 @@ impl Highlight for Highlighter<BlockHighlight> {
         ));
 
         canvas.fill_path(&shadow_path, &shadow_paint);
+
+        if self.data.editing && self.data.centered {
+            draw_center_marker(canvas, self.data.origin);
+        }
+
         Ok(())
     }
 }
@@ -303,6 +304,18 @@ impl Drawable for HighlightKind {
             HighlightKind::Freehand(highlighter) => highlighter.highlight(canvas),
         }
     }
+
+    fn set_centered(&mut self, centered: bool) {
+        if let HighlightKind::Block(highlighter) = self {
+            highlighter.data.centered = centered;
+            highlighter.data.origin = highlighter.data.top_left + highlighter.data.size / 2.0;
+        }
+    }
+    fn set_editing(&mut self, editing: bool) {
+        if let HighlightKind::Block(highlighter) = self {
+            highlighter.data.editing = editing;
+        }
+    }
 }
 
 impl Tool for HighlightTool {
@@ -346,7 +359,7 @@ impl Tool for HighlightTool {
                                     top_left: event.pos,
                                     size: Vec2D::zero(),
                                     centered: false,
-                                    finishing: false,
+                                    editing: true,
                                 },
                                 style: self.style,
                             }))
@@ -438,7 +451,7 @@ impl Tool for HighlightTool {
                 }
 
                 if let HighlightKind::Block(highlighter) = &mut *highlighter_kind {
-                    highlighter.data.finishing = true;
+                    highlighter.data.editing = false;
                 }
 
                 let result = highlighter_kind.clone_box();

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -244,9 +244,14 @@ pub trait Drawable: DrawableClone + Debug + AsAny {
     fn get_style(&self) -> Option<&Style> {
         None
     }
-
     fn get_style_mut(&mut self) -> Option<&mut Style> {
         None
+    }
+    fn set_centered(&mut self, centered: bool) {
+        let _ = centered;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        let _ = editing;
     }
 }
 

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -326,11 +326,6 @@ impl Drawable for Pixelate {
             bounds,
         );
 
-        self.renderable.set(true);
-
-        canvas.save();
-        canvas.flush();
-
         if (self.cached_image.borrow().is_none() || self.editing)
             && let Some(x) = self.pixelate(canvas, image, pos, size)?
         {
@@ -352,12 +347,21 @@ impl Drawable for Pixelate {
                     1f32,
                 ),
             );
-            canvas.restore();
         }
+
         if self.editing && self.centered {
-            draw_center_marker(canvas, self.origin);
+            draw_center_marker(canvas, pos + size / 2.0);
         }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -443,7 +447,7 @@ impl Tool for PixelateTool {
                     style: self.style,
                     cached_image: RefCell::new(None),
                     mode: self.mode,
-                    renderable: Cell::new(false),
+                    renderable: Cell::new(true),
                 });
 
                 ToolUpdateResult::Redraw

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -10,7 +10,7 @@ use crate::{
     configuration::APP_CONFIG,
     math::{Vec2D, ensure_bounding_box, get_closest_aspect_ratio},
     sketch_board::{KeyEventMsg, MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
-    tools::RenderingMode,
+    tools::{RenderingMode, drag_box::draw_center_marker},
 };
 
 use super::{Drawable, InputContext, Tool, ToolUpdateResult, Tools};
@@ -291,6 +291,8 @@ struct SelectionOverlay {
     tl: Vec2D,
     br: Vec2D,
     scaled_handle_size: Cell<f32>,
+    centered: bool,
+    editing: bool,
 }
 
 impl Drawable for SelectionOverlay {
@@ -304,8 +306,6 @@ impl Drawable for SelectionOverlay {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
-
         // draw handles in inverse zoom scale so the visual size stays constant on screen.
         let scale = canvas.transform().average_scale().max(f32::EPSILON);
 
@@ -336,14 +336,17 @@ impl Drawable for SelectionOverlay {
                 handle_size,
                 handle_size,
             );
-            canvas.fill_path(&hpath, &Paint::color(Color::rgba(255, 255, 255, 255)));
+            canvas.fill_path(&hpath, &Paint::color(Color::white()));
             canvas.stroke_path(
                 &hpath,
                 &Paint::color(Color::rgba(70, 130, 180, 255)).with_line_width(stroke_width),
             );
         }
 
-        canvas.restore();
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.tl + (self.br - self.tl) * 0.5);
+        }
+
         Ok(())
     }
 }
@@ -578,6 +581,8 @@ impl PointerTool {
             br: br + Vec2D::new(border_outset_x, border_outset_y),
             // is updated in draw() to maintain constant on-screen size regardless of zoom level
             scaled_handle_size: Cell::new(HANDLE_SIZE),
+            centered: false,
+            editing: true,
         });
 
         if let Some(sender) = &self.sender {
@@ -738,8 +743,9 @@ impl Tool for PointerTool {
                     let (new_tl, new_br) = handle.resize(event, orig_bounds.0, orig_bounds.1);
                     let mut preview = original.clone_box();
                     preview.resize_bounds(new_tl, new_br);
+                    preview.set_centered(event.modifier.intersects(ModifierType::ALT_MASK));
+                    preview.set_editing(true);
                     self.emit_dimensions_update(preview.as_ref());
-
                     self.update_selection_bounds(new_tl, new_br);
                     self.preview = Some(preview);
                     ToolUpdateResult::Redraw
@@ -794,6 +800,8 @@ impl Tool for PointerTool {
                                 handle.resize(event, orig_bounds.0, orig_bounds.1);
                             let mut final_drawable = original;
                             final_drawable.resize_bounds(new_tl, new_br);
+                            final_drawable.set_centered(false);
+                            final_drawable.set_editing(false);
                             self.update_selection_bounds(new_tl, new_br);
                             self.preview = None;
                             ToolUpdateResult::ReplaceDrawable(index, final_drawable)

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -22,7 +22,7 @@ pub struct Rectangle {
     size: Vec2D,
     style: Style,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 impl Drawable for Rectangle {
@@ -48,7 +48,7 @@ impl Drawable for Rectangle {
         self.size = br - tl;
         self.origin = tl;
         self.centered = false;
-        self.finishing = true;
+        self.editing = false;
     }
 
     fn get_style(&self) -> Option<&Style> {
@@ -65,7 +65,6 @@ impl Drawable for Rectangle {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
         let mut path = Path::new();
         path.rounded_rect(
             self.top_left.x,
@@ -75,17 +74,24 @@ impl Drawable for Rectangle {
             APP_CONFIG.read().corner_roundness(),
         );
 
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.origin);
-        }
-
         if self.style.fill {
             canvas.fill_path(&path, &self.style.into());
         }
         canvas.stroke_path(&path, &self.style.into());
-        canvas.restore();
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
 
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -132,7 +138,7 @@ impl Tool for RectangleTool {
                     size: Vec2D::zero(),
                     style: self.style,
                     centered: false,
-                    finishing: false,
+                    editing: true,
                 });
 
                 ToolUpdateResult::Redraw
@@ -143,7 +149,7 @@ impl Tool for RectangleTool {
                 }
 
                 if let Some(rectangle) = &mut self.rectangle {
-                    rectangle.finishing = true;
+                    rectangle.editing = false;
                     if event.pos == Vec2D::zero() {
                         self.rectangle = None;
                         ToolUpdateResult::Redraw


### PR DESCRIPTION
Fixes #653

Also change the state vars across all tools to be the same name,
i.e. `editing` and not `finishing`.

Draw center marker always last, as it will not be visible on filled
shapes otherwise.