### PR TITLE
feat: system wide config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ You can download a prebuilt binary for x86-64 on the [Satty Releases](https://gi
 
 Start by providing a filename or a screenshot via stdin and annotate using the available tools. Save to clipboard or file when finished. Tools and Interface have been kept simple.
 
-All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/satty/config.toml` or via the command line interface. In case both are specified, the command line options always override the configuration file.
+The order of configuration is:
+- builtin
+- system wide config (`$XDG_CONFIG_DIRS/satty/config.toml`, usually `/etc/xdg/satty/config.toml`) if present <sup>NEXTRELEASE</sup>
+- user config (`$XDG_CONFIG_HOME/satty/config.toml`, usually `$HOME/.config/satty/config.toml`) if present
+- config specified in command line, if any. Please note: in this case Satty ignores the former two files, and a file not found error on the given config file becomes fatal
+- command line options
 
 ### Shortcuts
 
@@ -408,7 +413,7 @@ Options:
       --license
           Show license
   -c, --config <CONFIG>
-          Path to the config file. Otherwise will be read from XDG_CONFIG_DIR/satty/config.toml
+          Path to the config file, if specified, this will be an exclusive config. Otherwise, config will be stacked from system and user config using XDG_CONFIG_DIRS/satty/config.toml and XDG_CONFIG_HOME/satty/config.toml
   -f, --filename <FILENAME>
           Path to input image or '-' to read from stdin
       --fullscreen [<FULLSCREEN>]

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -13,7 +13,8 @@ pub struct CommandLine {
     #[arg(long, exclusive = true)]
     pub license: bool,
 
-    /// Path to the config file. Otherwise will be read from XDG_CONFIG_DIR/satty/config.toml
+    /// Path to the config file, if specified, this will be an exclusive config.
+    /// Otherwise, config will be stacked from system and user config using XDG_CONFIG_DIRS/satty/config.toml and XDG_CONFIG_HOME/satty/config.toml.
     #[arg(short, long)]
     pub config: Option<String>,
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -108,7 +108,7 @@ impl FontConfiguration {
             self.style = Some(v);
         }
         if let Some(v) = file_font.fallback {
-            self.fallback = v
+            self.fallback.extend(v);
         }
     }
 }
@@ -253,12 +253,8 @@ impl Configuration {
         };
 
         // read configuration file and exit on error
-        let file = match ConfigurationFile::try_read(&command_line.config) {
+        let files = match ConfigurationFile::try_read(&command_line.config) {
             Ok(c) => c,
-            Err(ConfigurationFileError::ReadFile(e)) if e.kind() == io::ErrorKind::NotFound => {
-                eprintln!("config file not found");
-                None
-            }
             Err(e) => {
                 eprintln!("Error reading config file: {e}");
 
@@ -271,7 +267,7 @@ impl Configuration {
             }
         };
 
-        APP_CONFIG.write().merge(file, command_line);
+        APP_CONFIG.write().merge(files, command_line);
     }
 
     fn merge_general(&mut self, general: ConfigurationFileGeneral) {
@@ -388,12 +384,12 @@ impl Configuration {
         // ---
     }
 
-    fn merge(&mut self, file: Option<ConfigurationFile>, command_line: CommandLine) {
+    fn merge(&mut self, files: Vec<ConfigurationFile>, command_line: CommandLine) {
         // input_filename is required and needs to be overwritten
         self.input_filename = command_line.filename;
 
         // overwrite with all specified values from config file
-        if let Some(file) = file {
+        for file in files {
             if let Some(general) = file.general {
                 self.merge_general(general);
             }
@@ -403,7 +399,9 @@ impl Configuration {
             if let Some(v) = file.font {
                 self.font.merge(v);
             }
-            self.keybinds = file.keybinds.unwrap_or_default();
+            if let Some(v) = file.keybinds {
+                self.keybinds.extend(v);
+            }
         }
 
         // overwrite with all specified values from command line
@@ -829,25 +827,36 @@ struct ColorPaletteFile {
 impl ConfigurationFile {
     fn try_read(
         specified_path: &Option<String>,
-    ) -> Result<Option<ConfigurationFile>, ConfigurationFileError> {
-        match specified_path {
-            None => Self::try_read_xdg(),
-            Some(p) => Self::try_read_path(p),
+    ) -> Result<Vec<ConfigurationFile>, ConfigurationFileError> {
+        if let Some(p) = specified_path {
+            return match Self::try_read_path(p)? {
+                Some(f) => Ok(vec![f]),
+                // _ can't happen with current implementation of try_read_path, any errors (including file not found) are propagated
+                _ => Ok(vec![]),
+            };
         }
-    }
 
-    fn try_read_xdg() -> Result<Option<ConfigurationFile>, ConfigurationFileError> {
+        let mut files = Vec::new();
+
         let dirs = BaseDirectories::with_prefix(env!("CARGO_PKG_NAME"));
-        match dirs.get_config_file("config.toml") {
-            Some(path) => Self::try_read_path(path),
-            None => Ok(None),
+        // only present config files are used
+        for c in dirs.find_config_files("config.toml") {
+            if let Some(f) = Self::try_read_path(c)? {
+                files.push(f);
+            }
         }
+
+        Ok(files)
     }
 
     fn try_read_path<P: AsRef<Path>>(
         path: P,
     ) -> Result<Option<ConfigurationFile>, ConfigurationFileError> {
-        let content = fs::read_to_string(path)?;
-        Ok(Some(toml::from_str::<ConfigurationFile>(&content)?))
+        let path = path.as_ref();
+        eprintln!("Reading configuration file: {:?}", path);
+        match fs::read_to_string(path) {
+            Ok(content) => Ok(Some(toml::from_str::<ConfigurationFile>(&content)?)),
+            Err(e) => Err(e.into()),
+        }
     }
 }


### PR DESCRIPTION
Closes: #630

Changes configuration.rs code slightly to allow a system wide config file in XDG_CONFIG_DIRS/satty/config.toml (usually /etc/xdg/satty/config.toml).

File not found on any specified config (--config) is still fatal, I think this is sensible. For the system and user config, they're used if present and skipped via external BaseDirectories::find_config_files if not present.

This PR clashes with #664.

Design choices:

- shortcuts are extended (I suppose it would suck if this wasn't the case), there is always none to unset
- fallback fonts vec is extended, additional fonts on user side wouldn't hurt much
- palette and custom colours are overwritten. otherwise it might be tricky to prevent a full style toolbar on user side, depending on how many entries packagers provide via system config. I didn't feel like providing any special notation to clear this.