### PR TITLE
fix: make selection border zoom independent

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -407,8 +407,9 @@ impl FemtoVgAreaMut {
     // Hit-test all drawables and return all indices whose bounds contain `pos`, in order from topmost to bottommost.
     pub fn hit_test(&self, pos: Vec2D) -> Vec<usize> {
         let mut results = Vec::new();
+        let tolerance = crate::tools::HIT_BORDER_TOLERANCE / self.scale_factor;
         for (i, d) in self.drawables.iter().enumerate().rev() {
-            if d.hit_test(pos, crate::tools::HIT_BORDER_TOLERANCE) {
+            if d.hit_test(pos, tolerance) {
                 results.push(i);
             }
         }

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -127,10 +127,6 @@ impl Drawable for Blur {
             bounds,
         );
         if self.editing {
-            if self.centered {
-                draw_center_marker(canvas, self.origin);
-            }
-
             // set style
             let mut color = Color::black();
             color.set_alphaf(0.6);
@@ -152,9 +148,6 @@ impl Drawable for Blur {
             if size.x <= 0.0 || size.y <= 0.0 {
                 return Ok(());
             }
-
-            canvas.save();
-            canvas.flush();
 
             // create new cached image
             if self.cached_image.borrow().is_none() {
@@ -189,9 +182,21 @@ impl Drawable for Blur {
                     1f32,
                 ),
             );
-            canvas.restore();
         }
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -17,7 +17,7 @@ pub struct Crop {
     top_left: Vec2D,
     size: Vec2D,
     centered: bool,
-    finishing: bool,
+    editing: bool,
     active: bool,
 }
 
@@ -70,10 +70,6 @@ impl Drawable for Crop {
         _font: femtovg::FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.origin);
-        }
-
         let size = self.size;
 
         let shadow_paint = Paint::color(Color::rgbaf(0.0, 0.0, 0.0, 0.5))
@@ -88,12 +84,22 @@ impl Drawable for Crop {
         let mut border_path = Path::new();
         border_path.rect(self.top_left.x, self.top_left.y, size.x, size.y);
 
-        canvas.save();
         canvas.fill_path(&shadow_path, &shadow_paint);
         canvas.stroke_path(&border_path, &border_paint);
 
-        canvas.restore();
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -127,7 +133,7 @@ impl Tool for CropTool {
                     top_left: event.pos,
                     size: Vec2D::zero(),
                     centered: false,
-                    finishing: false,
+                    editing: true,
                     active: true,
                 });
                 ToolUpdateResult::Redraw
@@ -141,7 +147,7 @@ impl Tool for CropTool {
                     self.crop = None;
                     return ToolUpdateResult::Redraw;
                 }
-                crop.finishing = true;
+                crop.editing = false;
                 crop.calculate_shape(self.sender.as_ref().unwrap(), &event);
                 ToolUpdateResult::Commit(crop.clone_box())
             }

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     math::{self, Vec2D},
     sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
-    tools::{RenderingMode, hit_test_rectangle},
+    tools::{RenderingMode, drag_box::draw_rect_marker, hit_test_rectangle},
 };
 use anyhow::Result;
 use femtovg::{Color, Paint, Path};
@@ -70,26 +70,34 @@ impl Drawable for Crop {
         _font: femtovg::FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        let size = self.size;
+        let shadow_paint = Paint::color(Color::rgbaf(
+            0.0,
+            0.0,
+            0.0,
+            if self.editing { 0.5 } else { 0.9 },
+        ))
+        .with_fill_rule(femtovg::FillRule::EvenOdd);
 
-        let shadow_paint = Paint::color(Color::rgbaf(0.0, 0.0, 0.0, 0.5))
-            .with_fill_rule(femtovg::FillRule::EvenOdd);
         let (img_tl, img_br) = bounds;
-        let img_size = img_br - img_tl;
+        // increase it a bit as otherwise subpixel of the image will still be visible
+        let shadow_tl = (img_tl).min(self.top_left) - 1.0;
+        let shadow_br = (img_br).max(self.top_left + self.size);
+        let shadow_size = shadow_br - shadow_tl + 2.0;
         let mut shadow_path = Path::new();
-        shadow_path.rect(img_tl.x, img_tl.y, img_size.x, img_size.y);
-        shadow_path.rect(self.top_left.x, self.top_left.y, size.x, size.y);
-
-        let border_paint = Paint::color(Color::rgbf(0.1, 0.1, 0.1)).with_line_width(2.0);
-        let mut border_path = Path::new();
-        border_path.rect(self.top_left.x, self.top_left.y, size.x, size.y);
+        // the outer rectangle of the shadow
+        shadow_path.rect(shadow_tl.x, shadow_tl.y, shadow_size.x, shadow_size.y);
+        let tl = self.top_left;
+        let size = self.size;
+        // the inner rectangle of the shadow
+        shadow_path.rect(tl.x, tl.y, size.x, size.y);
 
         canvas.fill_path(&shadow_path, &shadow_paint);
-        canvas.stroke_path(&border_path, &border_paint);
 
         if self.editing && self.centered {
             draw_center_marker(canvas, self.origin);
         }
+
+        draw_rect_marker(canvas, tl, size, false);
 
         Ok(())
     }

--- a/src/tools/drag_box.rs
+++ b/src/tools/drag_box.rs
@@ -87,9 +87,56 @@ impl DragBox {
     }
 }
 
+fn inner_color() -> Paint {
+    Paint::color(Color::white())
+}
+
+fn outer_color() -> Paint {
+    Paint::color(Color::rgb(70u8, 130u8, 180u8))
+}
+
 pub fn draw_center_marker(canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>, center: Vec2D) {
-    let mut helpers = Path::new();
-    helpers.circle(center.x, center.y, 2.0);
-    let paint = Paint::color(Color::rgba(128, 128, 128, 255)).with_line_width(1.0);
-    canvas.stroke_path(&helpers, &paint);
+    // in inverse zoom scale so the visual size stays constant on screen
+    let scale = canvas.transform().average_scale().max(f32::EPSILON);
+
+    let radius = 4.0 / scale;
+    let mut path = Path::new();
+    path.circle(center.x, center.y, radius);
+    canvas.fill_path(&path, &inner_color());
+    canvas.stroke_path(&path, &outer_color().with_line_width(1.5 / scale));
+}
+
+pub fn draw_rect_marker(
+    canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+    top_left: Vec2D,
+    size: Vec2D,
+    filled: bool,
+) {
+    // draw in inverse zoom scale so the visual size stays constant on screen
+    let scale = canvas.transform().average_scale().max(f32::EPSILON);
+    let line_width = 1.5 / scale;
+
+    let border_paint = inner_color().with_line_width(line_width);
+    let mut border_path = Path::new();
+
+    border_path.rect(top_left.x, top_left.y, size.x, size.y);
+    if filled {
+        canvas.fill_path(&border_path, &border_paint);
+    } else {
+        canvas.stroke_path(&border_path, &border_paint);
+    }
+
+    let border_paint = outer_color().with_line_width(line_width);
+    let mut tl = top_left;
+    let mut size = size;
+
+    // set-out to draw the border outside the original rectangle, e.g. for crop
+    if !filled {
+        tl = tl - line_width;
+        size = size + 2.0 * line_width;
+    }
+
+    let mut border_path = Path::new();
+    border_path.rect(tl.x, tl.y, size.x, size.y);
+    canvas.stroke_path(&border_path, &border_paint);
 }

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -20,7 +20,7 @@ pub struct Ellipse {
     radii: Vec2D,
     style: Style,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 impl Drawable for Ellipse {
@@ -58,7 +58,7 @@ impl Drawable for Ellipse {
         self.origin = center;
         self.radii = (br - tl).abs() / 2.0;
         self.centered = false;
-        self.finishing = true;
+        self.editing = false;
     }
 
     fn get_style(&self) -> Option<&Style> {
@@ -75,21 +75,26 @@ impl Drawable for Ellipse {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
         let mut path = Path::new();
         path.ellipse(self.middle.x, self.middle.y, self.radii.x, self.radii.y);
-
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.middle);
-        }
 
         if self.style.fill {
             canvas.fill_path(&path, &self.style.into());
         }
         canvas.stroke_path(&path, &self.style.into());
-        canvas.restore();
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.middle);
+        }
 
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -140,8 +145,8 @@ impl Tool for EllipseTool {
                     middle: event.pos,
                     radii: Vec2D::zero(),
                     style: self.style,
-                    centered: true,
-                    finishing: false,
+                    centered: false,
+                    editing: true,
                 });
 
                 ToolUpdateResult::Redraw
@@ -152,7 +157,7 @@ impl Tool for EllipseTool {
                 }
 
                 if let Some(ellipse) = &mut self.ellipse {
-                    ellipse.finishing = true;
+                    ellipse.editing = false;
                     if event.pos == Vec2D::zero() {
                         self.ellipse = None;
 

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -48,7 +48,7 @@ struct BlockHighlight {
     top_left: Vec2D,
     size: Vec2D,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -107,10 +107,6 @@ impl Highlight for Highlighter<BlockHighlight> {
     fn highlight(&self, canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>) -> Result<()> {
         let (pos, size) = math::rect_ensure_positive_size(self.data.top_left, self.data.size);
 
-        if !self.data.finishing && self.data.centered {
-            draw_center_marker(canvas, self.data.origin);
-        }
-
         let mut shadow_path = Path::new();
         shadow_path.rounded_rect(
             pos.x,
@@ -128,6 +124,11 @@ impl Highlight for Highlighter<BlockHighlight> {
         ));
 
         canvas.fill_path(&shadow_path, &shadow_paint);
+
+        if self.data.editing && self.data.centered {
+            draw_center_marker(canvas, self.data.origin);
+        }
+
         Ok(())
     }
 }
@@ -303,6 +304,18 @@ impl Drawable for HighlightKind {
             HighlightKind::Freehand(highlighter) => highlighter.highlight(canvas),
         }
     }
+
+    fn set_centered(&mut self, centered: bool) {
+        if let HighlightKind::Block(highlighter) = self {
+            highlighter.data.centered = centered;
+            highlighter.data.origin = highlighter.data.top_left + highlighter.data.size / 2.0;
+        }
+    }
+    fn set_editing(&mut self, editing: bool) {
+        if let HighlightKind::Block(highlighter) = self {
+            highlighter.data.editing = editing;
+        }
+    }
 }
 
 impl Tool for HighlightTool {
@@ -346,7 +359,7 @@ impl Tool for HighlightTool {
                                     top_left: event.pos,
                                     size: Vec2D::zero(),
                                     centered: false,
-                                    finishing: false,
+                                    editing: true,
                                 },
                                 style: self.style,
                             }))
@@ -438,7 +451,7 @@ impl Tool for HighlightTool {
                 }
 
                 if let HighlightKind::Block(highlighter) = &mut *highlighter_kind {
-                    highlighter.data.finishing = true;
+                    highlighter.data.editing = false;
                 }
 
                 let result = highlighter_kind.clone_box();

--- a/src/tools/image.rs
+++ b/src/tools/image.rs
@@ -1,11 +1,12 @@
 use std::cell::Cell;
 
 use anyhow::Result;
-use femtovg::{Color, ImageId, Paint, Path};
+use femtovg::{ImageId, Paint, Path};
 use relm4::gtk::gdk_pixbuf::Pixbuf;
 use relm4::gtk::prelude::*;
 use relm4::{RelmWidgetExt, Sender, gtk};
 
+use crate::tools::drag_box::draw_rect_marker;
 use crate::{
     configuration::APP_CONFIG,
     femtovg_area::create_image_from_pixbuf,
@@ -74,18 +75,7 @@ impl Drawable for DragPreview {
             draw_center_marker(canvas, self.origin);
         }
 
-        let DragBox { top_left, size, .. } = self.drag_box;
-        let mut path = Path::new();
-        path.rect(top_left.x, top_left.y, size.x, size.y);
-        // a light line under a dark one, so the box shows on any screenshot
-        canvas.stroke_path(
-            &path,
-            &Paint::color(Color::rgbf(1.0, 1.0, 1.0)).with_line_width(3.0),
-        );
-        canvas.stroke_path(
-            &path,
-            &Paint::color(Color::rgbf(0.1, 0.1, 0.1)).with_line_width(1.0),
-        );
+        draw_rect_marker(canvas, self.drag_box.top_left, self.drag_box.size, false);
         Ok(())
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -244,9 +244,14 @@ pub trait Drawable: DrawableClone + Debug + AsAny {
     fn get_style(&self) -> Option<&Style> {
         None
     }
-
     fn get_style_mut(&mut self) -> Option<&mut Style> {
         None
+    }
+    fn set_centered(&mut self, centered: bool) {
+        let _ = centered;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        let _ = editing;
     }
 }
 

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -326,11 +326,6 @@ impl Drawable for Pixelate {
             bounds,
         );
 
-        self.renderable.set(true);
-
-        canvas.save();
-        canvas.flush();
-
         if (self.cached_image.borrow().is_none() || self.editing)
             && let Some(x) = self.pixelate(canvas, image, pos, size)?
         {
@@ -352,12 +347,21 @@ impl Drawable for Pixelate {
                     1f32,
                 ),
             );
-            canvas.restore();
         }
+
         if self.editing && self.centered {
-            draw_center_marker(canvas, self.origin);
+            draw_center_marker(canvas, pos + size / 2.0);
         }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -443,7 +447,7 @@ impl Tool for PixelateTool {
                     style: self.style,
                     cached_image: RefCell::new(None),
                     mode: self.mode,
-                    renderable: Cell::new(false),
+                    renderable: Cell::new(true),
                 });
 
                 ToolUpdateResult::Redraw

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -293,7 +293,7 @@ pub fn hit_handle(
 struct SelectionOverlay {
     tl: Vec2D,
     br: Vec2D,
-    scaled_handle_size: Cell<f32>,
+    scale: Cell<f32>,
     centered: bool,
     editing: bool,
 }
@@ -309,15 +309,20 @@ impl Drawable for SelectionOverlay {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
+        let scale = canvas.transform().average_scale().max(f32::EPSILON);
+        // to be used at other places where the scale is not available
+        self.scale.set(scale);
+
         // Selection rectangle
-        draw_rect_marker(canvas, self.tl, self.br - self.tl, false);
+        let out_set = SELECTION_BORDER_OUTSET / scale;
+        let tl = self.tl - out_set;
+        let size = (self.br - self.tl) + out_set * 2.0;
+        draw_rect_marker(canvas, tl, size, false);
 
         // Resize handles
         // draw handles in inverse zoom scale so the visual size stays constant on screen.
-        let scale = canvas.transform().average_scale().max(f32::EPSILON);
         let handle_half = HANDLE_HALF / scale;
         let handle_size = HANDLE_SIZE / scale;
-        self.scaled_handle_size.set(handle_size);
         for handle in ResizeHandle::all() {
             let tl = handle.center(self.tl, self.br) - handle_half;
             draw_rect_marker(canvas, tl, Vec2D::new(handle_size, handle_size), true);
@@ -471,7 +476,7 @@ impl PointerTool {
     // Returns the handle under `pos` given the current selection bounds.
     pub fn hit_test_handles(&self, pos: Vec2D) -> Option<ResizeHandle> {
         let overlay = self.selection_overlay.as_ref()?;
-        let scaled_handle_size = overlay.scaled_handle_size.get();
+        let scaled_handle_size = HANDLE_SIZE / overlay.scale.get();
         hit_handle(scaled_handle_size, pos, overlay.tl, overlay.br)
     }
 
@@ -536,31 +541,11 @@ impl PointerTool {
         let (tl, br) = ensure_bounding_box(tl, br);
         self.selected_bounds = Some((tl, br));
 
-        let handle_size = if let Some(overlay) = &self.selection_overlay {
-            overlay.scaled_handle_size.get()
-        } else {
-            HANDLE_SIZE
-        };
-
-        // Add extra outset to selection overlay if the drawable is small to reduce handle overlapping
-        let w = br.x - tl.x + SELECTION_BORDER_OUTSET * 2.0;
-        let h = br.y - tl.y + SELECTION_BORDER_OUTSET * 2.0;
-        let border_outset_x = if w < 3.0 * handle_size {
-            HANDLE_SIZE
-        } else {
-            SELECTION_BORDER_OUTSET
-        };
-        let border_outset_y = if h < 3.0 * handle_size {
-            HANDLE_SIZE
-        } else {
-            SELECTION_BORDER_OUTSET
-        };
-
         self.selection_overlay = Some(SelectionOverlay {
-            tl: tl - Vec2D::new(border_outset_x, border_outset_y),
-            br: br + Vec2D::new(border_outset_x, border_outset_y),
+            tl,
+            br,
             // is updated in draw() to maintain constant on-screen size regardless of zoom level
-            scaled_handle_size: Cell::new(HANDLE_SIZE),
+            scale: Cell::new(1.0),
             centered: false,
             editing: true,
         });

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -10,7 +10,7 @@ use crate::{
     configuration::APP_CONFIG,
     math::{Vec2D, ensure_bounding_box, get_closest_aspect_ratio},
     sketch_board::{KeyEventMsg, MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
-    tools::RenderingMode,
+    tools::{RenderingMode, drag_box::draw_center_marker},
 };
 
 use super::{Drawable, InputContext, Tool, ToolUpdateResult, Tools};
@@ -291,6 +291,8 @@ struct SelectionOverlay {
     tl: Vec2D,
     br: Vec2D,
     scaled_handle_size: Cell<f32>,
+    centered: bool,
+    editing: bool,
 }
 
 impl Drawable for SelectionOverlay {
@@ -304,8 +306,6 @@ impl Drawable for SelectionOverlay {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
-
         // draw handles in inverse zoom scale so the visual size stays constant on screen.
         let scale = canvas.transform().average_scale().max(f32::EPSILON);
 
@@ -336,14 +336,17 @@ impl Drawable for SelectionOverlay {
                 handle_size,
                 handle_size,
             );
-            canvas.fill_path(&hpath, &Paint::color(Color::rgba(255, 255, 255, 255)));
+            canvas.fill_path(&hpath, &Paint::color(Color::white()));
             canvas.stroke_path(
                 &hpath,
                 &Paint::color(Color::rgba(70, 130, 180, 255)).with_line_width(stroke_width),
             );
         }
 
-        canvas.restore();
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.tl + (self.br - self.tl) * 0.5);
+        }
+
         Ok(())
     }
 }
@@ -578,6 +581,8 @@ impl PointerTool {
             br: br + Vec2D::new(border_outset_x, border_outset_y),
             // is updated in draw() to maintain constant on-screen size regardless of zoom level
             scaled_handle_size: Cell::new(HANDLE_SIZE),
+            centered: false,
+            editing: true,
         });
 
         if let Some(sender) = &self.sender {
@@ -738,8 +743,9 @@ impl Tool for PointerTool {
                     let (new_tl, new_br) = handle.resize(event, orig_bounds.0, orig_bounds.1);
                     let mut preview = original.clone_box();
                     preview.resize_bounds(new_tl, new_br);
+                    preview.set_centered(event.modifier.intersects(ModifierType::ALT_MASK));
+                    preview.set_editing(true);
                     self.emit_dimensions_update(preview.as_ref());
-
                     self.update_selection_bounds(new_tl, new_br);
                     self.preview = Some(preview);
                     ToolUpdateResult::Redraw
@@ -794,6 +800,8 @@ impl Tool for PointerTool {
                                 handle.resize(event, orig_bounds.0, orig_bounds.1);
                             let mut final_drawable = original;
                             final_drawable.resize_bounds(new_tl, new_br);
+                            final_drawable.set_centered(false);
+                            final_drawable.set_editing(false);
                             self.update_selection_bounds(new_tl, new_br);
                             self.preview = None;
                             ToolUpdateResult::ReplaceDrawable(index, final_drawable)

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use femtovg::{Color, FontId, Paint, Path};
+use femtovg::FontId;
 use relm4::{
     Sender,
     gtk::{self, gdk::ModifierType, prelude::WidgetExt},
@@ -10,7 +10,10 @@ use crate::{
     configuration::APP_CONFIG,
     math::{Vec2D, ensure_bounding_box, get_closest_aspect_ratio},
     sketch_board::{KeyEventMsg, MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
-    tools::{RenderingMode, drag_box::draw_center_marker},
+    tools::{
+        RenderingMode,
+        drag_box::{draw_center_marker, draw_rect_marker},
+    },
 };
 
 use super::{Drawable, InputContext, Tool, ToolUpdateResult, Tools};
@@ -306,41 +309,18 @@ impl Drawable for SelectionOverlay {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        // draw handles in inverse zoom scale so the visual size stays constant on screen.
-        let scale = canvas.transform().average_scale().max(f32::EPSILON);
-
         // Selection rectangle
-        let stroke_width = 1.5 / scale;
-        let mut rect = Path::new();
-        rect.rect(
-            self.tl.x,
-            self.tl.y,
-            self.br.x - self.tl.x,
-            self.br.y - self.tl.y,
-        );
-        canvas.stroke_path(
-            &rect,
-            &Paint::color(Color::rgba(70, 130, 180, 220)).with_line_width(stroke_width),
-        );
+        draw_rect_marker(canvas, self.tl, self.br - self.tl, false);
 
         // Resize handles
+        // draw handles in inverse zoom scale so the visual size stays constant on screen.
+        let scale = canvas.transform().average_scale().max(f32::EPSILON);
         let handle_half = HANDLE_HALF / scale;
         let handle_size = HANDLE_SIZE / scale;
         self.scaled_handle_size.set(handle_size);
         for handle in ResizeHandle::all() {
-            let c = handle.center(self.tl, self.br);
-            let mut hpath = Path::new();
-            hpath.rect(
-                c.x - handle_half,
-                c.y - handle_half,
-                handle_size,
-                handle_size,
-            );
-            canvas.fill_path(&hpath, &Paint::color(Color::white()));
-            canvas.stroke_path(
-                &hpath,
-                &Paint::color(Color::rgba(70, 130, 180, 255)).with_line_width(stroke_width),
-            );
+            let tl = handle.center(self.tl, self.br) - handle_half;
+            draw_rect_marker(canvas, tl, Vec2D::new(handle_size, handle_size), true);
         }
 
         if self.editing && self.centered {

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -22,7 +22,7 @@ pub struct Rectangle {
     size: Vec2D,
     style: Style,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 impl Drawable for Rectangle {
@@ -48,7 +48,7 @@ impl Drawable for Rectangle {
         self.size = br - tl;
         self.origin = tl;
         self.centered = false;
-        self.finishing = true;
+        self.editing = false;
     }
 
     fn get_style(&self) -> Option<&Style> {
@@ -65,7 +65,6 @@ impl Drawable for Rectangle {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
         let mut path = Path::new();
         path.rounded_rect(
             self.top_left.x,
@@ -75,17 +74,24 @@ impl Drawable for Rectangle {
             APP_CONFIG.read().corner_roundness(),
         );
 
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.origin);
-        }
-
         if self.style.fill {
             canvas.fill_path(&path, &self.style.into());
         }
         canvas.stroke_path(&path, &self.style.into());
-        canvas.restore();
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
 
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -132,7 +138,7 @@ impl Tool for RectangleTool {
                     size: Vec2D::zero(),
                     style: self.style,
                     centered: false,
-                    finishing: false,
+                    editing: true,
                 });
 
                 ToolUpdateResult::Redraw
@@ -143,7 +149,7 @@ impl Tool for RectangleTool {
                 }
 
                 if let Some(rectangle) = &mut self.rectangle {
-                    rectangle.finishing = true;
+                    rectangle.editing = false;
                     if event.pos == Vec2D::zero() {
                         self.rectangle = None;
                         ToolUpdateResult::Redraw


### PR DESCRIPTION
Closes #650

The handles now will sit on the bounds of the shape and
the selection border sits on the outer border of the
handles and thus still will not overlay small shapes.

Also when zoomed in hit test is zoom independent.