### PR TITLE
feat: export crop selection outside image

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -699,6 +699,12 @@ impl FemtoVgAreaMut {
             preview.draw(canvas, font, bounds)?;
         }
 
+        // if not onscreen, flush and return early as the rest is not for export
+        if !onscreen {
+            canvas.flush();
+            return Ok(());
+        }
+
         // draw crop on top of everything but pointer tool selection overlay
         if self.active_tool.borrow().get_tool_type() == Tools::Crop
             && let Some(crop) = self.active_tool.borrow().get_drawable()

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -24,7 +24,7 @@ use crate::{
     APP_CONFIG,
     configuration::Action,
     epoxy,
-    math::{Vec2D, crop_rect_in_bounds},
+    math::Vec2D,
     sketch_board::SketchBoardInput,
     tools::{Drawable, RenderingMode, Tool, Tools},
 };
@@ -561,10 +561,7 @@ impl FemtoVgAreaMut {
             .drawables
             .iter()
             .find(|d| d.get_rendering_mode() == RenderingMode::Crop)
-            .and_then(|d| {
-                d.bounds()
-                    .map(|(tl, br)| crop_rect_in_bounds((tl, br - tl), bounds))
-            })
+            .and_then(|d| d.bounds().map(|(tl, br)| (tl, br - tl)))
             .unwrap_or(bounds);
 
         if size.x <= 0.0 || size.y <= 0.0 {

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -407,8 +407,9 @@ impl FemtoVgAreaMut {
     // Hit-test all drawables and return all indices whose bounds contain `pos`, in order from topmost to bottommost.
     pub fn hit_test(&self, pos: Vec2D) -> Vec<usize> {
         let mut results = Vec::new();
+        let tolerance = crate::tools::HIT_BORDER_TOLERANCE / self.scale_factor;
         for (i, d) in self.drawables.iter().enumerate().rev() {
-            if d.hit_test(pos, crate::tools::HIT_BORDER_TOLERANCE) {
+            if d.hit_test(pos, tolerance) {
                 results.push(i);
             }
         }

--- a/src/math.rs
+++ b/src/math.rs
@@ -84,6 +84,10 @@ impl Vec2D {
         self.x * self.x + self.y * self.y
     }
 
+    pub fn area(&self) -> f32 {
+        self.x * self.y
+    }
+
     pub fn abs(&self) -> Self {
         Self {
             x: self.x.abs(),

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -421,12 +421,30 @@ impl SketchBoard {
         )
     }
 
+    fn is_drawable_too_small(&self, drawable: &dyn crate::tools::Drawable) -> bool {
+        if let Some((tl, br)) = drawable.bounds()
+            && let size = br - tl
+            && (size.x < 1.0 || size.y < 1.0 || size.area() < 1.0)
+        {
+            eprintln!(
+                "Drawable size{:?} resp. area {} is too small, ignoring commit.",
+                size,
+                size.area()
+            );
+            return true;
+        }
+        false
+    }
+
     fn deactivate_active_tool(&mut self) -> bool {
         if self.active_tool.borrow().active()
-            && let ToolUpdateResult::Commit(result) =
+            && let ToolUpdateResult::Commit(drawable) =
                 self.active_tool.borrow_mut().handle_deactivated()
         {
-            self.renderer.commit(result);
+            if self.is_drawable_too_small(drawable.as_ref()) {
+                return true;
+            };
+            self.renderer.commit(drawable);
             return true;
         }
         false
@@ -1925,6 +1943,9 @@ impl Component for SketchBoard {
 
         match result {
             ToolUpdateResult::Commit(drawable) => {
+                if self.is_drawable_too_small(drawable.as_ref()) {
+                    return;
+                };
                 self.renderer.commit(drawable);
                 // Queue this after any live drag update so the final display is authoritative.
                 sender_clone.input(SketchBoardInput::ShapeDimensionsUpdate(

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1210,6 +1210,12 @@ impl SketchBoard {
                         widget: widget_ref,
                     }));
 
+                if target_tool == Tools::Crop {
+                    self.active_tool
+                        .borrow_mut()
+                        .set_image_size(self.image_bounds.1);
+                }
+
                 // set sender for tool
                 self.active_tool
                     .borrow_mut()
@@ -2098,17 +2104,19 @@ impl Component for SketchBoard {
         model.renderer.add_controller(focus_controller);
 
         let widget_ref: gtk::Widget = model.renderer.clone().upcast();
-        model
-            .active_tool
-            .borrow_mut()
-            .set_im_context(Some(crate::tools::InputContext {
-                im_context: model.im_context.clone(),
-                widget: widget_ref,
-            }));
-        model
-            .active_tool
-            .borrow_mut()
-            .set_sender(sender.input_sender().clone());
+        let mut tool = model.active_tool.borrow_mut();
+
+        tool.set_im_context(Some(crate::tools::InputContext {
+            im_context: model.im_context.clone(),
+            widget: widget_ref,
+        }));
+        tool.set_sender(sender.input_sender().clone());
+
+        if tool.get_tool_type() == Tools::Crop {
+            tool.set_image_size(image_bounds.1);
+        }
+
+        drop(tool);
 
         ComponentParts { model, widgets }
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -290,3 +290,13 @@ impl Size {
         }
     }
 }
+
+impl Style {
+    pub fn corner_radius(&self) -> f32 {
+        if self.round_caps {
+            APP_CONFIG.read().corner_roundness()
+        } else {
+            0.0
+        }
+    }
+}

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -144,7 +144,7 @@ impl Drawable for Arrow {
         }
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         // Preserve the arrow direction by remembering which corner each endpoint was in.
         // bounds() always returns (min, max), so we detect which corners start/end occupy
         // and map them into the new bounds accordingly.

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -99,7 +99,7 @@ impl Drawable for Blur {
         *self.cached_image.borrow_mut() = None;
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         self.top_left = tl;
         self.size = br - tl;

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -127,10 +127,6 @@ impl Drawable for Blur {
             bounds,
         );
         if self.editing {
-            if self.centered {
-                draw_center_marker(canvas, self.origin);
-            }
-
             // set style
             let mut color = Color::black();
             color.set_alphaf(0.6);
@@ -152,9 +148,6 @@ impl Drawable for Blur {
             if size.x <= 0.0 || size.y <= 0.0 {
                 return Ok(());
             }
-
-            canvas.save();
-            canvas.flush();
 
             // create new cached image
             if self.cached_image.borrow().is_none() {
@@ -189,9 +182,21 @@ impl Drawable for Blur {
                     1f32,
                 ),
             );
-            canvas.restore();
         }
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -6,7 +6,6 @@ use femtovg::{Color, ImageFilter, ImageFlags, ImageId, Paint, Path, imgref::Img}
 use relm4::Sender;
 
 use crate::{
-    configuration::APP_CONFIG,
     math::{self, Vec2D},
     sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
     style::Style,
@@ -134,13 +133,7 @@ impl Drawable for Blur {
 
             // make rect
             let mut path = Path::new();
-            path.rounded_rect(
-                pos.x,
-                pos.y,
-                size.x,
-                size.y,
-                APP_CONFIG.read().corner_roundness(),
-            );
+            path.rounded_rect(pos.x, pos.y, size.x, size.y, self.style.corner_radius());
 
             // draw
             canvas.fill_path(&path, &paint);
@@ -162,13 +155,7 @@ impl Drawable for Blur {
             }
 
             let mut path = Path::new();
-            path.rounded_rect(
-                pos.x,
-                pos.y,
-                size.x,
-                size.y,
-                APP_CONFIG.read().corner_roundness(),
-            );
+            path.rounded_rect(pos.x, pos.y, size.x, size.y, self.style.corner_radius());
 
             canvas.fill_path(
                 &path,

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -64,7 +64,7 @@ impl Drawable for BrushDrawable {
         }
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         // Get current bounds
         if let Some((current_tl, current_br)) = self.bounds() {

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -17,7 +17,7 @@ pub struct Crop {
     top_left: Vec2D,
     size: Vec2D,
     centered: bool,
-    finishing: bool,
+    editing: bool,
     active: bool,
 }
 
@@ -70,10 +70,6 @@ impl Drawable for Crop {
         _font: femtovg::FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.origin);
-        }
-
         let size = self.size;
 
         let shadow_paint = Paint::color(Color::rgbaf(0.0, 0.0, 0.0, 0.5))
@@ -88,12 +84,22 @@ impl Drawable for Crop {
         let mut border_path = Path::new();
         border_path.rect(self.top_left.x, self.top_left.y, size.x, size.y);
 
-        canvas.save();
         canvas.fill_path(&shadow_path, &shadow_paint);
         canvas.stroke_path(&border_path, &border_paint);
 
-        canvas.restore();
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -127,7 +133,7 @@ impl Tool for CropTool {
                     top_left: event.pos,
                     size: Vec2D::zero(),
                     centered: false,
-                    finishing: false,
+                    editing: true,
                     active: true,
                 });
                 ToolUpdateResult::Redraw
@@ -141,7 +147,7 @@ impl Tool for CropTool {
                     self.crop = None;
                     return ToolUpdateResult::Redraw;
                 }
-                crop.finishing = true;
+                crop.editing = false;
                 crop.calculate_shape(self.sender.as_ref().unwrap(), &event);
                 ToolUpdateResult::Commit(crop.clone_box())
             }

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use super::{
     Drawable, DrawableClone, Tool, ToolUpdateResult, Tools,
     drag_box::{DragBox, draw_center_marker},
@@ -11,14 +13,16 @@ use anyhow::Result;
 use femtovg::{Color, Paint, Path};
 use relm4::Sender;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Crop {
     origin: Vec2D,
     top_left: Vec2D,
     size: Vec2D,
+    image_size: Vec2D,
     centered: bool,
     editing: bool,
     active: bool,
+    scale: Cell<f32>,
 }
 
 #[derive(Default)]
@@ -26,15 +30,117 @@ pub struct CropTool {
     crop: Option<Crop>,
     dragging: bool,
     input_enabled: bool,
+    image_size: Vec2D,
     sender: Option<Sender<SketchBoardInput>>,
 }
 
+// a odd number that I like
+const SNAP_THRESHOLD: f32 = 23.0;
+
 impl Crop {
+    // `anchor` is the point that must stay fixed while size/top_left are adjusted
+    // aspect ratio comes from unrounded coordinates to avoid jitter
+    fn snap_to_image_bounds(&mut self, is_drag: bool, aspect_ratio: f32, anchor: Vec2D) {
+        // scale independent snap threshold, i.e. in mouse coordinates
+        let snap_theshold = SNAP_THRESHOLD / self.scale.get();
+
+        let orig_tl = self.top_left;
+        let orig_size = self.size;
+        let br_offset = (orig_tl + orig_size) - self.image_size;
+
+        let mut new_tl = orig_tl;
+        let mut new_size = orig_size;
+
+        let anchor_right = anchor.x > orig_tl.x + orig_size.x / 2.0;
+        let anchor_bottom = anchor.y > orig_tl.y + orig_size.y / 2.0;
+
+        // only snap if we exceed 0 - a value of 0 is already snapped
+        // only snap one edge at a time to avoid conflicting adjustments
+        if -snap_theshold <= orig_tl.x && orig_tl.x < 0.0 {
+            new_tl.x = 0.0;
+            if is_drag {
+                new_size.x = orig_size.x + orig_tl.x;
+                if orig_tl.x < 0.0 && aspect_ratio > 0.0 {
+                    new_size.y = (new_size.x / aspect_ratio).round();
+                    if anchor_bottom {
+                        new_tl.y = anchor.y - new_size.y;
+                    }
+                }
+            }
+        } else if -snap_theshold <= orig_tl.y && orig_tl.y < 0.0 {
+            new_tl.y = 0.0;
+            if is_drag {
+                new_size.y = orig_size.y + orig_tl.y;
+                if orig_tl.y < 0.0 && aspect_ratio > 0.0 {
+                    new_size.x = (new_size.y * aspect_ratio).round();
+                    if anchor_right {
+                        new_tl.x = anchor.x - new_size.x;
+                    }
+                }
+            }
+        } else if 0.0 < br_offset.x && br_offset.x <= snap_theshold {
+            if is_drag {
+                new_size.x = orig_size.x - br_offset.x;
+                if br_offset.x > 0.0 && aspect_ratio > 0.0 {
+                    new_size.y = (new_size.x / aspect_ratio).round();
+                    if anchor_bottom {
+                        new_tl.y = anchor.y - new_size.y;
+                    }
+                }
+            } else {
+                new_tl.x = self.image_size.x - orig_size.x;
+            }
+        } else if 0.0 < br_offset.y && br_offset.y <= snap_theshold {
+            if is_drag {
+                new_size.y = orig_size.y - br_offset.y;
+                if br_offset.y > 0.0 && aspect_ratio > 0.0 {
+                    new_size.x = (new_size.y * aspect_ratio).round();
+                    if anchor_right {
+                        new_tl.x = anchor.x - new_size.x;
+                    }
+                }
+            } else {
+                new_tl.y = self.image_size.y - orig_size.y;
+            }
+        }
+
+        self.top_left = new_tl;
+        self.size = new_size;
+    }
+
     pub fn calculate_shape(&mut self, sender: &Sender<SketchBoardInput>, event: &MouseEventMsg) {
         let drag_box = DragBox::from_origin_delta(self.origin, self.size, event, sender);
         self.centered = drag_box.centered;
         self.top_left = drag_box.top_left;
-        self.size = drag_box.size;
+        let br = (drag_box.top_left + drag_box.size).round();
+        if drag_box.delta.x < 0.0 {
+            self.size.x = drag_box.size.x.round();
+            self.top_left.x = (br.x - self.size.x).round();
+        } else {
+            self.size.x = drag_box.size.x.round();
+            self.top_left.x = drag_box.top_left.x.round();
+        }
+        if drag_box.delta.y < 0.0 {
+            self.size.y = drag_box.size.y.round();
+            self.top_left.y = (br.y - self.size.y).round();
+        } else {
+            self.size.y = drag_box.size.y.round();
+            self.top_left.y = drag_box.top_left.y.round();
+        }
+
+        let aspect_ratio = if drag_box.keep_aspect && drag_box.size.y.abs() > f32::EPSILON {
+            drag_box.size.x / drag_box.size.y
+        } else {
+            0.0
+        };
+
+        // the drag origin is the fixed corner while creating the box
+        self.snap_to_image_bounds(true, aspect_ratio, self.origin);
+
+        // Notify the sender about the updated rounded dimensions
+        sender
+            .send(SketchBoardInput::ShapeDimensionsUpdate(self.size))
+            .ok();
     }
 }
 
@@ -45,8 +151,8 @@ impl Drawable for Crop {
 
     fn bounds(&self) -> Option<(Vec2D, Vec2D)> {
         Some(math::ensure_bounding_box(
-            self.top_left,
-            self.top_left + self.size,
+            self.top_left.round(),
+            (self.top_left + self.size).round(),
         ))
     }
 
@@ -55,13 +161,42 @@ impl Drawable for Crop {
     }
 
     fn translate(&mut self, delta: Vec2D) {
-        self.top_left += delta;
+        self.top_left = (self.top_left + delta).round();
+        self.snap_to_image_bounds(false, 0.0, delta);
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
-        let (tl, br) = math::ensure_bounding_box(tl, br);
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, keep_aspect: bool) {
+        let (tl, br) = math::ensure_bounding_box(tl.round(), br.round());
+
+        // Figure out which corner didn't move (the handle's opposite corner) -
+        // that's the anchor that must stay fixed while snapping/aspect-locking.
+        let orig_tl = self.top_left;
+        let orig_br = self.top_left + self.size;
+        let anchor = Vec2D::new(
+            if (tl.x - orig_tl.x).abs() <= (br.x - orig_br.x).abs() {
+                orig_tl.x
+            } else {
+                orig_br.x
+            },
+            if (tl.y - orig_tl.y).abs() <= (br.y - orig_br.y).abs() {
+                orig_tl.y
+            } else {
+                orig_br.y
+            },
+        );
+
+        // use the stable pre-drag size for the ratio, not the size we're about
+        // to overwrite below, to avoid compounding rounding error.
+        let orig_size = orig_br - orig_tl;
+        let aspect_ratio = if keep_aspect && orig_size.y.abs() > f32::EPSILON {
+            orig_size.x / orig_size.y
+        } else {
+            0.0
+        };
+
         self.top_left = tl;
         self.size = br - tl;
+        self.snap_to_image_bounds(true, aspect_ratio, anchor);
     }
 
     fn draw(
@@ -70,6 +205,9 @@ impl Drawable for Crop {
         _font: femtovg::FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
+        self.scale
+            .set(canvas.transform().average_scale().max(f32::EPSILON));
+
         let shadow_paint = Paint::color(Color::rgbaf(
             0.0,
             0.0,
@@ -128,6 +266,10 @@ impl Tool for CropTool {
         self.input_enabled = value;
     }
 
+    fn set_image_size(&mut self, size: Vec2D) {
+        self.image_size = size;
+    }
+
     fn get_tool_type(&self) -> super::Tools {
         Tools::Crop
     }
@@ -140,9 +282,11 @@ impl Tool for CropTool {
                     origin: event.pos,
                     top_left: event.pos,
                     size: Vec2D::zero(),
+                    image_size: self.image_size,
                     centered: false,
                     editing: true,
                     active: true,
+                    scale: Cell::new(1.0),
                 });
                 ToolUpdateResult::Redraw
             }
@@ -151,8 +295,13 @@ impl Tool for CropTool {
                 let Some(crop) = &mut self.crop else {
                     return ToolUpdateResult::Unmodified;
                 };
-                if crop.size == Vec2D::zero() {
+                if crop.size.x == 0.0 || crop.size.y == 0.0 {
                     self.crop = None;
+                    if let Some(sender) = &self.sender {
+                        sender
+                            .send(SketchBoardInput::ShapeDimensionsUpdate(self.image_size))
+                            .ok();
+                    }
                     return ToolUpdateResult::Redraw;
                 }
                 crop.editing = false;

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     math::{self, Vec2D},
     sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
-    tools::{RenderingMode, hit_test_rectangle},
+    tools::{RenderingMode, drag_box::draw_rect_marker, hit_test_rectangle},
 };
 use anyhow::Result;
 use femtovg::{Color, Paint, Path};
@@ -70,26 +70,34 @@ impl Drawable for Crop {
         _font: femtovg::FontId,
         bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        let size = self.size;
+        let shadow_paint = Paint::color(Color::rgbaf(
+            0.0,
+            0.0,
+            0.0,
+            if self.editing { 0.5 } else { 0.9 },
+        ))
+        .with_fill_rule(femtovg::FillRule::EvenOdd);
 
-        let shadow_paint = Paint::color(Color::rgbaf(0.0, 0.0, 0.0, 0.5))
-            .with_fill_rule(femtovg::FillRule::EvenOdd);
         let (img_tl, img_br) = bounds;
-        let img_size = img_br - img_tl;
+        // increase it a bit as otherwise subpixel of the image will still be visible
+        let shadow_tl = (img_tl).min(self.top_left) - 1.0;
+        let shadow_br = (img_br).max(self.top_left + self.size);
+        let shadow_size = shadow_br - shadow_tl + 2.0;
         let mut shadow_path = Path::new();
-        shadow_path.rect(img_tl.x, img_tl.y, img_size.x, img_size.y);
-        shadow_path.rect(self.top_left.x, self.top_left.y, size.x, size.y);
-
-        let border_paint = Paint::color(Color::rgbf(0.1, 0.1, 0.1)).with_line_width(2.0);
-        let mut border_path = Path::new();
-        border_path.rect(self.top_left.x, self.top_left.y, size.x, size.y);
+        // the outer rectangle of the shadow
+        shadow_path.rect(shadow_tl.x, shadow_tl.y, shadow_size.x, shadow_size.y);
+        let tl = self.top_left;
+        let size = self.size;
+        // the inner rectangle of the shadow
+        shadow_path.rect(tl.x, tl.y, size.x, size.y);
 
         canvas.fill_path(&shadow_path, &shadow_paint);
-        canvas.stroke_path(&border_path, &border_paint);
 
         if self.editing && self.centered {
             draw_center_marker(canvas, self.origin);
         }
+
+        draw_rect_marker(canvas, tl, size, false);
 
         Ok(())
     }

--- a/src/tools/drag_box.rs
+++ b/src/tools/drag_box.rs
@@ -14,6 +14,7 @@ pub struct DragBox {
     pub size: Vec2D,
     pub centered: bool,
     pub keep_aspect: bool,
+    pub delta: Vec2D,
 }
 
 impl DragBox {
@@ -75,6 +76,7 @@ impl DragBox {
             size: new_size.abs(),
             centered,
             keep_aspect: aspect || keep_aspect,
+            delta: event.pos,
         };
         sender
             .send(SketchBoardInput::ShapeDimensionsUpdate(drag_box.size))

--- a/src/tools/drag_box.rs
+++ b/src/tools/drag_box.rs
@@ -87,9 +87,56 @@ impl DragBox {
     }
 }
 
+fn inner_color() -> Paint {
+    Paint::color(Color::white())
+}
+
+fn outer_color() -> Paint {
+    Paint::color(Color::rgb(70u8, 130u8, 180u8))
+}
+
 pub fn draw_center_marker(canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>, center: Vec2D) {
-    let mut helpers = Path::new();
-    helpers.circle(center.x, center.y, 2.0);
-    let paint = Paint::color(Color::rgba(128, 128, 128, 255)).with_line_width(1.0);
-    canvas.stroke_path(&helpers, &paint);
+    // in inverse zoom scale so the visual size stays constant on screen
+    let scale = canvas.transform().average_scale().max(f32::EPSILON);
+
+    let radius = 4.0 / scale;
+    let mut path = Path::new();
+    path.circle(center.x, center.y, radius);
+    canvas.fill_path(&path, &inner_color());
+    canvas.stroke_path(&path, &outer_color().with_line_width(1.5 / scale));
+}
+
+pub fn draw_rect_marker(
+    canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
+    top_left: Vec2D,
+    size: Vec2D,
+    filled: bool,
+) {
+    // draw in inverse zoom scale so the visual size stays constant on screen
+    let scale = canvas.transform().average_scale().max(f32::EPSILON);
+    let line_width = 1.5 / scale;
+
+    let border_paint = inner_color().with_line_width(line_width);
+    let mut border_path = Path::new();
+
+    border_path.rect(top_left.x, top_left.y, size.x, size.y);
+    if filled {
+        canvas.fill_path(&border_path, &border_paint);
+    } else {
+        canvas.stroke_path(&border_path, &border_paint);
+    }
+
+    let border_paint = outer_color().with_line_width(line_width);
+    let mut tl = top_left;
+    let mut size = size;
+
+    // set-out to draw the border outside the original rectangle, e.g. for crop
+    if !filled {
+        tl = tl - line_width;
+        size = size + 2.0 * line_width;
+    }
+
+    let mut border_path = Path::new();
+    border_path.rect(tl.x, tl.y, size.x, size.y);
+    canvas.stroke_path(&border_path, &border_paint);
 }

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -51,7 +51,7 @@ impl Drawable for Ellipse {
         self.origin += delta;
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         let center = (tl + br) / 2.0;
         self.middle = center;

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -20,7 +20,7 @@ pub struct Ellipse {
     radii: Vec2D,
     style: Style,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 impl Drawable for Ellipse {
@@ -58,7 +58,7 @@ impl Drawable for Ellipse {
         self.origin = center;
         self.radii = (br - tl).abs() / 2.0;
         self.centered = false;
-        self.finishing = true;
+        self.editing = false;
     }
 
     fn get_style(&self) -> Option<&Style> {
@@ -75,21 +75,26 @@ impl Drawable for Ellipse {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
         let mut path = Path::new();
         path.ellipse(self.middle.x, self.middle.y, self.radii.x, self.radii.y);
-
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.middle);
-        }
 
         if self.style.fill {
             canvas.fill_path(&path, &self.style.into());
         }
         canvas.stroke_path(&path, &self.style.into());
-        canvas.restore();
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.middle);
+        }
 
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -140,8 +145,8 @@ impl Tool for EllipseTool {
                     middle: event.pos,
                     radii: Vec2D::zero(),
                     style: self.style,
-                    centered: true,
-                    finishing: false,
+                    centered: false,
+                    editing: true,
                 });
 
                 ToolUpdateResult::Redraw
@@ -152,7 +157,7 @@ impl Tool for EllipseTool {
                 }
 
                 if let Some(ellipse) = &mut self.ellipse {
-                    ellipse.finishing = true;
+                    ellipse.editing = false;
                     if event.pos == Vec2D::zero() {
                         self.ellipse = None;
 

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -210,7 +210,7 @@ impl Drawable for HighlightKind {
         }
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         match self {
             HighlightKind::Block(h) => {

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -48,7 +48,7 @@ struct BlockHighlight {
     top_left: Vec2D,
     size: Vec2D,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -107,10 +107,6 @@ impl Highlight for Highlighter<BlockHighlight> {
     fn highlight(&self, canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>) -> Result<()> {
         let (pos, size) = math::rect_ensure_positive_size(self.data.top_left, self.data.size);
 
-        if !self.data.finishing && self.data.centered {
-            draw_center_marker(canvas, self.data.origin);
-        }
-
         let mut shadow_path = Path::new();
         shadow_path.rounded_rect(
             pos.x,
@@ -128,6 +124,11 @@ impl Highlight for Highlighter<BlockHighlight> {
         ));
 
         canvas.fill_path(&shadow_path, &shadow_paint);
+
+        if self.data.editing && self.data.centered {
+            draw_center_marker(canvas, self.data.origin);
+        }
+
         Ok(())
     }
 }
@@ -303,6 +304,18 @@ impl Drawable for HighlightKind {
             HighlightKind::Freehand(highlighter) => highlighter.highlight(canvas),
         }
     }
+
+    fn set_centered(&mut self, centered: bool) {
+        if let HighlightKind::Block(highlighter) = self {
+            highlighter.data.centered = centered;
+            highlighter.data.origin = highlighter.data.top_left + highlighter.data.size / 2.0;
+        }
+    }
+    fn set_editing(&mut self, editing: bool) {
+        if let HighlightKind::Block(highlighter) = self {
+            highlighter.data.editing = editing;
+        }
+    }
 }
 
 impl Tool for HighlightTool {
@@ -346,7 +359,7 @@ impl Tool for HighlightTool {
                                     top_left: event.pos,
                                     size: Vec2D::zero(),
                                     centered: false,
-                                    finishing: false,
+                                    editing: true,
                                 },
                                 style: self.style,
                             }))
@@ -438,7 +451,7 @@ impl Tool for HighlightTool {
                 }
 
                 if let HighlightKind::Block(highlighter) = &mut *highlighter_kind {
-                    highlighter.data.finishing = true;
+                    highlighter.data.editing = false;
                 }
 
                 let result = highlighter_kind.clone_box();

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -108,13 +108,7 @@ impl Highlight for Highlighter<BlockHighlight> {
         let (pos, size) = math::rect_ensure_positive_size(self.data.top_left, self.data.size);
 
         let mut shadow_path = Path::new();
-        shadow_path.rounded_rect(
-            pos.x,
-            pos.y,
-            size.x,
-            size.y,
-            APP_CONFIG.read().corner_roundness(),
-        );
+        shadow_path.rounded_rect(pos.x, pos.y, size.x, size.y, self.style.corner_radius());
 
         let shadow_paint = Paint::color(femtovg::Color::rgba(
             self.style.color.r,

--- a/src/tools/image.rs
+++ b/src/tools/image.rs
@@ -158,7 +158,7 @@ impl Drawable for Image {
         self.top_left += delta;
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         self.top_left = tl;
         self.size = br - tl;

--- a/src/tools/image.rs
+++ b/src/tools/image.rs
@@ -1,11 +1,12 @@
 use std::cell::Cell;
 
 use anyhow::Result;
-use femtovg::{Color, ImageId, Paint, Path};
+use femtovg::{ImageId, Paint, Path};
 use relm4::gtk::gdk_pixbuf::Pixbuf;
 use relm4::gtk::prelude::*;
 use relm4::{RelmWidgetExt, Sender, gtk};
 
+use crate::tools::drag_box::draw_rect_marker;
 use crate::{
     configuration::APP_CONFIG,
     femtovg_area::create_image_from_pixbuf,
@@ -74,18 +75,7 @@ impl Drawable for DragPreview {
             draw_center_marker(canvas, self.origin);
         }
 
-        let DragBox { top_left, size, .. } = self.drag_box;
-        let mut path = Path::new();
-        path.rect(top_left.x, top_left.y, size.x, size.y);
-        // a light line under a dark one, so the box shows on any screenshot
-        canvas.stroke_path(
-            &path,
-            &Paint::color(Color::rgbf(1.0, 1.0, 1.0)).with_line_width(3.0),
-        );
-        canvas.stroke_path(
-            &path,
-            &Paint::color(Color::rgbf(0.1, 0.1, 0.1)).with_line_width(1.0),
-        );
+        draw_rect_marker(canvas, self.drag_box.top_left, self.drag_box.size, false);
         Ok(())
     }
 }

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -47,7 +47,7 @@ impl Drawable for Line {
         self.start += delta;
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         if let Some(direction) = self.direction {
             let end = self.start + direction;
             let start_is_left = self.start.x <= end.x;

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -69,7 +69,7 @@ impl Drawable for Marker {
         Some(&mut self.style)
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let Some((old_tl, old_br)) = self.bounds() else {
             return;
         };

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -138,6 +138,8 @@ pub trait Tool {
 
     fn set_input_enabled(&mut self, value: bool);
 
+    fn set_image_size(&mut self, _size: Vec2D) {}
+
     fn handle_undo(&mut self) -> ToolUpdateResult {
         ToolUpdateResult::Unmodified
     }
@@ -238,8 +240,8 @@ pub trait Drawable: DrawableClone + Debug + AsAny {
     fn translate(&mut self, delta: Vec2D) {
         let _ = delta;
     }
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
-        let _ = (tl, br);
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, delta: Vec2D, keep_aspect: bool) {
+        let _ = (tl, br, delta, keep_aspect);
     }
     fn get_style(&self) -> Option<&Style> {
         None

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -244,9 +244,14 @@ pub trait Drawable: DrawableClone + Debug + AsAny {
     fn get_style(&self) -> Option<&Style> {
         None
     }
-
     fn get_style_mut(&mut self) -> Option<&mut Style> {
         None
+    }
+    fn set_centered(&mut self, centered: bool) {
+        let _ = centered;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        let _ = editing;
     }
 }
 

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -334,7 +334,13 @@ impl Drawable for Pixelate {
 
         if let Some((image_id, paint_pos, paint_size)) = *self.cached_image.borrow() {
             let mut path = Path::new();
-            path.rect(paint_pos.x, paint_pos.y, paint_size.x, paint_size.y);
+            path.rounded_rect(
+                paint_pos.x,
+                paint_pos.y,
+                paint_size.x,
+                paint_size.y,
+                self.style.corner_radius(),
+            );
             canvas.fill_path(
                 &path,
                 &Paint::image(

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -289,7 +289,7 @@ impl Drawable for Pixelate {
         *self.cached_image.borrow_mut() = None;
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         self.top_left = tl;
         self.size = br - tl;

--- a/src/tools/pixelate.rs
+++ b/src/tools/pixelate.rs
@@ -326,11 +326,6 @@ impl Drawable for Pixelate {
             bounds,
         );
 
-        self.renderable.set(true);
-
-        canvas.save();
-        canvas.flush();
-
         if (self.cached_image.borrow().is_none() || self.editing)
             && let Some(x) = self.pixelate(canvas, image, pos, size)?
         {
@@ -352,12 +347,21 @@ impl Drawable for Pixelate {
                     1f32,
                 ),
             );
-            canvas.restore();
         }
+
         if self.editing && self.centered {
-            draw_center_marker(canvas, self.origin);
+            draw_center_marker(canvas, pos + size / 2.0);
         }
+
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -443,7 +447,7 @@ impl Tool for PixelateTool {
                     style: self.style,
                     cached_image: RefCell::new(None),
                     mode: self.mode,
-                    renderable: Cell::new(false),
+                    renderable: Cell::new(true),
                 });
 
                 ToolUpdateResult::Redraw

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -293,7 +293,7 @@ pub fn hit_handle(
 struct SelectionOverlay {
     tl: Vec2D,
     br: Vec2D,
-    scaled_handle_size: Cell<f32>,
+    scale: Cell<f32>,
     centered: bool,
     editing: bool,
 }
@@ -309,15 +309,20 @@ impl Drawable for SelectionOverlay {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
+        let scale = canvas.transform().average_scale().max(f32::EPSILON);
+        // to be used at other places where the scale is not available
+        self.scale.set(scale);
+
         // Selection rectangle
-        draw_rect_marker(canvas, self.tl, self.br - self.tl, false);
+        let out_set = SELECTION_BORDER_OUTSET / scale;
+        let tl = self.tl - out_set;
+        let size = (self.br - self.tl) + out_set * 2.0;
+        draw_rect_marker(canvas, tl, size, false);
 
         // Resize handles
         // draw handles in inverse zoom scale so the visual size stays constant on screen.
-        let scale = canvas.transform().average_scale().max(f32::EPSILON);
         let handle_half = HANDLE_HALF / scale;
         let handle_size = HANDLE_SIZE / scale;
-        self.scaled_handle_size.set(handle_size);
         for handle in ResizeHandle::all() {
             let tl = handle.center(self.tl, self.br) - handle_half;
             draw_rect_marker(canvas, tl, Vec2D::new(handle_size, handle_size), true);
@@ -471,7 +476,7 @@ impl PointerTool {
     // Returns the handle under `pos` given the current selection bounds.
     pub fn hit_test_handles(&self, pos: Vec2D) -> Option<ResizeHandle> {
         let overlay = self.selection_overlay.as_ref()?;
-        let scaled_handle_size = overlay.scaled_handle_size.get();
+        let scaled_handle_size = HANDLE_SIZE / overlay.scale.get();
         hit_handle(scaled_handle_size, pos, overlay.tl, overlay.br)
     }
 
@@ -536,31 +541,11 @@ impl PointerTool {
         let (tl, br) = ensure_bounding_box(tl, br);
         self.selected_bounds = Some((tl, br));
 
-        let handle_size = if let Some(overlay) = &self.selection_overlay {
-            overlay.scaled_handle_size.get()
-        } else {
-            HANDLE_SIZE
-        };
-
-        // Add extra outset to selection overlay if the drawable is small to reduce handle overlapping
-        let w = br.x - tl.x + SELECTION_BORDER_OUTSET * 2.0;
-        let h = br.y - tl.y + SELECTION_BORDER_OUTSET * 2.0;
-        let border_outset_x = if w < 3.0 * handle_size {
-            HANDLE_SIZE
-        } else {
-            SELECTION_BORDER_OUTSET
-        };
-        let border_outset_y = if h < 3.0 * handle_size {
-            HANDLE_SIZE
-        } else {
-            SELECTION_BORDER_OUTSET
-        };
-
         self.selection_overlay = Some(SelectionOverlay {
-            tl: tl - Vec2D::new(border_outset_x, border_outset_y),
-            br: br + Vec2D::new(border_outset_x, border_outset_y),
+            tl,
+            br,
             // is updated in draw() to maintain constant on-screen size regardless of zoom level
-            scaled_handle_size: Cell::new(HANDLE_SIZE),
+            scale: Cell::new(1.0),
             centered: false,
             editing: true,
         });

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -531,6 +531,7 @@ impl PointerTool {
         if let Some(sender) = &self.sender
             && let Some((tl, br)) = drawable.bounds()
         {
+            // get it from drawable as it represents the most up-to-date bounds
             sender
                 .send(SketchBoardInput::ShapeDimensionsUpdate(br - tl))
                 .ok();
@@ -549,12 +550,6 @@ impl PointerTool {
             centered: false,
             editing: true,
         });
-
-        if let Some(sender) = &self.sender {
-            sender
-                .send(SketchBoardInput::ShapeDimensionsUpdate(br - tl))
-                .ok();
-        }
     }
 
     // Select a drawable without starting a drag (e.g. after a commit/replace).
@@ -707,7 +702,10 @@ impl Tool for PointerTool {
                 } => {
                     let (new_tl, new_br) = handle.resize(event, orig_bounds.0, orig_bounds.1);
                     let mut preview = original.clone_box();
-                    preview.resize_bounds(new_tl, new_br);
+                    let keep_aspect = event
+                        .modifier
+                        .intersects(ModifierType::CONTROL_MASK | ModifierType::SHIFT_MASK);
+                    preview.resize_bounds(new_tl, new_br, event.pos, keep_aspect);
                     preview.set_centered(event.modifier.intersects(ModifierType::ALT_MASK));
                     preview.set_editing(true);
                     self.emit_dimensions_update(preview.as_ref());
@@ -764,7 +762,10 @@ impl Tool for PointerTool {
                             let (new_tl, new_br) =
                                 handle.resize(event, orig_bounds.0, orig_bounds.1);
                             let mut final_drawable = original;
-                            final_drawable.resize_bounds(new_tl, new_br);
+                            let keep_aspect = event
+                                .modifier
+                                .intersects(ModifierType::CONTROL_MASK | ModifierType::SHIFT_MASK);
+                            final_drawable.resize_bounds(new_tl, new_br, event.pos, keep_aspect);
                             final_drawable.set_centered(false);
                             final_drawable.set_editing(false);
                             self.update_selection_bounds(new_tl, new_br);

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -10,7 +10,7 @@ use crate::{
     configuration::APP_CONFIG,
     math::{Vec2D, ensure_bounding_box, get_closest_aspect_ratio},
     sketch_board::{KeyEventMsg, MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
-    tools::RenderingMode,
+    tools::{RenderingMode, drag_box::draw_center_marker},
 };
 
 use super::{Drawable, InputContext, Tool, ToolUpdateResult, Tools};
@@ -291,6 +291,8 @@ struct SelectionOverlay {
     tl: Vec2D,
     br: Vec2D,
     scaled_handle_size: Cell<f32>,
+    centered: bool,
+    editing: bool,
 }
 
 impl Drawable for SelectionOverlay {
@@ -304,8 +306,6 @@ impl Drawable for SelectionOverlay {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
-
         // draw handles in inverse zoom scale so the visual size stays constant on screen.
         let scale = canvas.transform().average_scale().max(f32::EPSILON);
 
@@ -336,14 +336,17 @@ impl Drawable for SelectionOverlay {
                 handle_size,
                 handle_size,
             );
-            canvas.fill_path(&hpath, &Paint::color(Color::rgba(255, 255, 255, 255)));
+            canvas.fill_path(&hpath, &Paint::color(Color::white()));
             canvas.stroke_path(
                 &hpath,
                 &Paint::color(Color::rgba(70, 130, 180, 255)).with_line_width(stroke_width),
             );
         }
 
-        canvas.restore();
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.tl + (self.br - self.tl) * 0.5);
+        }
+
         Ok(())
     }
 }
@@ -578,6 +581,8 @@ impl PointerTool {
             br: br + Vec2D::new(border_outset_x, border_outset_y),
             // is updated in draw() to maintain constant on-screen size regardless of zoom level
             scaled_handle_size: Cell::new(HANDLE_SIZE),
+            centered: false,
+            editing: true,
         });
 
         if let Some(sender) = &self.sender {
@@ -738,8 +743,9 @@ impl Tool for PointerTool {
                     let (new_tl, new_br) = handle.resize(event, orig_bounds.0, orig_bounds.1);
                     let mut preview = original.clone_box();
                     preview.resize_bounds(new_tl, new_br);
+                    preview.set_centered(event.modifier.intersects(ModifierType::ALT_MASK));
+                    preview.set_editing(true);
                     self.emit_dimensions_update(preview.as_ref());
-
                     self.update_selection_bounds(new_tl, new_br);
                     self.preview = Some(preview);
                     ToolUpdateResult::Redraw
@@ -794,6 +800,8 @@ impl Tool for PointerTool {
                                 handle.resize(event, orig_bounds.0, orig_bounds.1);
                             let mut final_drawable = original;
                             final_drawable.resize_bounds(new_tl, new_br);
+                            final_drawable.set_centered(false);
+                            final_drawable.set_editing(false);
                             self.update_selection_bounds(new_tl, new_br);
                             self.preview = None;
                             ToolUpdateResult::ReplaceDrawable(index, final_drawable)

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use femtovg::{Color, FontId, Paint, Path};
+use femtovg::FontId;
 use relm4::{
     Sender,
     gtk::{self, gdk::ModifierType, prelude::WidgetExt},
@@ -10,7 +10,10 @@ use crate::{
     configuration::APP_CONFIG,
     math::{Vec2D, ensure_bounding_box, get_closest_aspect_ratio},
     sketch_board::{KeyEventMsg, MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
-    tools::{RenderingMode, drag_box::draw_center_marker},
+    tools::{
+        RenderingMode,
+        drag_box::{draw_center_marker, draw_rect_marker},
+    },
 };
 
 use super::{Drawable, InputContext, Tool, ToolUpdateResult, Tools};
@@ -306,41 +309,18 @@ impl Drawable for SelectionOverlay {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        // draw handles in inverse zoom scale so the visual size stays constant on screen.
-        let scale = canvas.transform().average_scale().max(f32::EPSILON);
-
         // Selection rectangle
-        let stroke_width = 1.5 / scale;
-        let mut rect = Path::new();
-        rect.rect(
-            self.tl.x,
-            self.tl.y,
-            self.br.x - self.tl.x,
-            self.br.y - self.tl.y,
-        );
-        canvas.stroke_path(
-            &rect,
-            &Paint::color(Color::rgba(70, 130, 180, 220)).with_line_width(stroke_width),
-        );
+        draw_rect_marker(canvas, self.tl, self.br - self.tl, false);
 
         // Resize handles
+        // draw handles in inverse zoom scale so the visual size stays constant on screen.
+        let scale = canvas.transform().average_scale().max(f32::EPSILON);
         let handle_half = HANDLE_HALF / scale;
         let handle_size = HANDLE_SIZE / scale;
         self.scaled_handle_size.set(handle_size);
         for handle in ResizeHandle::all() {
-            let c = handle.center(self.tl, self.br);
-            let mut hpath = Path::new();
-            hpath.rect(
-                c.x - handle_half,
-                c.y - handle_half,
-                handle_size,
-                handle_size,
-            );
-            canvas.fill_path(&hpath, &Paint::color(Color::white()));
-            canvas.stroke_path(
-                &hpath,
-                &Paint::color(Color::rgba(70, 130, 180, 255)).with_line_width(stroke_width),
-            );
+            let tl = handle.center(self.tl, self.br) - handle_half;
+            draw_rect_marker(canvas, tl, Vec2D::new(handle_size, handle_size), true);
         }
 
         if self.editing && self.centered {

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -22,7 +22,7 @@ pub struct Rectangle {
     size: Vec2D,
     style: Style,
     centered: bool,
-    finishing: bool,
+    editing: bool,
 }
 
 impl Drawable for Rectangle {
@@ -48,7 +48,7 @@ impl Drawable for Rectangle {
         self.size = br - tl;
         self.origin = tl;
         self.centered = false;
-        self.finishing = true;
+        self.editing = false;
     }
 
     fn get_style(&self) -> Option<&Style> {
@@ -65,7 +65,6 @@ impl Drawable for Rectangle {
         _font: FontId,
         _bounds: (Vec2D, Vec2D),
     ) -> Result<()> {
-        canvas.save();
         let mut path = Path::new();
         path.rounded_rect(
             self.top_left.x,
@@ -75,17 +74,24 @@ impl Drawable for Rectangle {
             APP_CONFIG.read().corner_roundness(),
         );
 
-        if !self.finishing && self.centered {
-            draw_center_marker(canvas, self.origin);
-        }
-
         if self.style.fill {
             canvas.fill_path(&path, &self.style.into());
         }
         canvas.stroke_path(&path, &self.style.into());
-        canvas.restore();
+
+        if self.editing && self.centered {
+            draw_center_marker(canvas, self.origin);
+        }
 
         Ok(())
+    }
+
+    fn set_centered(&mut self, centered: bool) {
+        self.centered = centered;
+        self.origin = self.top_left + self.size / 2.0;
+    }
+    fn set_editing(&mut self, editing: bool) {
+        self.editing = editing;
     }
 }
 
@@ -132,7 +138,7 @@ impl Tool for RectangleTool {
                     size: Vec2D::zero(),
                     style: self.style,
                     centered: false,
-                    finishing: false,
+                    editing: true,
                 });
 
                 ToolUpdateResult::Redraw
@@ -143,7 +149,7 @@ impl Tool for RectangleTool {
                 }
 
                 if let Some(rectangle) = &mut self.rectangle {
-                    rectangle.finishing = true;
+                    rectangle.editing = false;
                     if event.pos == Vec2D::zero() {
                         self.rectangle = None;
                         ToolUpdateResult::Redraw

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -3,7 +3,6 @@ use femtovg::{FontId, Path};
 use relm4::Sender;
 
 use crate::{
-    configuration::APP_CONFIG,
     math::{self, Vec2D},
     sketch_board::{MouseButton, MouseEventMsg, MouseEventType, SketchBoardInput},
     style::Style,
@@ -71,7 +70,7 @@ impl Drawable for Rectangle {
             self.top_left.y,
             self.size.x,
             self.size.y,
-            APP_CONFIG.read().corner_roundness(),
+            self.style.corner_radius(),
         );
 
         if self.style.fill {

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -42,7 +42,7 @@ impl Drawable for Rectangle {
         self.origin += delta;
     }
 
-    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D) {
+    fn resize_bounds(&mut self, tl: Vec2D, br: Vec2D, _delta: Vec2D, _keep_aspect: bool) {
         let (tl, br) = math::ensure_bounding_box(tl, br);
         self.top_left = tl;
         self.size = br - tl;


### PR DESCRIPTION
See also #633, #337 

Closes #339

The background will be transparent so people can put the
saved/copied image on top of other background in another
tool. Maybe in the future we can allow to move annotations
behind the image - but for now this is IMHO sufficient.